### PR TITLE
CHORE: DNSControl.org zone/zone transfer to TransIP

### DIFF
--- a/.dns/dnsconfig.js
+++ b/.dns/dnsconfig.js
@@ -1,0 +1,16 @@
+var PROVIDER_NONE = NewRegistrar('none');
+var PROVIDER_TRANSIP = NewDnsProvider('transip', '-');
+
+DEFAULTS(
+  DefaultTTL('1d')
+)
+
+require_glob(
+  './domains/',
+  false
+);
+
+require_glob(
+  './domains/dnscontrol.org/',
+  false
+);

--- a/.dns/domains/dnscontrol.org.js
+++ b/.dns/domains/dnscontrol.org.js
@@ -1,0 +1,8 @@
+D(
+  'dnscontrol.org',
+  PROVIDER_NONE,
+  DnsProvider(PROVIDER_TRANSIP),
+  ALIAS('@', 'stackexchange.github.io.'),
+  CNAME('www', 'dnscontrol.org.'),
+  END,
+);

--- a/.dns/domains/dnscontrol.org/gitbook.js
+++ b/.dns/domains/dnscontrol.org/gitbook.js
@@ -1,0 +1,3 @@
+D_EXTEND('dnscontrol.org',
+  CNAME('docs', 'db3053e25d-hosting.gitbook.io.'),
+);

--- a/.dns/domains/dnscontrol.org/google-site-verification.js
+++ b/.dns/domains/dnscontrol.org/google-site-verification.js
@@ -1,0 +1,3 @@
+D_EXTEND('dnscontrol.org',
+  TXT('@', 'google-site-verification=iItI_5CTvxVLRyanzMjE9xYi_E2IEotex05tH2AgrVw'),
+);

--- a/.dns/domains/dnscontrol.org/spf.js
+++ b/.dns/domains/dnscontrol.org/spf.js
@@ -1,0 +1,9 @@
+D_EXTEND('dnscontrol.org',
+  SPF_BUILDER({
+    label: '@',
+    parts: [
+      'v=spf1',
+      '-all',
+    ],
+  }),
+);


### PR DESCRIPTION
Initial zone configuration for `dnscontrol.org`, based on the records provided by @TomOnTime.

## Records

- `ALIAS @` → `stackexchange.github.io.`
- `CNAME docs` → `db3053e25d-hosting.gitbook.io.`
- `CNAME www` → `dnscontrol.org.`
- `TXT @` Google Search Console verification
- `SPF_NONE` (domain does not send email)

**Notes**: The zone is staged ahead of the domain transfer. Nameservers will be pointed to the new registrar (TransIP) once Stack completes the transfer.