### PR TITLE
PORKBUN: Fix url/url301/porkbun_urlfwd

### DIFF
--- a/integrationTest/helpers_integration_test.go
+++ b/integrationTest/helpers_integration_test.go
@@ -751,20 +751,20 @@ func tlsa(name string, usage, selector, matchingtype uint8, target string) *mode
 	return r
 }
 
-func porkbunUrlfwd(name, target, t, includePath, wildcard string) *models.RecordConfig {
-	rc, err := globalDC.NewRecordConfig(name, defaultTTL, privatetypes.TypePORKBUNURLFWD, target, t, includePath, wildcard)
+func porkbunUrlfwd(name, target string) *models.RecordConfig {
+	rc, err := globalDC.NewRecordConfig(name, defaultTTL, privatetypes.TypePORKBUNURLFWD, target)
 	panicOnErr(err)
 	return rc
 }
 
 func url(name, target string) *models.RecordConfig {
-	rc, err := globalDC.NewRecordConfig(name, defaultTTL, privatetypes.TypeURL, target, false, false)
+	rc, err := globalDC.NewRecordConfig(name, defaultTTL, privatetypes.TypeURL, target)
 	panicOnErr(err)
 	return rc
 }
 
 func url301(name, target string) *models.RecordConfig {
-	rc, err := globalDC.NewRecordConfig(name, defaultTTL, privatetypes.TypeURL301, target, false, false)
+	rc, err := globalDC.NewRecordConfig(name, defaultTTL, privatetypes.TypeURL301, target)
 	panicOnErr(err)
 	return rc
 }

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -2135,11 +2135,24 @@ func makeTests() []*TestGroup {
 
 		// PORKBUN features
 
-		testgroup("PORKBUN_URLFWD tests",
+		testgroup("PORKBUN url forwarding tests",
 			only("PORKBUN"),
-			tc("Add a urlfwd", porkbunUrlfwd("urlfwd1", "http://example.com", "", "", "")),
-			tc("Update a urlfwd", porkbunUrlfwd("urlfwd1", "http://example.org", "", "", "")),
-			tc("Update a urlfwd with metadata", porkbunUrlfwd("urlfwd1", "http://example.org", "permanent", "no", "no")),
+			tc("Add a urlfwd", porkbunUrlfwd("urlfwd1", "http://example.com")),
+			tc("Update a urlfwd with metadata", withMeta(porkbunUrlfwd("urlfwd1", "http://example.com"), map[string]string{
+				"type":        "permanent",
+				"includePath": "yes",
+				"wildcard":    "no",
+			})),
+			tc("Add a url", url("urlfwd2", "http://example.com")),
+			tc("Update a url with metadata", withMeta(url("urlfwd2", "http://example.com"), map[string]string{
+				"includePath": "yes",
+				"wildcard":    "no",
+			})),
+			tc("Add a url301", url301("urlfwd3", "http://example.com")),
+			tc("Update a url with metadata", withMeta(url301("urlfwd3", "http://example.com"), map[string]string{
+				"includePath": "yes",
+				"wildcard":    "no",
+			})),
 		),
 
 		// GCORE features

--- a/models/populatelegacy.go
+++ b/models/populatelegacy.go
@@ -71,12 +71,7 @@ func (rc *RecordConfig) copyRDtoLegacyFields() error {
 		rc.SetTarget(rd.PublicKey)
 
 	case privatetypesrdata.PORKBUNURLFWD:
-		if rc.Metadata == nil {
-			rc.Metadata = map[string]string{}
-		}
-		rc.Metadata["type"] = rd.TypeName
-		rc.Metadata["includePath"] = rd.IncludePath
-		rc.Metadata["wildcard"] = rd.Wildcard
+		rc.SetTarget(rd.Location)
 	case dnsrdatav2.PTR:
 		rc.SetTarget(rd.Ptr)
 
@@ -113,11 +108,6 @@ func (rc *RecordConfig) copyRDtoLegacyFields() error {
 
 	case privatetypesrdata.URL:
 		rc.SetTarget(rd.Location)
-		if rc.Metadata == nil {
-			rc.Metadata = map[string]string{}
-		}
-		rc.Metadata["includePath"] = fmt.Sprintf("%t", rd.PorkbunIncludePath)
-		rc.Metadata["wildcard"] = fmt.Sprintf("%t", rd.PorkbunWildCard)
 	case privatetypesrdata.URL301:
 		rc.SetTarget(rd.Location)
 

--- a/models/populaterd.go
+++ b/models/populaterd.go
@@ -222,13 +222,9 @@ func (rc *RecordConfig) copyLegacyFieldsToRD(origin string) {
 		rc.SetRDATA(rd)
 
 	case privatetypes.TypePORKBUNURLFWD:
-		// NB(tlim): Should this use privatetypesrdata.MakePORKBUNURLFWD() instead?
-		rc.SetRDATA(&privatetypesrdata.PORKBUNURLFWD{
-			Target:      rc.GetTargetField(),
-			TypeName:    rc.Metadata["type"],
-			IncludePath: rc.Metadata["includePath"],
-			Wildcard:    rc.Metadata["wildcard"],
-		})
+		rd, err := privatetypesrdata.MakePORKBUNURLFWD(origin, nil, rc.GetTargetField())
+		errorChk(err)
+		rc.SetRDATA(rd)
 
 	case dnsv2.TypePTR:
 		rd, err := MakePTR(origin, nil, rc.GetTargetField())
@@ -279,11 +275,7 @@ func (rc *RecordConfig) copyLegacyFieldsToRD(origin string) {
 		rc.SetRDATA(rd)
 
 	case privatetypes.TypeURL:
-		rd, err := privatetypesrdata.MakeURL(origin, nil,
-			rc.GetTargetField(),
-			rc.Metadata["includePath"],
-			rc.Metadata["wildcard"],
-		)
+		rd, err := privatetypesrdata.MakeURL(origin, nil, rc.GetTargetField())
 		errorChk(err)
 		rc.SetRDATA(rd)
 	case privatetypes.TypeURL301:

--- a/pkg/privatetypes/rdata/rdata_porkbun_urlfwd.go
+++ b/pkg/privatetypes/rdata/rdata_porkbun_urlfwd.go
@@ -10,10 +10,7 @@ import (
 )
 
 type PORKBUNURLFWD struct {
-	Target      string
-	TypeName    string
-	IncludePath string
-	Wildcard    string
+	Location string
 }
 
 func (rd PORKBUNURLFWD) Len() int {
@@ -21,23 +18,17 @@ func (rd PORKBUNURLFWD) Len() int {
 }
 
 func (rd PORKBUNURLFWD) String() string {
-	parts := make([]string, 0, 4)
-	parts = append(parts, txtutil.ZoneifyString(rd.Target))
-	parts = append(parts, txtutil.ZoneifyString(rd.TypeName))
-	parts = append(parts, txtutil.ZoneifyString(rd.IncludePath))
-	parts = append(parts, txtutil.ZoneifyString(rd.Wildcard))
+	parts := make([]string, 0, 1)
+	parts = append(parts, txtutil.ZoneifyString(rd.Location))
 	return strings.Join(parts, " ")
 }
 
 func MakePORKBUNURLFWD(origin string, _ map[string]string, args ...any) (dnsv2.RDATA, error) {
 	mustbe.ValidArgs(args)
-	if len(args) != 4 {
-		return nil, fmt.Errorf("PORKBUN_URLFWD expects 4 arguments, got %d: %+v", len(args), args)
+	if len(args) != 1 {
+		return nil, fmt.Errorf("PORKBUN_URLFWD expects 1 arguments, got %d: %+v", len(args), args)
 	}
 	return PORKBUNURLFWD{
-		Target:      mustbe.RawString(args[0]),
-		TypeName:    mustbe.RawString(args[1]),
-		IncludePath: mustbe.RawString(args[2]),
-		Wildcard:    mustbe.RawString(args[3]),
+		Location: mustbe.RawString(args[0]),
 	}, nil
 }

--- a/pkg/privatetypes/rdata/rdata_url.go
+++ b/pkg/privatetypes/rdata/rdata_url.go
@@ -10,9 +10,7 @@ import (
 )
 
 type URL struct {
-	Location           string
-	PorkbunIncludePath bool
-	PorkbunWildCard    bool
+	Location string
 }
 
 func (rd URL) Len() int {
@@ -20,21 +18,17 @@ func (rd URL) Len() int {
 }
 
 func (rd URL) String() string {
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 1)
 	parts = append(parts, txtutil.ZoneifyString(rd.Location))
-	parts = append(parts, fmt.Sprintf("%t", rd.PorkbunIncludePath))
-	parts = append(parts, fmt.Sprintf("%t", rd.PorkbunWildCard))
 	return strings.Join(parts, " ")
 }
 
 func MakeURL(origin string, _ map[string]string, args ...any) (dnsv2.RDATA, error) {
 	mustbe.ValidArgs(args)
-	if len(args) != 3 {
-		return nil, fmt.Errorf("URL expects 3 arguments, got %d: %+v", len(args), args)
+	if len(args) != 1 {
+		return nil, fmt.Errorf("URL expects 1 arguments, got %d: %+v", len(args), args)
 	}
 	return URL{
-		Location:           mustbe.RawString(args[0]),
-		PorkbunIncludePath: mustbe.Bool(args[1]),
-		PorkbunWildCard:    mustbe.Bool(args[2]),
+		Location: mustbe.RawString(args[0]),
 	}, nil
 }

--- a/pkg/privatetypes/rdata/rdata_url301.go
+++ b/pkg/privatetypes/rdata/rdata_url301.go
@@ -6,12 +6,11 @@ import (
 
 	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v4/pkg/mustbe"
+	"github.com/DNSControl/dnscontrol/v4/pkg/txtutil"
 )
 
 type URL301 struct {
-	Location           string
-	PorkbunIncludePath bool
-	PorkbunWildCard    bool
+	Location string
 }
 
 func (rd URL301) Len() int {
@@ -19,21 +18,17 @@ func (rd URL301) Len() int {
 }
 
 func (rd URL301) String() string {
-	parts := make([]string, 0, 3)
-	parts = append(parts, rd.Location)
-	parts = append(parts, fmt.Sprintf("%t", rd.PorkbunIncludePath))
-	parts = append(parts, fmt.Sprintf("%t", rd.PorkbunWildCard))
+	parts := make([]string, 0, 1)
+	parts = append(parts, txtutil.ZoneifyString(rd.Location))
 	return strings.Join(parts, " ")
 }
 
 func MakeURL301(origin string, _ map[string]string, args ...any) (dnsv2.RDATA, error) {
 	mustbe.ValidArgs(args)
-	if len(args) != 3 {
-		return nil, fmt.Errorf("URL301 expects 3 arguments, got %d: %+v", len(args), args)
+	if len(args) != 1 {
+		return nil, fmt.Errorf("URL301 expects 1 arguments, got %d: %+v", len(args), args)
 	}
 	return URL301{
-		Location:           mustbe.TargetHost(origin, args[0]),
-		PorkbunIncludePath: mustbe.Bool(args[1]),
-		PorkbunWildCard:    mustbe.Bool(args[2]),
+		Location: mustbe.RawString(args[0]),
 	}, nil
 }

--- a/pkg/privatetypes/t_porkbun_urlfwd.go
+++ b/pkg/privatetypes/t_porkbun_urlfwd.go
@@ -22,10 +22,7 @@ type PORKBUNURLFWD struct {
 	Hdr dnsv2.Header
 
 	privatetypesrdata.PORKBUNURLFWD
-	// Target               string
-	// TypeName             string
-	// IncludePath          string
-	// Wildcard             string
+	// Location             string
 }
 
 // Typer interface.
@@ -39,16 +36,13 @@ func (rr *PORKBUNURLFWD) Len() int {
 	return rr.Hdr.Len() + rr.Data().Len()
 }
 func (rr *PORKBUNURLFWD) Data() dnsv2.RDATA {
-	return &privatetypesrdata.PORKBUNURLFWD{Target: rr.Target, TypeName: rr.TypeName, IncludePath: rr.IncludePath, Wildcard: rr.Wildcard}
+	return &privatetypesrdata.PORKBUNURLFWD{Location: rr.Location}
 }
 func (rr *PORKBUNURLFWD) Clone() dnsv2.RR {
 	return &PORKBUNURLFWD{
 		Hdr: rr.Hdr,
 		PORKBUNURLFWD: privatetypesrdata.PORKBUNURLFWD{
-			Target:      rr.Target,
-			TypeName:    rr.TypeName,
-			IncludePath: rr.IncludePath,
-			Wildcard:    rr.Wildcard,
+			Location: rr.Location,
 		}}
 }
 func (rr *PORKBUNURLFWD) String() string {
@@ -60,12 +54,9 @@ func (rr *PORKBUNURLFWD) String() string {
 // Parse makes an RDATA for this type using the tokens from dnsv2's parser.
 func (rr *PORKBUNURLFWD) Parse(tokens []string, s string) error {
 	args := TokensToArgs(tokens)
-	if len(args) != 4 {
-		return fmt.Errorf("PORKBUN_URLFWD requires exactly 4 arguments, got %d: %v", len(args), args)
+	if len(args) != 1 {
+		return fmt.Errorf("PORKBUN_URLFWD requires exactly 1 arguments, got %d: %v", len(args), args)
 	}
-	rr.Target = mustbe.RawString(args[0])
-	rr.TypeName = mustbe.RawString(args[1])
-	rr.IncludePath = mustbe.RawString(args[2])
-	rr.Wildcard = mustbe.RawString(args[3])
+	rr.Location = mustbe.RawString(args[0])
 	return nil
 }

--- a/pkg/privatetypes/t_porkbun_urlfwd_test.go
+++ b/pkg/privatetypes/t_porkbun_urlfwd_test.go
@@ -11,48 +11,7 @@ func TestPorkbunUrlfwd_Plain(t *testing.T) {
 	y := &PORKBUNURLFWD{
 		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
 		PORKBUNURLFWD: privatetypesrdata.PORKBUNURLFWD{
-			Target:      "http://example.com",
-			TypeName:    "urlfwd",
-			IncludePath: "no",
-			Wildcard:    "no",
-		},
-	}
-	rry, err := dnsv2.New(y.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rry.String() != y.String() {
-		t.Fatalf("PORKBUN_URLFWD string presentations should be identical:\n%s\n%s", rry.String(), y.String())
-	}
-}
-
-func TestPorkbunUrlfwd_WithMetadata(t *testing.T) {
-	y := &PORKBUNURLFWD{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		PORKBUNURLFWD: privatetypesrdata.PORKBUNURLFWD{
-			Target:      "http://example.com",
-			TypeName:    "urlfwd",
-			IncludePath: "permanent",
-			Wildcard:    "no",
-		},
-	}
-	rry, err := dnsv2.New(y.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rry.String() != y.String() {
-		t.Fatalf("PORKBUN_URLFWD string presentations should be identical:\n%s\n%s", rry.String(), y.String())
-	}
-}
-
-func TestPorkbunUrlfwd_WithWildcard(t *testing.T) {
-	y := &PORKBUNURLFWD{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		PORKBUNURLFWD: privatetypesrdata.PORKBUNURLFWD{
-			Target:      "http://example.com",
-			TypeName:    "urlfwd",
-			IncludePath: "no",
-			Wildcard:    "yes",
+			Location: "",
 		},
 	}
 	rry, err := dnsv2.New(y.String())

--- a/pkg/privatetypes/t_url.go
+++ b/pkg/privatetypes/t_url.go
@@ -23,8 +23,6 @@ type URL struct {
 
 	privatetypesrdata.URL
 	// Location             string
-	// PorkbunIncludePath   bool
-	// PorkbunWildCard      bool
 }
 
 // Typer interface.
@@ -38,15 +36,13 @@ func (rr *URL) Len() int {
 	return rr.Hdr.Len() + rr.Data().Len()
 }
 func (rr *URL) Data() dnsv2.RDATA {
-	return &privatetypesrdata.URL{Location: rr.Location, PorkbunIncludePath: rr.PorkbunIncludePath, PorkbunWildCard: rr.PorkbunWildCard}
+	return &privatetypesrdata.URL{Location: rr.Location}
 }
 func (rr *URL) Clone() dnsv2.RR {
 	return &URL{
 		Hdr: rr.Hdr,
 		URL: privatetypesrdata.URL{
-			Location:           rr.Location,
-			PorkbunIncludePath: rr.PorkbunIncludePath,
-			PorkbunWildCard:    rr.PorkbunWildCard,
+			Location: rr.Location,
 		}}
 }
 func (rr *URL) String() string {
@@ -58,11 +54,9 @@ func (rr *URL) String() string {
 // Parse makes an RDATA for this type using the tokens from dnsv2's parser.
 func (rr *URL) Parse(tokens []string, s string) error {
 	args := TokensToArgs(tokens)
-	if len(args) != 3 {
-		return fmt.Errorf("URL requires exactly 3 arguments, got %d: %v", len(args), args)
+	if len(args) != 1 {
+		return fmt.Errorf("URL requires exactly 1 arguments, got %d: %v", len(args), args)
 	}
 	rr.Location = mustbe.RawString(args[0])
-	rr.PorkbunIncludePath = mustbe.Bool(args[1])
-	rr.PorkbunWildCard = mustbe.Bool(args[2])
 	return nil
 }

--- a/pkg/privatetypes/t_url301.go
+++ b/pkg/privatetypes/t_url301.go
@@ -23,8 +23,6 @@ type URL301 struct {
 
 	privatetypesrdata.URL301
 	// Location             string
-	// PorkbunIncludePath   bool
-	// PorkbunWildCard      bool
 }
 
 // Typer interface.
@@ -38,15 +36,13 @@ func (rr *URL301) Len() int {
 	return rr.Hdr.Len() + rr.Data().Len()
 }
 func (rr *URL301) Data() dnsv2.RDATA {
-	return &privatetypesrdata.URL301{Location: rr.Location, PorkbunIncludePath: rr.PorkbunIncludePath, PorkbunWildCard: rr.PorkbunWildCard}
+	return &privatetypesrdata.URL301{Location: rr.Location}
 }
 func (rr *URL301) Clone() dnsv2.RR {
 	return &URL301{
 		Hdr: rr.Hdr,
 		URL301: privatetypesrdata.URL301{
-			Location:           rr.Location,
-			PorkbunIncludePath: rr.PorkbunIncludePath,
-			PorkbunWildCard:    rr.PorkbunWildCard,
+			Location: rr.Location,
 		}}
 }
 func (rr *URL301) String() string {
@@ -58,11 +54,9 @@ func (rr *URL301) String() string {
 // Parse makes an RDATA for this type using the tokens from dnsv2's parser.
 func (rr *URL301) Parse(tokens []string, s string) error {
 	args := TokensToArgs(tokens)
-	if len(args) != 3 {
-		return fmt.Errorf("URL301 requires exactly 3 arguments, got %d: %v", len(args), args)
+	if len(args) != 1 {
+		return fmt.Errorf("URL301 requires exactly 1 arguments, got %d: %v", len(args), args)
 	}
-	rr.Location = mustbe.TargetHost("", args[0])
-	rr.PorkbunIncludePath = mustbe.Bool(args[1])
-	rr.PorkbunWildCard = mustbe.Bool(args[2])
+	rr.Location = mustbe.RawString(args[0])
 	return nil
 }

--- a/pkg/privatetypes/t_url301_test.go
+++ b/pkg/privatetypes/t_url301_test.go
@@ -11,9 +11,7 @@ func TestUrl301(t *testing.T) {
 	y := &URL301{
 		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
 		URL301: privatetypesrdata.URL301{
-			Location:           "example.com.",
-			PorkbunIncludePath: true,
-			PorkbunWildCard:    false,
+			Location: "https://example.com/",
 		},
 	}
 	rry, err := dnsv2.New(y.String())

--- a/pkg/privatetypes/t_url_test.go
+++ b/pkg/privatetypes/t_url_test.go
@@ -11,9 +11,7 @@ func TestUrl(t *testing.T) {
 	y := &URL{
 		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
 		URL: privatetypesrdata.URL{
-			Location:           "https://example.com/",
-			PorkbunIncludePath: true,
-			PorkbunWildCard:    false,
+			Location: "https://example.com/",
 		},
 	}
 	rry, err := dnsv2.New(y.String())

--- a/pkg/privatetypes/types_generate.yaml
+++ b/pkg/privatetypes/types_generate.yaml
@@ -191,33 +191,12 @@ types:
   - name: Porkbun_Urlfwd
     codepoint: 65297
     fields:
-      - name: Target
-        type: RawString
-      - name: TypeName
-        type: RawString
-      - name: IncludePath
-        type: RawString
-      - name: Wildcard
+      - name: Location
         type: RawString
     test_data:
       - name: "plain"
         values:
           Target: http://example.com
-          TypeName: urlfwd
-          IncludePath: no
-          Wildcard: no
-      - name: "with metadata"
-        values:
-          Target: http://example.com
-          TypeName: urlfwd
-          IncludePath: permanent
-          Wildcard: no
-      - name: "with wildcard"
-        values:
-          Target: http://example.com
-          TypeName: urlfwd
-          IncludePath: no
-          Wildcard: yes
 
   - name: R53_Alias
     codepoint: 65298
@@ -244,29 +223,17 @@ types:
     fields:
       - name: Location
         type: RawString
-      - name: PorkbunIncludePath
-        type: Bool
-      - name: PorkbunWildCard
-        type: Bool
     test_data:
       - name: ""
         values:
           Location: https://example.com/
-          PorkbunIncludePath: true
-          PorkbunWildCard: false
 
   - name: Url301
     codepoint: 65300
     fields:
       - name: Location
-        type: TargetHost
-      - name: PorkbunIncludePath
-        type: Bool
-      - name: PorkbunWildCard
-        type: Bool
+        type: RawString
     test_data:
       - name: ""
         values:
-          Location: example.com.
-          PorkbunIncludePath: true
-          PorkbunWildCard: false
+          Location: https://example.com/

--- a/providers/porkbun/porkbunProvider.go
+++ b/providers/porkbun/porkbunProvider.go
@@ -165,6 +165,47 @@ func genComparable(rec *models.RecordConfig) string {
 	return ""
 }
 
+func porkbunURLForwardingMetadata(recordType string, metadata map[string]string) (string, string, string) {
+	t := metadata[metaType]
+	if t == "" {
+		if recordType == "URL301" {
+			t = "permanent"
+		} else {
+			t = "temporary"
+		}
+	}
+	includePath := metadata[metaIncludePath]
+	if includePath == "" {
+		includePath = "no"
+	}
+	wildcard := metadata[metaWildcard]
+	if wildcard == "" {
+		wildcard = "yes"
+	}
+	return t, includePath, wildcard
+}
+
+func normalizeURLForwardingRecord(record *models.RecordConfig, origin string) {
+	if !isURLForwardingType(record.Type) {
+		return
+	}
+	record.TTL = 0
+	if record.Metadata == nil {
+		record.Metadata = make(map[string]string)
+	}
+	t, includePath, wildcard := porkbunURLForwardingMetadata(record.Type, record.Metadata)
+	record.Metadata[metaType] = t
+	record.Metadata[metaIncludePath] = includePath
+	record.Metadata[metaWildcard] = wildcard
+	if record.Type == "PORKBUN_URLFWD" {
+		if record.Metadata[metaType] == "permanent" {
+			record.Type = "URL301"
+		} else {
+			record.Type = "URL"
+		}
+	}
+}
+
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
 func (c *porkbunProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existingRecords models.Records) ([]*models.Correction, int, error) {
 	var corrections []*models.Correction
@@ -175,35 +216,7 @@ func (c *porkbunProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exi
 	// Make sure TTL larger than the minimum TTL
 	for _, record := range dc.Records {
 		record.TTL = fixTTL(record.TTL)
-		if isURLForwardingType(record.Type) {
-			record.TTL = 0
-			if record.Metadata == nil {
-				record.Metadata = make(map[string]string)
-			}
-			// Set metadata type based on record type
-			if record.Metadata[metaType] == "" {
-				if record.Type == "URL301" {
-					record.Metadata[metaType] = "permanent"
-				} else {
-					// Default for URL and PORKBUN_URLFWD
-					record.Metadata[metaType] = "temporary"
-				}
-			}
-			if record.Metadata[metaIncludePath] == "" {
-				record.Metadata[metaIncludePath] = "no"
-			}
-			if record.Metadata[metaWildcard] == "" {
-				record.Metadata[metaWildcard] = "yes"
-			}
-			if record.Type == "PORKBUN_URLFWD" {
-				printer.Warnf("`PORKBUN_URLFWD` is deprecated. Please use `URL` or `URL301` instead.\n")
-				if record.Metadata[metaType] == "permanent" {
-					record.Type = "URL301"
-				} else {
-					record.Type = "URL"
-				}
-			}
-		}
+		normalizeURLForwardingRecord(record, dc.Name)
 	}
 
 	changes, actualChangeCount, err := diff2.ByRecord(existingRecords, dc, genComparable)


### PR DESCRIPTION
- removed PorkbunIncludePath and PorkbunWildCard from URL/URL301
- removed TypeName and IncludePath and Wildcard from PORKBUN_URLFWD
- add URL/URL301 to integration test
- modify the type of Location in URL301 from TargetHost to RawString
- keep PORKBUN_URLFWD

Those fields are in metadata rather in RecordConfig, so I believed it is fine to let it stay in metadata, and it wouldn't cause too much memory.

By removing from URL/URL301, it also save some times from other provider using the same type, like NAMECHEAP.

Integration test are running in progress, if it success, I will mark this PR ready to merge.