### PR TITLE
CHORE: Use dc.LabelFromShort() even when not required for safety.

### DIFF
--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -151,19 +151,20 @@ func nativeToRecord(record *egoscale.DNSDomainRecord, dc *models.DomainConfig) (
 		return nil, nil
 	}
 
+	label := dc.LabelFromShort(record.Name)
 	ttl := uint32(record.Ttl)
 
 	var recordConfig *models.RecordConfig
 	var err error
 	switch record.Type {
 	case "ALIAS", "URL":
-		recordConfig, err = dc.NewRecordConfig(record.Name, ttl, string(record.Type), recordContent)
+		recordConfig, err = dc.NewRecordConfig(label, ttl, string(record.Type), recordContent)
 	case "MX":
-		recordConfig, err = dc.NewRecordConfig(record.Name, ttl, string(record.Type), record.Priority, recordContent)
+		recordConfig, err = dc.NewRecordConfig(label, ttl, string(record.Type), record.Priority, recordContent)
 	case "TXT":
-		recordConfig, err = dc.NewRecordConfig(record.Name, ttl, string(record.Type), recordContent)
+		recordConfig, err = dc.NewRecordConfig(label, ttl, string(record.Type), recordContent)
 	default:
-		recordConfig, err = dc.NewRecordConfigParse(record.Name, ttl, string(record.Type), recordContent)
+		recordConfig, err = dc.NewRecordConfigParse(label, ttl, string(record.Type), recordContent)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unparsable record received from exoscale: %w", err)

--- a/providers/gcore/convert.go
+++ b/providers/gcore/convert.go
@@ -15,7 +15,7 @@ import (
 // nativeToRecord takes a DNS record from G-Core and returns a native RecordConfig struct.
 func nativeToRecords(n gcoreRRSetExtended, dc *models.DomainConfig) ([]*models.RecordConfig, error) {
 	var rcs []*models.RecordConfig
-	recName := dc.ToShort(n.Name)
+	recName := dc.LabelFromShort(n.Name)
 	recType := n.Type
 
 	// Split G-Core's RRset into individual records
@@ -24,6 +24,7 @@ func nativeToRecords(n gcoreRRSetExtended, dc *models.DomainConfig) ([]*models.R
 		if err != nil {
 			return nil, fmt.Errorf("unparsable record received from G-Core: %w", err)
 		}
+
 		var rc *models.RecordConfig
 		switch recType {
 		case "CAA": // G-Core API don't need quotes around CAA with whitespace

--- a/providers/gigahost/gigahostProvider.go
+++ b/providers/gigahost/gigahostProvider.go
@@ -238,15 +238,18 @@ func (c *gigahostProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 
 // nativeToRecordConfig converts a Gigahost record into a RecordConfig.
 func nativeToRecordConfig(dc *models.DomainConfig, r *record) (*models.RecordConfig, error) {
+	label := dc.LabelFromShort(r.RecordName)
+	ttl := r.RecordTTL.Value
+
 	var rc *models.RecordConfig
 	var err error
 	switch r.RecordType {
 	case "MX":
-		rc, err = dc.NewRecordConfig(r.RecordName, r.RecordTTL.Value, r.RecordType, r.RecordPrio.Value, addDot(r.RecordValue))
+		rc, err = dc.NewRecordConfig(label, ttl, r.RecordType, r.RecordPrio.Value, addDot(r.RecordValue))
 	case "CNAME", "NS", "ALIAS", "PTR", "DNAME":
 		// Gigahost stores hostname targets inconsistently (some with a trailing
 		// dot, some without); RecordConfig targets are always FQDNs.
-		rc, err = dc.NewRecordConfig(r.RecordName, r.RecordTTL.Value, r.RecordType, addDot(r.RecordValue))
+		rc, err = dc.NewRecordConfig(label, ttl, r.RecordType, addDot(r.RecordValue))
 	case "TXT":
 		val := r.RecordValue
 		// The API returns >255-octet TXT values in the RFC1035 chunked form
@@ -260,14 +263,16 @@ func nativeToRecordConfig(dc *models.DomainConfig, r *record) (*models.RecordCon
 				val = decoded
 			}
 		}
-		rc, err = dc.NewRecordConfig(r.RecordName, r.RecordTTL.Value, r.RecordType, val)
+		rc, err = dc.NewRecordConfig(label, ttl, r.RecordType, val)
 	default:
-		rc, err = dc.NewRecordConfigParse(r.RecordName, r.RecordTTL.Value, r.RecordType, r.RecordValue)
+		rc, err = dc.NewRecordConfigParse(label, ttl, r.RecordType, r.RecordValue)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("gigahost: unparsable %s record %q: %w", r.RecordType, r.RecordValue, err)
 	}
+
 	rc.Original = r
+
 	return rc, nil
 }
 

--- a/providers/hetznerv2/hetznerv2Provider.go
+++ b/providers/hetznerv2/hetznerv2Provider.go
@@ -245,7 +245,7 @@ func (h *hetznerv2Provider) GetZoneRecords(dc *models.DomainConfig) (models.Reco
 		}
 
 		for _, r := range rrSet.Records {
-			rc, err := dc.NewRecordConfigParse(rrSet.Name, ttl, string(rrSet.Type), r.Value)
+			rc, err := dc.NewRecordConfigParse(dc.LabelFromShort(rrSet.Name), ttl, string(rrSet.Type), r.Value)
 			if err != nil {
 				return nil, err
 			}

--- a/providers/mikrotik/convert.go
+++ b/providers/mikrotik/convert.go
@@ -258,7 +258,7 @@ const ForwarderZone = "_forwarders.mikrotik"
 
 // forwarderToRecord converts a RouterOS DNS forwarder to a RecordConfig.
 func forwarderToRecord(dc *models.DomainConfig, fwd dnsForwarder) *models.RecordConfig {
-	rc := dc.MustNewRecordConfig(fwd.Name, 300, privatetypes.TypeMIKROTIKFORWARDER, fwd.DNSServers)
+	rc := dc.MustNewRecordConfig(dc.LabelFromShort(fwd.Name), 300, privatetypes.TypeMIKROTIKFORWARDER, fwd.DNSServers)
 	// Forwarders have no TTL; use dnscontrol's default to avoid spurious diffs.
 	rc.Original = &fwd
 	if fwd.DohServers != "" {

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -316,9 +316,7 @@ func toSRVRecords(result *nc.DomainSRVGetRecordsResult, dc *models.DomainConfig)
 	var records models.Records
 	for _, srvRecord := range result.Records {
 		label := dc.LabelFromShort(srvRecord.Service + srvRecord.Protocol)
-		record, err := dc.NewRecordConfig(
-			label,
-			0,
+		record, err := dc.NewRecordConfig(label, 0,
 			dnsv2.TypeSRV,
 			srvRecord.Priority,
 			srvRecord.Weight,

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -561,9 +561,7 @@ func nativeToRecords(dc *models.DomainConfig, set r53Types.ResourceRecordSet, or
 	var results models.Records
 	if set.AliasTarget != nil {
 
-		rc, err := dc.NewRecordConfig(
-			dc.LabelFromFQDNNoDot(unescape(set.Name)),
-			300,
+		rc, err := dc.NewRecordConfig(dc.LabelFromFQDNNoDot(unescape(set.Name)), 300,
 			privatetypes.TypeR53ALIAS,
 			string(set.Type),
 			aws.ToString(set.AliasTarget.DNSName),
@@ -621,8 +619,7 @@ func nativeToRecords(dc *models.DomainConfig, set r53Types.ResourceRecordSet, or
 				// Using nrc.TARGET_IS_FQDN_NO_DOT will work, but will be extra
 				// work for all other records.
 
-				rc, err := dc.NewRecordConfigParse(
-					dc.LabelFromFQDNNoDot(unescape(set.Name)),
+				rc, err := dc.NewRecordConfigParse(dc.LabelFromFQDNNoDot(unescape(set.Name)),
 					uint32(aws.ToInt64(set.TTL)),
 					rtypeString,
 					val,


### PR DESCRIPTION
These are low-risk, cosmetic changes.

CC @Giza @xddxdd @hedger @willpower232 @tresni  for visibility