### PR TITLE
NS1: Modernization fixes

### DIFF
--- a/providers/ns1/convert_test.go
+++ b/providers/ns1/convert_test.go
@@ -1,0 +1,57 @@
+package ns1
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v5/models"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+func TestConvertTXT(t *testing.T) {
+	t.Parallel()
+
+	dc := models.MustNewDomainConfig("example.com")
+	zr := &dns.ZoneRecord{
+		Domain:   "example.com",
+		Type:     "TXT",
+		TTL:      300,
+		ShortAns: []string{"v=spf1 include:_spf.google.com ~all"},
+	}
+
+	recs, err := convert(zr, dc)
+	if err != nil {
+		t.Fatalf("convert() error: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("len(recs) = %d, want 1", len(recs))
+	}
+	if got := recs[0].GetTargetTXTJoined(); got != "v=spf1 include:_spf.google.com ~all" {
+		t.Errorf("TXT = %q, want %q", got, "v=spf1 include:_spf.google.com ~all")
+	}
+}
+
+func TestConvertNAPTR(t *testing.T) {
+	t.Parallel()
+
+	dc := models.MustNewDomainConfig("example.com")
+	zr := &dns.ZoneRecord{
+		Domain: "example.com",
+		Type:   "NAPTR",
+		TTL:    300,
+		ShortAns: []string{
+			`100 10 U E2U+sip "!^.*$!sip:customer-service@example.com!" .`,
+		},
+	}
+
+	recs, err := convert(zr, dc)
+	if err != nil {
+		t.Fatalf("convert() error: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("len(recs) = %d, want 1", len(recs))
+	}
+	want := `100 10 "U" "E2U+sip" "!^.*$!sip:customer-service@example.com!" .`
+	if got := recs[0].GetRDATA().String(); got != want {
+		t.Errorf("NAPTR = %q, want %q", got, want)
+	}
+}

--- a/providers/ns1/naptr.go
+++ b/providers/ns1/naptr.go
@@ -1,0 +1,84 @@
+package ns1
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ns1NAPTRAnswer(ans string) (string, error) {
+	// NS1 doesn't quote a missing parameter properly. Therefore we look for 2
+	// spaces and assume there is a missing item.
+	ans = strings.ReplaceAll(ans, "  ", ` "" `)
+	return naptrAssureQuotedFields(ans)
+}
+
+// naptrAssureQuotedFields makes sure that NAPTR flags, service, and regexp
+// fields are RFC1035-quoted. NS1 returns these without quotes.
+func naptrAssureQuotedFields(contents string) (string, error) {
+	fields := strings.Fields(contents)
+	if len(fields) < 5 {
+		return "", fmt.Errorf("not enough NAPTR fields: %q", contents)
+	}
+
+	flag, err := naptrAddQuotes(fields[2])
+	if err != nil {
+		return "", err
+	}
+
+	service, err := naptrAddQuotes(fields[3])
+	if err != nil {
+		return "", err
+	}
+
+	regex := fields[4]
+	if regex != `""` { // empty regex is permitted.
+		regex, err = naptrAddQuotes(fields[4])
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if fields[2] == flag && fields[3] == service && fields[4] == regex {
+		return contents, nil
+	}
+
+	fields[2] = flag
+	fields[3] = service
+	fields[4] = regex
+	return strings.Join(fields, " "), nil
+}
+
+func naptrAddQuotes(flag string) (string, error) {
+	switch len(flag) {
+	case 0:
+		return "", fmt.Errorf("empty flag")
+	case 1:
+		if flag[0] == '"' {
+			return "", fmt.Errorf("invalid flag: %q", flag)
+		}
+		return `"` + flag + `"`, nil
+	case 2:
+		if flag == `""` {
+			return "", fmt.Errorf("empty flag")
+		}
+		if flag[0] == '"' {
+			return "", fmt.Errorf("unclosed quote")
+		}
+		if flag[1] == '"' {
+			return "", fmt.Errorf("unopened quote")
+		}
+		return `"` + flag + `"`, nil
+	}
+
+	last := len(flag) - 1
+	if flag[0] == '"' && flag[last] == '"' {
+		return flag, nil
+	}
+	if flag[0] == '"' {
+		return "", fmt.Errorf("unclosed quote")
+	}
+	if flag[last] == '"' {
+		return "", fmt.Errorf("unopened quote")
+	}
+	return `"` + flag + `"`, nil
+}

--- a/providers/ns1/records.go
+++ b/providers/ns1/records.go
@@ -200,10 +200,10 @@ func convert(zr *dns.ZoneRecord, dc *models.DomainConfig) (models.Records, error
 			xAns := strings.SplitN(ans, " ", 3)
 			rec, err = dc.NewRecordConfig(label, ttl, rtype, xAns[0], xAns[1], xAns[2])
 		case "NAPTR":
-			// NB(tlim): This is a stupid hack.  NS1 doesn't quote a missing
-			// parameter properly. Therefore we look for 2 spaces and assume there is
-			// a missing item.
-			ans = strings.ReplaceAll(ans, "  ", ` "" `)
+			ans, err = ns1NAPTRAnswer(ans)
+			if err != nil {
+				break
+			}
 			rec, err = dc.NewRecordConfigParse(label, ttl, rtype, ans)
 		case "TXT":
 			// NS1 returns TXT values as plain strings, not RFC1035 quoted presentation.

--- a/providers/ns1/records.go
+++ b/providers/ns1/records.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
@@ -204,6 +205,9 @@ func convert(zr *dns.ZoneRecord, dc *models.DomainConfig) (models.Records, error
 			// a missing item.
 			ans = strings.ReplaceAll(ans, "  ", ` "" `)
 			rec, err = dc.NewRecordConfigParse(label, ttl, rtype, ans)
+		case "TXT":
+			// NS1 returns TXT values as plain strings, not RFC1035 quoted presentation.
+			rec, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, ans)
 		case "REDIRECT":
 			// NS1 returns REDIRECTs as records, but there is only one and dummy answer:
 			// "NS1 MANAGED RECORD"


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
This changeset provides fixes for TXT and NAPTR handling under the new record converter.

* For TXT, it ensures that we parse it as a simple string and not an RFC1035 quoted representation.
* For NAPTR, it restores the usage of naptrAssureQuotedFields, but in a provider-private way, ensuring no other providers will be impacted now or in the future.