### PR TITLE
POWERDNS: Update SVCB handling to preserve quotes for ECH parameters

### DIFF
--- a/providers/powerdns/convert_test.go
+++ b/providers/powerdns/convert_test.go
@@ -81,6 +81,16 @@ func TestBuildRecordListSvcbAutoHints(t *testing.T) {
 	assert.Equal(t, "1 . alpn=h3,h2 ipv4hint=auto ipv6hint=auto", records[0].Content)
 }
 
+func TestBuildRecordListSvcbEchKeepsQuotes(t *testing.T) {
+	dc := models.MustNewDomainConfig("example.com")
+	recordConfig := dc.MustNewRecordConfig("@", 300, "SVCB", uint16(3), "example.com.", "alpn=h2,h3 port=999 ech=some+base64+encoded+value///")
+
+	records := buildRecordList(diff2.Change{New: models.Records{recordConfig}})
+
+	assert.Len(t, records, 1)
+	assert.Equal(t, `3 example.com. alpn=h2,h3 port=999 ech="some+base64+encoded+value///"`, records[0].Content)
+}
+
 func TestParseText(t *testing.T) {
 	// short TXT record
 	short := parseTxt("\"simple\"")

--- a/providers/powerdns/diff.go
+++ b/providers/powerdns/diff.go
@@ -3,6 +3,7 @@ package powerdns
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/DNSControl/dnscontrol/v5/models"
@@ -10,6 +11,11 @@ import (
 	"github.com/fatih/color"
 	"github.com/mittwald/go-powerdns/apis/zones"
 )
+
+// powerDNSSvcParamQuoteRe matches quoted SVCB/HTTPS parameter values that do
+// not contain characters PowerDNS requires to remain quoted, such as ECH
+// base64 data containing + or /.
+var powerDNSSvcParamQuoteRe = regexp.MustCompile(`="([^"+/ ]*)"`)
 
 func (dsp *powerdnsProvider) getDiff2DomainCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, int, error) {
 	changes, actualChangeCount, err := diff2.ByRecordSet(existing, dc, nil)
@@ -87,10 +93,9 @@ func buildRecordList(change diff2.Change) (records []zones.Record) {
 			Content: powerDNSTargetCombined(recordContent),
 		}
 		if recordContent.Type == "HTTPS" || recordContent.Type == "SVCB" {
-			// PowerDNS API will return HTTP 422 error if record content contains double quotes.
-			// Remove double quotes to work around this limitation.
-			// e.g. `1 . alpn="h3,h2"`  ==> `1 . alpn=h3,h2`
-			record.Content = strings.ReplaceAll(record.Content, "\"", "")
+			// PowerDNS rejects quoted simple param values like alpn="h3,h2",
+			// but validates ECH base64 data against the quoted parsed form.
+			record.Content = powerDNSSvcParamQuoteRe.ReplaceAllString(record.Content, `=$1`)
 		}
 		records = append(records, record)
 	}


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->

PowerDNS rejects quotes around simple SVCB params like alpn, but ECH base64-style values containing + or / must remain quoted. This updates the PowerDNS payload conversion to strip only simple param quotes and adds regression coverage for SVCB ECH records.