### PR TITLE
NEW PROVIDER: NexDNS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ providers/netbird @yzqzss
 providers/netcup @kordianbruck
 providers/netlify @SphericalKat
 providers/netnod @Netnod
+providers/nexdns @nexdns
 providers/ns1 @costasd
 # providers/opensrs NEEDS VOLUNTEER
 providers/openwrt @huskyistaken

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -142,6 +142,9 @@ provider-NETLIFY:
 provider-NETNOD:
   - changed-files:
       - any-glob-to-any-file: providers/netnod/**
+provider-NEXDNS:
+  - changed-files:
+      - any-glob-to-any-file: providers/nexdns/**
 provider-NS1:
   - changed-files:
       - any-glob-to-any-file: providers/ns1/**

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -136,6 +136,7 @@ jobs:
       NAMEDOTCOM_DOMAIN: ${{ vars.NAMEDOTCOM_DOMAIN }}
       NETBIRD_DOMAIN: ${{ vars.NETBIRD_DOMAIN }}
       NETNOD_DOMAIN: ${{ vars.NETNOD_DOMAIN }}
+      NEXDNS_DOMAIN: ${{ vars.NEXDNS_DOMAIN }}
       NS1_DOMAIN: ${{ vars.NS1_DOMAIN }}
       OPENWRT_DOMAIN: ${{ vars.OPENWRT_DOMAIN }}
       POWERDNS_DOMAIN: ${{ vars.POWERDNS_DOMAIN }}
@@ -245,6 +246,8 @@ jobs:
       #
       NETNOD_APIKEY: ${{ secrets.NETNOD_APIKEY }}
       NETNOD_APIURL: ${{ secrets.NETNOD_APIURL }}
+      #
+      NEXDNS_API_TOKEN: ${{ secrets.NEXDNS_API_TOKEN }}
       #
       NS1_TOKEN: ${{ secrets.NS1_TOKEN }}
       #

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ changelog:
       regexp: "(?i)^.*(major|new provider|feature)[(\\w)]*:+.*$"
       order: 1
     - title: 'Provider-specific changes:'
-      regexp: "(?i)((adguardhome|akamaiedgedns|alidns|autodns|axfrddns|azure_dns|azure_private_dns|azuredns|bind|bunny_dns|bunnydns|cloudflare|cloudflareapi|cloudns|cnr|cscglobal|desec|digitalocean|dnscale|dnsimple|dnsmadeeasy|dnsoverhttps|doh|domainnameshop|dynadot|dynu|easyname|exoscale|fortigate|gandi|gandi_v5|gcloud|gcore|gidinet|gigahost|hedns|hetzner_v2|hexonet|hostingde|huaweicloud|infomaniak|internetbs|inwx|joker|linode|loopia|luadns|mikrotik|mythicbeasts|namecheap|namedotcom|netbird|netcup|netlify|netnod|ns1|opensrs|openwrt|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|scaleway|softlayer|tencentdns|transip|unifi|vercel|vultr|websupport).*:)+.*"
+      regexp: "(?i)((adguardhome|akamaiedgedns|alidns|autodns|axfrddns|azure_dns|azure_private_dns|azuredns|bind|bunny_dns|bunnydns|cloudflare|cloudflareapi|cloudns|cnr|cscglobal|desec|digitalocean|dnscale|dnsimple|dnsmadeeasy|dnsoverhttps|doh|domainnameshop|dynadot|dynu|easyname|exoscale|fortigate|gandi|gandi_v5|gcloud|gcore|gidinet|gigahost|hedns|hetzner_v2|hexonet|hostingde|huaweicloud|infomaniak|internetbs|inwx|joker|linode|loopia|luadns|mikrotik|mythicbeasts|namecheap|namedotcom|netbird|netcup|netlify|netnod|nexdns|ns1|opensrs|openwrt|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|scaleway|softlayer|tencentdns|transip|unifi|vercel|vultr|websupport).*:)+.*"
       order: 2
     - title: 'Documentation:'
       regexp: "(?i)^.*(docs)[(\\w)]*:+.*$"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [Getting Started](https://docs.dnscontrol.org/getting-started/getting-starte
 
 ## Supported Providers
 
-DNSControl supports 64 DNS providers and registrars:
+DNSControl supports 65 DNS providers and registrars:
 
 | | | | | |
 | ----- | ----- | ----- | ----- | ----- |
@@ -55,11 +55,11 @@ DNSControl supports 64 DNS providers and registrars:
 | [hosting.de](https://docs.dnscontrol.org/provider/hostingde)¹ | [Huawei Cloud DNS](https://docs.dnscontrol.org/provider/huaweicloud) | [Hurricane Electric DNS](https://docs.dnscontrol.org/provider/hedns) | [Infomaniak](https://docs.dnscontrol.org/provider/infomaniak) | [Internet.bs](https://docs.dnscontrol.org/provider/internetbs)² |
 | [INWX](https://docs.dnscontrol.org/provider/inwx)¹ | [Joker](https://docs.dnscontrol.org/provider/joker) | [Linode](https://docs.dnscontrol.org/provider/linode) | [Loopia](https://docs.dnscontrol.org/provider/loopia)¹ | [LuaDNS](https://docs.dnscontrol.org/provider/luadns) |
 | Windows Server DNS | [MikroTik RouterOS](https://docs.dnscontrol.org/provider/mikrotik) | [Mythic Beasts](https://docs.dnscontrol.org/provider/mythicbeasts) | [Name.com](https://docs.dnscontrol.org/provider/namedotcom)¹ | [Namecheap](https://docs.dnscontrol.org/provider/namecheap)¹ |
-| [Netcup](https://docs.dnscontrol.org/provider/netcup) | [Netlify](https://docs.dnscontrol.org/provider/netlify) | [Netnod](https://docs.dnscontrol.org/provider/netnod) | [NS1](https://docs.dnscontrol.org/provider/ns1) | [OpenSRS](https://docs.dnscontrol.org/provider/opensrs)² |
-| [Oracle Cloud](https://docs.dnscontrol.org/provider/oracle) | [OVH](https://docs.dnscontrol.org/provider/ovh)¹ | [Packetframe](https://docs.dnscontrol.org/provider/packetframe) | [Porkbun](https://docs.dnscontrol.org/provider/porkbun)¹ | [PowerDNS](https://docs.dnscontrol.org/provider/powerdns) |
-| [Realtime Register](https://docs.dnscontrol.org/provider/realtimeregister)¹ | [RWTH DNS-Admin](https://docs.dnscontrol.org/provider/rwth) | [Sakura Cloud](https://docs.dnscontrol.org/provider/sakuracloud) | [SoftLayer](https://docs.dnscontrol.org/provider/softlayer) | [Tencent Cloud DNS](https://docs.dnscontrol.org/provider/tencentdns)¹ |
-| [TransIP](https://docs.dnscontrol.org/provider/transip) | [UniFi Network](https://docs.dnscontrol.org/provider/unifi) | [Vercel](https://docs.dnscontrol.org/provider/vercel) | [Vultr](https://docs.dnscontrol.org/provider/vultr) | [Netbird](https://docs.dnscontrol.org/provider/netbird) |
-| [WebSupport](https://docs.dnscontrol.org/provider/websupport) | | | | |
+| [Netcup](https://docs.dnscontrol.org/provider/netcup) | [Netlify](https://docs.dnscontrol.org/provider/netlify) | [Netnod](https://docs.dnscontrol.org/provider/netnod) | [NexDNS](https://docs.dnscontrol.org/provider/nexdns) | [NS1](https://docs.dnscontrol.org/provider/ns1) |
+| [OpenSRS](https://docs.dnscontrol.org/provider/opensrs)² | [Oracle Cloud](https://docs.dnscontrol.org/provider/oracle) | [OVH](https://docs.dnscontrol.org/provider/ovh)¹ | [Packetframe](https://docs.dnscontrol.org/provider/packetframe) | [Porkbun](https://docs.dnscontrol.org/provider/porkbun)¹ |
+| [PowerDNS](https://docs.dnscontrol.org/provider/powerdns) | [Realtime Register](https://docs.dnscontrol.org/provider/realtimeregister)¹ | [RWTH DNS-Admin](https://docs.dnscontrol.org/provider/rwth) | [Sakura Cloud](https://docs.dnscontrol.org/provider/sakuracloud) | [SoftLayer](https://docs.dnscontrol.org/provider/softlayer) |
+| [Tencent Cloud DNS](https://docs.dnscontrol.org/provider/tencentdns)¹ | [TransIP](https://docs.dnscontrol.org/provider/transip) | [UniFi Network](https://docs.dnscontrol.org/provider/unifi) | [Vercel](https://docs.dnscontrol.org/provider/vercel) | [Vultr](https://docs.dnscontrol.org/provider/vultr) |
+| [Netbird](https://docs.dnscontrol.org/provider/netbird) | [WebSupport](https://docs.dnscontrol.org/provider/websupport) |  |  |  |
 
 ¹also supports registrar functions
 ²registrar only

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -171,6 +171,7 @@
 * [Netcup](provider/netcup.md)
 * [Netlify](provider/netlify.md)
 * [Netnod](provider/netnod.md)
+* [NexDNS](provider/nexdns.md)
 * [NS1](provider/ns1.md)
 * [OpenWrt](provider/openwrt.md)
 * [OpenSRS](provider/opensrs.md)

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -71,6 +71,7 @@ Jump to a table:
 | [`NETCUP`](netcup.md) | ❌ | ✅ | ❌ |
 | [`NETLIFY`](netlify.md) | ❌ | ✅ | ❌ |
 | [`NETNOD`](netnod.md) | ❌ | ✅ | ❌ |
+| [`NEXDNS`](nexdns.md) | ❌ | ✅ | ❌ |
 | [`NS1`](ns1.md) | ❌ | ✅ | ❌ |
 | [`OPENSRS`](opensrs.md) | ❌ | ❌ | ✅ |
 | [`OPENWRT`](openwrt.md) | ❌ | ✅ | ❌ |
@@ -145,6 +146,7 @@ Jump to a table:
 | [`NETCUP`](netcup.md) | ❔ | ❌ | ❌ | ❌ |
 | [`NETLIFY`](netlify.md) | ✅ | ❌ | ❌ | ✅ |
 | [`NETNOD`](netnod.md) | ❔ | ✅ | ✅ | ✅ |
+| [`NEXDNS`](nexdns.md) | ❔ | ❌ | ✅ | ✅ |
 | [`NS1`](ns1.md) | ✅ | ✅ | ✅ | ✅ |
 | [`OPENSRS`](opensrs.md) | ❔ | ❔ | ❌ | ❔ |
 | [`OPENWRT`](openwrt.md) | ❔ | ❔ | ❌ | ✅ |
@@ -215,6 +217,7 @@ Jump to a table:
 | [`NETCUP`](netcup.md) | ❔ | ❔ | ❌ | ❌ | ❔ |
 | [`NETLIFY`](netlify.md) | ✅ | ❔ | ❌ | ❌ | ❔ |
 | [`NETNOD`](netnod.md) | ✅ | ❌ | ❌ | ✅ | ❌ |
+| [`NEXDNS`](nexdns.md) | ✅ | ✅ | ❌ | ✅ | ❌ |
 | [`NS1`](ns1.md) | ✅ | ✅ | ❌ | ✅ | ❔ |
 | [`OPENWRT`](openwrt.md) | ❌ | ❔ | ❔ | ❔ | ❔ |
 | [`ORACLE`](oracle.md) | ✅ | ❔ | ❔ | ✅ | ❔ |
@@ -283,6 +286,7 @@ Jump to a table:
 | [`NETCUP`](netcup.md) | ❔ | ❔ | ✅ | ❔ |
 | [`NETLIFY`](netlify.md) | ❔ | ❌ | ✅ | ❔ |
 | [`NETNOD`](netnod.md) | ❌ | ✅ | ✅ | ✅ |
+| [`NEXDNS`](nexdns.md) | ❌ | ❌ | ✅ | ❌ |
 | [`NS1`](ns1.md) | ✅ | ✅ | ✅ | ✅ |
 | [`OPENWRT`](openwrt.md) | ❔ | ❔ | ✅ | ❔ |
 | [`ORACLE`](oracle.md) | ❔ | ✅ | ✅ | ❔ |
@@ -350,6 +354,7 @@ Jump to a table:
 | [`NETCUP`](netcup.md) | ✅ | ❔ | ❔ | ❔ | ✅ |
 | [`NETLIFY`](netlify.md) | ✅ | ❔ | ❔ | ❌ | ❌ |
 | [`NETNOD`](netnod.md) | ✅ | ✅ | ❔ | ✅ | ✅ |
+| [`NEXDNS`](nexdns.md) | ✅ | ❌ | ❌ | ❌ | ✅ |
 | [`NS1`](ns1.md) | ✅ | ✅ | ❔ | ❔ | ✅ |
 | [`ORACLE`](oracle.md) | ✅ | ❔ | ❔ | ✅ | ✅ |
 | [`OVH`](ovh.md) | ✅ | ❔ | ❔ | ✅ | ✅ |
@@ -403,6 +408,7 @@ Jump to a table:
 | [`NETBIRD`](netbird.md) | ❌ | ❌ | ❌ |
 | [`NETLIFY`](netlify.md) | ❌ | ❔ | ❌ |
 | [`NETNOD`](netnod.md) | ❌ | ❌ | ❌ |
+| [`NEXDNS`](nexdns.md) | ❔ | ❌ | ❌ |
 | [`NS1`](ns1.md) | ✅ | ❔ | ✅ |
 | [`ORACLE`](oracle.md) | ❔ | ❔ | ❌ |
 | [`PORKBUN`](porkbun.md) | ❌ | ❔ | ❌ |

--- a/documentation/provider/nexdns.md
+++ b/documentation/provider/nexdns.md
@@ -1,0 +1,174 @@
+## Configuration
+
+To use this provider, add an entry to `creds.json` with `TYPE` set to `NEXDNS`
+along with a [NexDNS API key](https://nexdns.tech/settings/api-keys).
+
+Example:
+
+{% code title="creds.json" %}
+```json
+{
+  "nexdns": {
+    "TYPE": "NEXDNS",
+    "api_token": "your-nexdns-api-key"
+  }
+}
+```
+{% endcode %}
+
+You can also use environment variables:
+
+```shell
+export NEXDNS_API_TOKEN=XXXXXXXXX
+```
+
+{% code title="creds.json" %}
+```json
+{
+  "nexdns": {
+    "TYPE": "NEXDNS",
+    "api_token": "$NEXDNS_API_TOKEN"
+  }
+}
+```
+{% endcode %}
+
+The base URL of the API can be changed with the optional `api_url` field. It
+defaults to `https://api.nexdns.tech/v1`.
+
+## Metadata
+
+This provider does not recognize any special metadata fields unique to NexDNS.
+
+## Usage
+
+An example configuration:
+
+{% code title="dnsconfig.js" %}
+```javascript
+var REG_NONE = NewRegistrar("none");
+var DSP_NEXDNS = NewDnsProvider("nexdns");
+
+D("example.com", REG_NONE, DnsProvider(DSP_NEXDNS),
+    A("@", "203.0.113.10"),
+    A("www", "203.0.113.10"),
+    AAAA("@", "2001:db8::1"),
+    CNAME("blog", "example.github.io."),
+    MX("@", 10, "mail.example.com."),
+    TXT("@", "v=spf1 -all"),
+    CAA("@", "issue", "letsencrypt.org"),
+    SRV("_sip._tcp", 10, 60, 5060, "sip.example.com."),
+);
+```
+{% endcode %}
+
+## Activation
+
+DNSControl talks to the [NexDNS API](https://nexdns.tech/docs/api), which needs
+an API key.
+
+1. Sign in and open **Settings**, then **API keys**.
+2. Create a key holding the `zones.read`, `zones.write`, `records.read` and
+   `records.write` scopes. The key is shown once, when it is created.
+3. Put it in `creds.json` as shown above.
+
+The API is available on a plan that includes API access; see the
+[pricing page](https://nexdns.tech/pricing) for which plans those are.
+
+## Supported record types
+
+| Name  | Description |
+| ----- | ----------- |
+| A     | IPv4 address record |
+| AAAA  | IPv6 address record |
+| ALIAS | Alias record |
+| CAA   | Certification Authority Authorization record |
+| CNAME | Canonical name (alias) record |
+| DNAME | Delegation name record |
+| DS    | Delegation signer record, for a delegated child only |
+| MX    | Mail exchange record |
+| NS    | Name server record, for a delegated child only |
+| PTR   | Pointer record |
+| SRV   | Service record |
+| TLSA  | TLSA record |
+| TXT   | Text record |
+
+No other record type is supported.
+
+## New domains
+
+If a domain does not exist in your NexDNS account, DNSControl will add it with
+the `push` command.
+
+## Limitations
+
+### TTLs belong to the record set
+
+A TTL is a property of the record set, not of a single value in it, so every
+value under one label and type shares one TTL. This is what DNSControl already
+requires of a configuration, so it only matters when reading a zone that was
+edited elsewhere.
+
+### Zone apex
+
+The SOA record and the NS records at the zone apex are maintained by NexDNS and
+cannot be written through the API, so DNSControl leaves both alone:
+
+* They are not reported by `dnscontrol get-zones`.
+* An apex `NS` record that matches one of the zone's declared nameservers is
+  dropped silently. Any other apex `NS` record is dropped with a warning,
+  because the API would refuse it. Dual hosting a zone with a second DNS
+  provider is therefore not possible.
+
+The provider reports the nameservers the zone is served from, so no explicit
+`NAMESERVER()` is needed for DNSControl to tell the registrar where to delegate.
+
+### DS records
+
+`DS` records are supported for delegated children. A `DS` record at the zone
+apex belongs in the parent zone and is rejected by `dnscontrol check`.
+
+### DNSSEC
+
+`AUTODNSSEC_ON` is not implemented. DNSSEC is switched on per zone outside of
+DNSControl.
+
+### Concurrent operations
+
+Zone data is not gathered concurrently. The provider has not been verified for
+concurrent use.
+
+## Feature Summary
+
+<!-- provider-features-start -->
+- Provider Type
+  - [Official Support](../provider/index.md#providers-with-official-support): ❌
+  - DNS Provider: ✅
+  - Registrar: ❌
+- Provider API
+  - [Concurrency Verified](../advanced-features/concurrency-verified.md): ❔
+  - [dual host](../advanced-features/dual-host.md): ❌
+  - create-domains: ✅
+  - [get-zones](../commands/get-zones.md): ✅
+- DNS extensions
+  - [`ALIAS`](../language-reference/domain-modifiers/ALIAS.md): ✅
+  - [`DNAME`](../language-reference/domain-modifiers/DNAME.md): ✅
+  - [`LOC`](../language-reference/domain-modifiers/LOC.md): ❌
+  - [`PTR`](../language-reference/domain-modifiers/PTR.md): ✅
+  - [`SOA`](../language-reference/domain-modifiers/SOA.md): ❌
+- Service discovery
+  - [`DHCID`](../language-reference/domain-modifiers/DHCID.md): ❌
+  - [`NAPTR`](../language-reference/domain-modifiers/NAPTR.md): ❌
+  - [`SRV`](../language-reference/domain-modifiers/SRV.md): ✅
+  - [`SVCB`](../language-reference/domain-modifiers/SVCB.md): ❌
+- Security
+  - [`CAA`](../language-reference/domain-modifiers/CAA.md): ✅
+  - [`HTTPS`](../language-reference/domain-modifiers/HTTPS.md): ❌
+  - [`SMIMEA`](../language-reference/domain-modifiers/SMIMEA.md): ❌
+  - [`SSHFP`](../language-reference/domain-modifiers/SSHFP.md): ❌
+  - [`TLSA`](../language-reference/domain-modifiers/TLSA.md): ✅
+- DNSSEC
+  - [`AUTODNSSEC`](../language-reference/domain-modifiers/AUTODNSSEC_ON.md): ❔
+  - [`DNSKEY`](../language-reference/domain-modifiers/DNSKEY.md): ❌
+  - [`DS`](../language-reference/domain-modifiers/DS.md): ❌
+<!-- provider-features-end -->

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -500,6 +500,7 @@ func makeTests() []*TestGroup {
 				"NAMEDOTCOM",        // "Ignores @ for NS records"
 				"NAMECHEAP",         // cannot handle single NS at apex but does handle dual
 				"NETCUP",            // NS records not currently supported.
+				"NEXDNS",            // The apex NS records follow the zone's nameserver group and are not editable.
 				"PORKBUN",           // Record ignored.
 				"SAKURACLOUD",       // Silently ignores requests to remove NS at @.
 				"TRANSIP",           // "it is not allowed to have an NS for an @ record"
@@ -1992,7 +1993,7 @@ func makeTests() []*TestGroup {
 			),
 			tc("Create some records",
 				a("foo", "1.1.1.1"),
-				a("foo", "10.10.10.10"),
+				a("foo", "9.9.9.9"),
 				aaaa("foo", "2003:dd:d7ff::fe71:aaaa"),
 				mx("foo", 10, "aspmx.l.google.com."),
 				mx("foo", 20, "alt1.aspmx.l.google.com."),

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -300,6 +300,11 @@
     "customer-number": "$NETCUP_CUSTOMER_NUMBER",
     "domain": "$NETCUP_DOMAIN"
   },
+  "NEXDNS": {
+    "TYPE": "NEXDNS",
+    "api_token": "$NEXDNS_API_TOKEN",
+    "domain": "$NEXDNS_DOMAIN"
+  },
   "NETLIFY": {
     "TYPE": "NETLIFY",
     "domain": "$NETLIFY_DOMAIN",

--- a/pkg/providers/_all/all.go
+++ b/pkg/providers/_all/all.go
@@ -48,6 +48,7 @@ import (
 	_ "github.com/DNSControl/dnscontrol/v4/providers/mythicbeasts"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/namecheap"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/namedotcom"
+	_ "github.com/DNSControl/dnscontrol/v4/providers/nexdns"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/netbird"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/netcup"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/netlify"

--- a/providers/nexdns/api.go
+++ b/providers/nexdns/api.go
@@ -1,0 +1,337 @@
+package nexdns
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	// defaultAPIURL is the base URL of the API.
+	defaultAPIURL = "https://api.nexdns.tech/v1"
+
+	// defaultTTL is the TTL the API gives an rrset that is created without one.
+	defaultTTL = 3600
+
+	// zonesPerPage is the largest page the zone list accepts.
+	zonesPerPage = 100
+
+	// defaultRetryAfter is how long to wait after a 429 that carries no
+	// Retry-After header.
+	defaultRetryAfter = 5 * time.Second
+
+	// Retry-After is treated as a lower bound rather than as the answer. A
+	// sliding-window limiter reports the time one token needs at the average
+	// release rate, which can be a second even when nothing is released until
+	// the window rolls over a minute later; honouring such a value literally
+	// burns a retry budget in seconds while making no progress. Backing off
+	// from it converges on the true wait without needing to know the server's
+	// policy.
+	initialRateLimitBackoff = 2 * time.Second
+	maxRateLimitBackoff     = time.Minute
+
+	// maxRateLimitWait bounds the total time one request may spend waiting out
+	// rate limits. It is generous because a push is not transactional: giving
+	// up halfway leaves the zone holding some of the intended records and none
+	// of the rest, which is worse for the operator than a slow run.
+	maxRateLimitWait = 3 * time.Minute
+)
+
+type apiClient struct {
+	baseURL    string
+	apiToken   string
+	httpClient *http.Client
+
+	// sleep is time.Sleep, replaced in tests so that exercising the rate-limit
+	// backoff does not cost the wall-clock time it is waiting out.
+	sleep func(time.Duration)
+}
+
+// apiResponse is the envelope every successful response is wrapped in.
+type apiResponse struct {
+	Status string          `json:"status"`
+	Data   json.RawMessage `json:"data"`
+}
+
+// apiZone is a zone as returned by GET /zones/{id}.
+type apiZone struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Nameservers []string `json:"nameservers"`
+}
+
+// apiZoneListItem is a zone as returned by GET /zones. Name is the canonical
+// punycode name; UnicodeName is the same name in its native script and is equal
+// to Name for an ASCII zone.
+type apiZoneListItem struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	UnicodeName string `json:"unicode_name"`
+}
+
+// apiRecord is one record value as returned by GET /zones/{id}/records. Name is
+// relative to the zone, "@" at the apex, and Content is the assembled rdata.
+type apiRecord struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Content string `json:"content"`
+	TTL     int    `json:"ttl"`
+}
+
+// recordRequest is the body of a record create or update. Content holds only the
+// primary value of the record; the numeric and keyword parts of MX, SRV, CAA, DS
+// and TLSA are sent alongside it.
+type recordRequest struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	Content      string `json:"content"`
+	TTL          int    `json:"ttl,omitempty"`
+	Priority     *int   `json:"priority,omitempty"`
+	Weight       *int   `json:"weight,omitempty"`
+	Port         *int   `json:"port,omitempty"`
+	Flags        *int   `json:"flags,omitempty"`
+	Tag          string `json:"tag,omitempty"`
+	KeyTag       *int   `json:"keytag,omitempty"`
+	Algorithm    *int   `json:"algorithm,omitempty"`
+	DigestType   *int   `json:"digest_type,omitempty"`
+	Usage        *int   `json:"usage,omitempty"`
+	Selector     *int   `json:"selector,omitempty"`
+	MatchingType *int   `json:"matching_type,omitempty"`
+}
+
+// apiError carries the status code as well as the message, so a caller can tell
+// a missing zone (a normal outcome for EnsureZoneExists) from a real failure.
+type apiError struct {
+	StatusCode int
+	Code       string
+	Message    string
+}
+
+func (e *apiError) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("NEXDNS: API error: HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("NEXDNS: API error: %s (HTTP %d)", e.Message, e.StatusCode)
+}
+
+// isNotFound reports whether err is the API saying the resource does not exist.
+func isNotFound(err error) bool {
+	var apiErr *apiError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+func newAPIClient(baseURL, token string) *apiClient {
+	return &apiClient{
+		baseURL:  baseURL,
+		apiToken: token,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		sleep: time.Sleep,
+	}
+}
+
+// getZone looks a zone up by its exact name. The search parameter matches on a
+// substring, so the exact name is picked out here; an internationalized zone is
+// also matched on its native-script name.
+func (c *apiClient) getZone(name string) (*apiZone, error) {
+	zones, err := c.searchZones(name)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, z := range zones {
+		if z.Name != name && z.UnicodeName != name {
+			continue
+		}
+
+		var zone apiZone
+		if err := c.doRequest(http.MethodGet, "/zones/"+z.ID, nil, &zone); err != nil {
+			return nil, err
+		}
+		return &zone, nil
+	}
+
+	return nil, &apiError{
+		StatusCode: http.StatusNotFound,
+		Code:       "not_found",
+		Message:    fmt.Sprintf("zone %q not found", name),
+	}
+}
+
+// listZones returns every zone the API key can see.
+func (c *apiClient) listZones() ([]apiZoneListItem, error) {
+	return c.searchZones("")
+}
+
+// searchZones pages through GET /zones, optionally narrowed by a search term.
+func (c *apiClient) searchZones(search string) ([]apiZoneListItem, error) {
+	query := url.Values{}
+	query.Set("per_page", strconv.Itoa(zonesPerPage))
+	if search != "" {
+		query.Set("search", search)
+	}
+
+	var all []apiZoneListItem
+	for page := 1; ; page++ {
+		query.Set("page", strconv.Itoa(page))
+
+		var zones []apiZoneListItem
+		if err := c.doRequest(http.MethodGet, "/zones?"+query.Encode(), nil, &zones); err != nil {
+			return nil, err
+		}
+
+		all = append(all, zones...)
+		if len(zones) < zonesPerPage {
+			return all, nil
+		}
+	}
+}
+
+func (c *apiClient) createZone(name string) error {
+	return c.doRequest(http.MethodPost, "/zones", map[string]string{"name": name}, nil)
+}
+
+func (c *apiClient) listRecords(zoneID string) ([]apiRecord, error) {
+	var records []apiRecord
+	if err := c.doRequest(http.MethodGet, "/zones/"+zoneID+"/records", nil, &records); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func (c *apiClient) createRecord(zoneID string, rec recordRequest) error {
+	return c.doRequest(http.MethodPost, "/zones/"+zoneID+"/records", rec, nil)
+}
+
+func (c *apiClient) updateRecord(zoneID, recordID string, rec recordRequest) error {
+	return c.doRequest(http.MethodPut, "/zones/"+zoneID+"/records/"+recordID, rec, nil)
+}
+
+func (c *apiClient) deleteRecord(zoneID, recordID string) error {
+	return c.doRequest(http.MethodDelete, "/zones/"+zoneID+"/records/"+recordID, nil, nil)
+}
+
+// doRequest performs one API call, unwrapping the response envelope into result.
+// A push sends one request per record, which can run into the account's rate
+// limit, so a "429 Too Many Requests" is waited out rather than reported.
+func (c *apiClient) doRequest(method, path string, body, result any) error {
+	var payload []byte
+	if body != nil {
+		var err error
+		payload, err = json.Marshal(body)
+		if err != nil {
+			return err
+		}
+	}
+
+	var waited time.Duration
+	backoff := initialRateLimitBackoff
+
+	for {
+		status, header, respBody, err := c.send(method, path, payload)
+		if err != nil {
+			return err
+		}
+
+		if status == http.StatusTooManyRequests {
+			wait := max(retryAfter(header), backoff)
+			if waited+wait > maxRateLimitWait {
+				return parseAPIError(status, respBody)
+			}
+
+			c.sleep(wait)
+			waited += wait
+			backoff = min(backoff*2, maxRateLimitBackoff)
+
+			continue
+		}
+		if status >= 400 {
+			return parseAPIError(status, respBody)
+		}
+		if result == nil || status == http.StatusNoContent {
+			return nil
+		}
+
+		var envelope apiResponse
+		if json.Unmarshal(respBody, &envelope) == nil && envelope.Status == "success" {
+			return json.Unmarshal(envelope.Data, result)
+		}
+		return json.Unmarshal(respBody, result)
+	}
+}
+
+func (c *apiClient) send(method, path string, payload []byte) (int, http.Header, []byte, error) {
+	var bodyReader io.Reader
+	if payload != nil {
+		bodyReader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequest(method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	return resp.StatusCode, resp.Header, respBody, nil
+}
+
+// retryAfter reads the Retry-After header of a rate-limited response.
+func retryAfter(header http.Header) time.Duration {
+	seconds, err := strconv.Atoi(header.Get("Retry-After"))
+	if err != nil || seconds < 0 {
+		return defaultRetryAfter
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// parseAPIError unwraps the error envelope. The per-field detail is kept, so a
+// rejected record reports which field the API objected to.
+func parseAPIError(statusCode int, body []byte) error {
+	var envelope struct {
+		Error *struct {
+			Code    string                     `json:"code"`
+			Message string                     `json:"message"`
+			Details map[string]json.RawMessage `json:"details"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Error == nil {
+		return &apiError{StatusCode: statusCode, Message: string(body)}
+	}
+
+	message := envelope.Error.Message
+	for field, raw := range envelope.Error.Details {
+		var list []string
+		if json.Unmarshal(raw, &list) == nil && len(list) > 0 {
+			message = fmt.Sprintf("%s (%s: %s)", message, field, list[0])
+			continue
+		}
+
+		var single string
+		if json.Unmarshal(raw, &single) == nil {
+			message = fmt.Sprintf("%s (%s: %s)", message, field, single)
+		}
+	}
+
+	return &apiError{StatusCode: statusCode, Code: envelope.Error.Code, Message: message}
+}

--- a/providers/nexdns/auditrecords.go
+++ b/providers/nexdns/auditrecords.go
@@ -1,0 +1,110 @@
+package nexdns
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/rejectif"
+)
+
+// caaTags are the property tags the API accepts in a CAA record.
+var caaTags = []string{"issue", "issuewild", "iodef"}
+
+// AuditRecords returns a list of errors corresponding to the records
+// that aren't supported by this provider.  If all records are
+// supported, an empty list is returned.
+func AuditRecords(records []*models.RecordConfig) []error {
+	a := rejectif.Auditor{}
+
+	// validation_error - value: Value is required. Last verified 2026-07-31.
+	a.Add("TXT", rejectif.TxtIsEmpty)
+
+	// The API trims a TXT value before storing it, so a leading or trailing
+	// space is dropped without being reported. Left alone that reads as a
+	// permanently pending change - the record never matches what was asked for,
+	// and every run offers the same correction. Refusing it names the reason
+	// once, before anything is written. Interior whitespace is kept and is
+	// therefore not rejected. Last verified 2026-07-31.
+	a.Add("TXT", rejectif.TxtHasTrailingSpace)
+	a.Add("TXT", rejectTxtLeadingSpace)
+
+	// The platform serves public zones only and turns away an address that
+	// cannot be reached from the internet, which is also what stops a zone from
+	// being used to point a public name at a visitor's own network. Catching it
+	// here names the address before a push starts, instead of failing partway
+	// through with some records already written. Last verified 2026-07-31.
+	a.Add("A", rejectUnroutableIP)
+	a.Add("AAAA", rejectUnroutableIP)
+
+	// The CAA value is stored inside quotes, so whitespace in it would produce
+	// rdata the nameserver refuses. The API turns that away first, with
+	// validation_error - value: CAA value must not contain spaces or quotes.
+	// Last verified 2026-07-31.
+	a.Add("CAA", rejectif.CaaTargetContainsWhitespace)
+
+	// Only the three property tags of RFC 8659 are accepted; anything else is
+	// validation_error - tag: Tag must be issue, issuewild, or iodef.
+	// Last verified 2026-07-31.
+	a.Add("CAA", rejectCaaTag)
+
+	return a.Audit(records)
+}
+
+// thisNetwork and reservedIPv4 are the two refused ranges that the netip
+// predicates below do not already cover. 240.0.0.0/4 takes in the broadcast
+// address with it.
+var (
+	thisNetwork  = netip.MustParsePrefix("0.0.0.0/8")
+	reservedIPv4 = netip.MustParsePrefix("240.0.0.0/4")
+)
+
+// rejectUnroutableIP rejects A and AAAA records whose address the API refuses.
+//
+// The set was read off the API rather than off a list of well-known ranges,
+// because the two do not agree: carrier-grade NAT (100.64.0.0/10),
+// documentation ranges (192.0.2.0/24, 2001:db8::/32) and multicast are all
+// accepted, so rejecting them here would block a record the platform is
+// perfectly willing to store.
+func rejectUnroutableIP(rc *models.RecordConfig) error {
+	ip := rc.GetTargetIP()
+	if !ip.IsValid() {
+		return nil // Not an address at all; a different check reports that.
+	}
+
+	unroutable := ip.IsPrivate() || // RFC 1918 and fc00::/7
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsUnspecified() ||
+		ip.Is4In6() ||
+		thisNetwork.Contains(ip) ||
+		reservedIPv4.Contains(ip)
+
+	if unroutable {
+		return fmt.Errorf("%s is a private or reserved address", ip)
+	}
+
+	return nil
+}
+
+// rejectTxtLeadingSpace rejects TXT records whose value starts with a space.
+// rejectif has a helper for the trailing case but not for this one, because the
+// integration suite leaves leading whitespace untested - it is nonetheless
+// trimmed the same way here.
+func rejectTxtLeadingSpace(rc *models.RecordConfig) error {
+	if strings.HasPrefix(rc.GetTargetTXTJoined(), " ") {
+		return errors.New("txtstring starts with space")
+	}
+	return nil
+}
+
+// rejectCaaTag rejects CAA records whose property tag the API does not accept.
+func rejectCaaTag(rc *models.RecordConfig) error {
+	if !slices.Contains(caaTags, rc.CaaTag) {
+		return fmt.Errorf("caa tag %q is not supported", rc.CaaTag)
+	}
+	return nil
+}

--- a/providers/nexdns/auditrecords_test.go
+++ b/providers/nexdns/auditrecords_test.go
@@ -1,0 +1,128 @@
+package nexdns
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+func TestAuditRecords(t *testing.T) {
+	tests := []struct {
+		name      string
+		record    *models.RecordConfig
+		wantCount int
+	}{
+		{
+			name:      "a TXT record with content is fine",
+			record:    auditTXT(t, "v=spf1 -all"),
+			wantCount: 0,
+		},
+		{
+			name:      "an empty TXT record is rejected",
+			record:    auditTXT(t, ""),
+			wantCount: 1,
+		},
+		{
+			name:      "a CAA record with a known tag is fine",
+			record:    auditCAA(t, 0, "issue", "letsencrypt.org"),
+			wantCount: 0,
+		},
+		{
+			name:      "a CAA record with an unknown tag is rejected",
+			record:    auditCAA(t, 0, "contactemail", "admin@example.com"),
+			wantCount: 1,
+		},
+		{
+			name:      "a CAA value with whitespace is rejected",
+			record:    auditCAA(t, 0, "issue", "letsencrypt.org; accounturi=x"),
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := AuditRecords([]*models.RecordConfig{tt.record})
+			if len(errs) != tt.wantCount {
+				t.Errorf("AuditRecords() returned %d errors, want %d: %v", len(errs), tt.wantCount, errs)
+			}
+		})
+	}
+}
+
+func auditTXT(t *testing.T, target string) *models.RecordConfig {
+	t.Helper()
+
+	rc := &models.RecordConfig{Type: "TXT"}
+	rc.SetLabel("@", testOrigin)
+	if err := rc.SetTargetTXT(target); err != nil {
+		t.Fatalf("SetTargetTXT() error = %v", err)
+	}
+	return rc
+}
+
+// The accepted and refused addresses below were read off the API on
+// 2026-07-31, not derived from a list of well-known ranges - the two disagree
+// on carrier-grade NAT, the documentation ranges and multicast, all of which
+// the platform stores happily.
+func TestRejectUnroutableIP(t *testing.T) {
+	tests := []struct {
+		address string
+		what    string
+		reject  bool
+	}{
+		{"1.1.1.1", "a public address", false},
+		{"172.32.0.1", "just outside RFC 1918", false},
+		{"100.64.0.1", "carrier-grade NAT", false},
+		{"192.0.2.1", "TEST-NET-1", false},
+		{"224.0.0.1", "multicast", false},
+		{"2606:4700::1111", "a public v6 address", false},
+		{"2001:db8::1", "the v6 documentation range", false},
+
+		{"10.0.0.1", "RFC 1918 /8", true},
+		{"172.16.0.1", "RFC 1918 /12", true},
+		{"192.168.0.1", "RFC 1918 /16", true},
+		{"127.0.0.1", "loopback", true},
+		{"169.254.0.1", "link-local", true},
+		{"0.0.0.1", "this-network", true},
+		{"240.0.0.1", "the reserved /4", true},
+		{"255.255.255.255", "broadcast", true},
+		{"fd00::1", "a unique-local v6 address", true},
+		{"fe80::1", "v6 link-local", true},
+		{"::1", "v6 loopback", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.what, func(t *testing.T) {
+			rtype := "A"
+			if strings.Contains(tt.address, ":") {
+				rtype = "AAAA"
+			}
+
+			rc := &models.RecordConfig{Type: rtype}
+			rc.SetLabel("@", testOrigin)
+			if err := rc.SetTarget(tt.address); err != nil {
+				t.Fatalf("SetTarget() error = %v", err)
+			}
+
+			err := rejectUnroutableIP(rc)
+			if tt.reject && err == nil {
+				t.Errorf("%s (%s) was accepted, want rejected", tt.address, tt.what)
+			}
+			if !tt.reject && err != nil {
+				t.Errorf("%s (%s) was rejected: %v", tt.address, tt.what, err)
+			}
+		})
+	}
+}
+
+func auditCAA(t *testing.T, flag uint8, tag, target string) *models.RecordConfig {
+	t.Helper()
+
+	rc := &models.RecordConfig{Type: "CAA"}
+	rc.SetLabel("@", testOrigin)
+	if err := rc.SetTargetCAA(flag, tag, target); err != nil {
+		t.Fatalf("SetTargetCAA() error = %v", err)
+	}
+	return rc
+}

--- a/providers/nexdns/convert.go
+++ b/providers/nexdns/convert.go
@@ -1,0 +1,98 @@
+package nexdns
+
+import (
+	"fmt"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/txtutil"
+)
+
+// apexLabel is how both DNSControl and the API name the zone apex.
+const apexLabel = "@"
+
+// toRecordConfig converts one record of an API response to a RecordConfig.
+// A response carries the assembled rdata in Content ("10 mail.example.com." for
+// an MX), which is what PopulateFromString parses, so no per-type handling is
+// needed on the way in - except for TXT.
+//
+// TXT is asymmetric: the API accepts a value verbatim but returns it in RFC 1035
+// presentation form, quoted and escaped, and chunked into 255-octet strings when
+// it is longer than that. PopulateFromString cannot undo that - it only strips
+// the outer quotes - so a backslash returned as `\\` would be read back as two
+// characters, written again as four, and doubled on every run until the record
+// no longer says what its owner wrote. txtutil.ParseQuoted is the decoder for
+// this form, and it passes an unquoted value through unchanged.
+func toRecordConfig(r apiRecord, origin string) (*models.RecordConfig, error) {
+	rc := &models.RecordConfig{
+		Type:     r.Type,
+		TTL:      uint32(r.TTL),
+		Original: r,
+	}
+	rc.SetLabel(r.Name, origin)
+
+	if r.Type == "TXT" {
+		value, err := txtutil.ParseQuoted(r.Content)
+		if err != nil {
+			return nil, fmt.Errorf("unparsable TXT value %q: %w", r.Content, err)
+		}
+		if err := rc.SetTargetTXT(value); err != nil {
+			return nil, err
+		}
+
+		return rc, nil
+	}
+
+	if err := rc.PopulateFromString(r.Type, r.Content, origin); err != nil {
+		return nil, err
+	}
+
+	return rc, nil
+}
+
+// fromRecordConfig converts a RecordConfig to the body of a create or update.
+// A request is not shaped like a response: Content carries only the primary
+// value, and the numeric and keyword parts of a type travel as their own fields,
+// so the assembled rdata is taken apart again here.
+//
+// Hostname targets are sent as the FQDN that DNSControl holds, trailing dot and
+// all, which is the form the API stores them in.
+func fromRecordConfig(rc *models.RecordConfig) recordRequest {
+	req := recordRequest{
+		Name: rc.GetLabel(),
+		Type: rc.Type,
+		TTL:  int(rc.TTL),
+	}
+
+	switch rc.Type {
+	case "MX":
+		req.Content = rc.GetTargetField()
+		req.Priority = new(int(rc.MxPreference))
+	case "SRV":
+		req.Content = rc.GetTargetField()
+		req.Priority = new(int(rc.SrvPriority))
+		req.Weight = new(int(rc.SrvWeight))
+		req.Port = new(int(rc.SrvPort))
+	case "CAA":
+		req.Content = rc.GetTargetField()
+		req.Flags = new(int(rc.CaaFlag))
+		req.Tag = rc.CaaTag
+	case "DS":
+		req.Content = rc.DsDigest
+		req.KeyTag = new(int(rc.DsKeyTag))
+		req.Algorithm = new(int(rc.DsAlgorithm))
+		req.DigestType = new(int(rc.DsDigestType))
+	case "TLSA":
+		// The certificate association data is the target; the three selectors
+		// are separate fields in the model as well as in the request.
+		req.Content = rc.GetTargetField()
+		req.Usage = new(int(rc.TlsaUsage))
+		req.Selector = new(int(rc.TlsaSelector))
+		req.MatchingType = new(int(rc.TlsaMatchingType))
+	case "TXT":
+		req.Content = rc.GetTargetTXTJoined()
+	default:
+		req.Content = rc.GetTargetField()
+	}
+
+	return req
+}

--- a/providers/nexdns/convert_test.go
+++ b/providers/nexdns/convert_test.go
@@ -1,0 +1,204 @@
+package nexdns
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+const testOrigin = "example.com"
+
+// TestRecordRoundTrip reads a record the way the API returns it, converts it
+// back into a request and checks that nothing was lost. A response carries the
+// assembled rdata while a request carries the primary value plus separate
+// fields, so a mistake in either direction shows up as a change DNSControl
+// would keep proposing for a record that already matches.
+func TestRecordRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		stored  apiRecord
+		content string
+		verify  func(t *testing.T, req recordRequest)
+	}{
+		{
+			name:    "A",
+			stored:  apiRecord{ID: "r1", Name: "www", Type: "A", Content: "203.0.113.10", TTL: 300},
+			content: "203.0.113.10",
+		},
+		{
+			name:    "CNAME keeps its trailing dot",
+			stored:  apiRecord{ID: "r2", Name: "alias", Type: "CNAME", Content: "www.example.net.", TTL: 300},
+			content: "www.example.net.",
+		},
+		{
+			name:    "MX splits off the preference",
+			stored:  apiRecord{ID: "r3", Name: "@", Type: "MX", Content: "10 mail.example.net.", TTL: 300},
+			content: "mail.example.net.",
+			verify: func(t *testing.T, req recordRequest) {
+				if req.Priority == nil || *req.Priority != 10 {
+					t.Errorf("priority = %v, want 10", req.Priority)
+				}
+			},
+		},
+		{
+			name:    "null MX keeps its bare dot",
+			stored:  apiRecord{ID: "r4", Name: "@", Type: "MX", Content: "0 .", TTL: 300},
+			content: ".",
+			verify: func(t *testing.T, req recordRequest) {
+				if req.Priority == nil || *req.Priority != 0 {
+					t.Errorf("priority = %v, want 0", req.Priority)
+				}
+			},
+		},
+		{
+			name:    "SRV splits off priority, weight and port",
+			stored:  apiRecord{ID: "r5", Name: "_sip._tcp", Type: "SRV", Content: "10 60 5060 sip.example.net.", TTL: 300},
+			content: "sip.example.net.",
+			verify: func(t *testing.T, req recordRequest) {
+				if req.Priority == nil || req.Weight == nil || req.Port == nil {
+					t.Fatalf("srv fields = %v %v %v, want all three", req.Priority, req.Weight, req.Port)
+				}
+				if *req.Priority != 10 || *req.Weight != 60 || *req.Port != 5060 {
+					t.Errorf("srv fields = %d %d %d, want 10 60 5060", *req.Priority, *req.Weight, *req.Port)
+				}
+			},
+		},
+		{
+			name:    "CAA splits off the flags and the tag",
+			stored:  apiRecord{ID: "r6", Name: "@", Type: "CAA", Content: `0 issue "letsencrypt.org"`, TTL: 300},
+			content: "letsencrypt.org",
+			verify: func(t *testing.T, req recordRequest) {
+				if req.Tag != "issue" {
+					t.Errorf("tag = %q, want issue", req.Tag)
+				}
+				if req.Flags == nil || *req.Flags != 0 {
+					t.Errorf("flags = %v, want 0", req.Flags)
+				}
+			},
+		},
+		{
+			name:    "DS sends the bare digest",
+			stored:  apiRecord{ID: "r7", Name: "child", Type: "DS", Content: "12345 13 2 2bb183af5f22588179a53b0a98631fad1a292118bd8e9ba3d3a1e01f2e1bd9c1", TTL: 300},
+			content: "2bb183af5f22588179a53b0a98631fad1a292118bd8e9ba3d3a1e01f2e1bd9c1",
+			verify: func(t *testing.T, req recordRequest) {
+				if req.KeyTag == nil || *req.KeyTag != 12345 {
+					t.Errorf("keytag = %v, want 12345", req.KeyTag)
+				}
+				if req.Algorithm == nil || *req.Algorithm != 13 {
+					t.Errorf("algorithm = %v, want 13", req.Algorithm)
+				}
+				if req.DigestType == nil || *req.DigestType != 2 {
+					t.Errorf("digest_type = %v, want 2", req.DigestType)
+				}
+			},
+		},
+		{
+			name:    "TLSA sends the bare certificate data",
+			stored:  apiRecord{ID: "r8", Name: "_443._tcp", Type: "TLSA", Content: "3 1 1 abcdef0123456789", TTL: 300},
+			content: "abcdef0123456789",
+			verify: func(t *testing.T, req recordRequest) {
+				if req.Usage == nil || req.Selector == nil || req.MatchingType == nil {
+					t.Fatalf("tlsa fields = %v %v %v, want all three", req.Usage, req.Selector, req.MatchingType)
+				}
+				if *req.Usage != 3 || *req.Selector != 1 || *req.MatchingType != 1 {
+					t.Errorf("tlsa fields = %d %d %d, want 3 1 1", *req.Usage, *req.Selector, *req.MatchingType)
+				}
+			},
+		},
+		{
+			name:    "TXT is unquoted",
+			stored:  apiRecord{ID: "r9", Name: "@", Type: "TXT", Content: `"v=spf1 -all"`, TTL: 300},
+			content: "v=spf1 -all",
+		},
+		// The API returns TXT in presentation form but accepts it verbatim, so
+		// a value whose escapes are not decoded on the way in is re-escaped on
+		// the way out. Each run then doubles them, and the record drifts away
+		// from what its owner wrote without anyone editing it.
+		{
+			name:    "TXT unescapes a backslash",
+			stored:  apiRecord{ID: "r10", Name: "bs", Type: "TXT", Content: `"1back\\slash"`, TTL: 300},
+			content: `1back\slash`,
+		},
+		{
+			name:    "TXT unescapes an interior quote",
+			stored:  apiRecord{ID: "r11", Name: "dq", Type: "TXT", Content: `"in\"side"`, TTL: 300},
+			content: `in"side`,
+		},
+		{
+			name:    "TXT joins the chunks of a value over 255 octets",
+			stored:  apiRecord{ID: "r12", Name: "long", Type: "TXT", Content: `"first" "second"`, TTL: 300},
+			content: "firstsecond",
+		},
+		{
+			name:    "TXT accepts a value that carries no quotes at all",
+			stored:  apiRecord{ID: "r13", Name: "bare", Type: "TXT", Content: "plain", TTL: 300},
+			content: "plain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc, err := toRecordConfig(tt.stored, testOrigin)
+			if err != nil {
+				t.Fatalf("toRecordConfig() error = %v", err)
+			}
+			if rc.TTL != uint32(tt.stored.TTL) {
+				t.Errorf("TTL = %d, want %d", rc.TTL, tt.stored.TTL)
+			}
+
+			req := fromRecordConfig(rc)
+			if req.Name != tt.stored.Name {
+				t.Errorf("name = %q, want %q", req.Name, tt.stored.Name)
+			}
+			if req.Type != tt.stored.Type {
+				t.Errorf("type = %q, want %q", req.Type, tt.stored.Type)
+			}
+			if req.Content != tt.content {
+				t.Errorf("content = %q, want %q", req.Content, tt.content)
+			}
+			if tt.verify != nil {
+				tt.verify(t, req)
+			}
+		})
+	}
+}
+
+func TestFilterApexNS(t *testing.T) {
+	nameservers, err := models.ToNameservers([]string{"ns1.example.net", "ns2.example.net"})
+	if err != nil {
+		t.Fatalf("ToNameservers() error = %v", err)
+	}
+
+	dc := &models.DomainConfig{
+		Name:        testOrigin,
+		Nameservers: nameservers,
+		Records: models.Records{
+			makeRecord(t, "NS", "@", "ns1.example.net."),
+			makeRecord(t, "NS", "@", "ns9.example.org."),
+			makeRecord(t, "NS", "sub", "ns1.example.org."),
+			makeRecord(t, "A", "www", "203.0.113.10"),
+		},
+	}
+
+	filterApexNS(dc)
+
+	if len(dc.Records) != 2 {
+		t.Fatalf("filterApexNS() left %d records, want 2: %v", len(dc.Records), dc.Records)
+	}
+	for _, rec := range dc.Records {
+		if rec.Type == "NS" && rec.GetLabel() == apexLabel {
+			t.Errorf("an apex NS record survived: %v", rec)
+		}
+	}
+}
+
+func makeRecord(t *testing.T, rtype, label, target string) *models.RecordConfig {
+	t.Helper()
+
+	rc := &models.RecordConfig{Type: rtype, TTL: 300}
+	rc.SetLabel(label, testOrigin)
+	if err := rc.PopulateFromString(rtype, target, testOrigin); err != nil {
+		t.Fatalf("PopulateFromString() error = %v", err)
+	}
+	return rc
+}

--- a/providers/nexdns/listzones.go
+++ b/providers/nexdns/listzones.go
@@ -1,0 +1,41 @@
+package nexdns
+
+import (
+	"fmt"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/printer"
+)
+
+// ListZones returns every zone the API key can see.
+func (n *nexdnsProvider) ListZones() ([]string, error) {
+	zones, err := n.client.listZones()
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(zones))
+	for _, z := range zones {
+		names = append(names, z.Name)
+	}
+
+	return names, nil
+}
+
+// EnsureZoneExists creates the zone if the account does not have it yet.
+func (n *nexdnsProvider) EnsureZoneExists(dc *models.DomainConfig) error {
+	_, err := n.getZone(dc.Name)
+	if err == nil {
+		return nil
+	}
+	if !isNotFound(err) {
+		return err
+	}
+
+	if err := n.client.createZone(dc.Name); err != nil {
+		return fmt.Errorf("NEXDNS: creating zone %s: %w", dc.Name, err)
+	}
+
+	printer.Warnf("NEXDNS: Added zone %s\n", dc.Name)
+	return nil
+}

--- a/providers/nexdns/nexdnsProvider.go
+++ b/providers/nexdns/nexdnsProvider.go
@@ -1,0 +1,144 @@
+package nexdns
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
+)
+
+/*
+NexDNS DNS provider:
+
+Info required in `creds.json`:
+   - api_token
+
+Optional in `creds.json`:
+   - api_url    Base URL of the API. Defaults to https://api.nexdns.tech/v1.
+
+The API addresses one record value at a time rather than a whole rrset, so this
+provider uses diff2.ByRecord(). A record's id is derived from its name, type and
+content, which means an id stops resolving as soon as the record it names is
+changed. Each correction therefore uses only the id it read from the zone it is
+about to modify.
+
+The SOA record and the NS records at the zone apex are maintained by the platform
+and are rejected by the API, so they are left out of both the zone contents and
+the desired state. See records.go.
+*/
+
+var features = providers.DocumentationNotes{
+	// The default for unlisted capabilities is 'Cannot'.
+	// See providers/capabilities.go for the entire list of capabilities.
+	providers.CanAutoDNSSEC:          providers.Unimplemented("DNSSEC is switched on per zone outside of DNSControl"),
+	providers.CanConcur:              providers.Unimplemented(),
+	providers.CanGetZones:            providers.Can(),
+	providers.CanUseAlias:            providers.Can(),
+	providers.CanUseCAA:              providers.Can(),
+	providers.CanUseDHCID:            providers.Cannot(),
+	providers.CanUseDNAME:            providers.Can(),
+	providers.CanUseDNSKEY:           providers.Cannot(),
+	providers.CanUseDS:               providers.Cannot("DS at the zone apex belongs in the parent zone"),
+	providers.CanUseDSForChildren:    providers.Can(),
+	providers.CanUseHTTPS:            providers.Cannot(),
+	providers.CanUseLOC:              providers.Cannot(),
+	providers.CanUseNAPTR:            providers.Cannot(),
+	providers.CanUseOPENPGPKEY:       providers.Cannot(),
+	providers.CanUsePTR:              providers.Can(),
+	providers.CanUseRP:               providers.Cannot(),
+	providers.CanUseSMIMEA:           providers.Cannot(),
+	providers.CanUseSOA:              providers.Cannot("The SOA record is maintained by the platform"),
+	providers.CanUseSRV:              providers.Can(),
+	providers.CanUseSSHFP:            providers.Cannot(),
+	providers.CanUseSVCB:             providers.Cannot(),
+	providers.CanUseTLSA:             providers.Can(),
+	providers.DocCreateDomains:       providers.Can(),
+	providers.DocDualHost:            providers.Cannot("The NS records at the zone apex cannot be changed through the API"),
+	providers.DocOfficiallySupported: providers.Cannot(),
+}
+
+type nexdnsProvider struct {
+	client *apiClient
+	zones  map[string]*apiZone
+}
+
+func init() {
+	const providerName = "NEXDNS"
+	const providerMaintainer = "@nexdns"
+	fns := providers.DspFuncs{
+		Initializer:   newNexdns,
+		RecordAuditor: AuditRecords,
+	}
+	providers.RegisterDomainServiceProviderType(providerName, fns, features)
+	providers.RegisterMaintainer(providerName, providerMaintainer)
+	providers.RegisterDefaultTTL(providerName, defaultTTL)
+
+	providers.RegisterCredsMetadata(providerName, providers.CredsMetadata{
+		DisplayName: "NexDNS",
+		Kind:        providers.KindDNS,
+		DocsURL:     "https://docs.dnscontrol.org/provider/nexdns",
+		PortalURL:   "https://nexdns.tech/settings/api-keys",
+		Notes:       "The API is available on a plan that includes API access. See https://nexdns.tech/pricing.",
+		Fields: []providers.CredsField{
+			{
+				Key:      "api_token",
+				Label:    "API token",
+				Help:     "An API key carrying the zones.read, zones.write, records.read and records.write scopes.",
+				Secret:   true,
+				Required: true,
+			},
+			{
+				Key:     "api_url",
+				Label:   "API base URL",
+				Help:    "Only needed to point the provider at a different endpoint.",
+				Default: defaultAPIURL,
+			},
+		},
+	})
+}
+
+// newNexdns builds a provider from the entry in creds.json.
+func newNexdns(settings map[string]string, _ json.RawMessage) (providers.DNSServiceProvider, error) {
+	token := settings["api_token"]
+	if token == "" {
+		return nil, errors.New("missing NEXDNS api_token")
+	}
+
+	apiURL := settings["api_url"]
+	if apiURL == "" {
+		apiURL = defaultAPIURL
+	}
+
+	return &nexdnsProvider{
+		client: newAPIClient(apiURL, token),
+		zones:  map[string]*apiZone{},
+	}, nil
+}
+
+// GetNameservers returns the nameservers the zone is served from.
+func (n *nexdnsProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
+	zone, err := n.getZone(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	return models.ToNameservers(zone.Nameservers)
+}
+
+// getZone looks a zone up by name and remembers it. Every entry point needs the
+// zone's id before it can address anything inside the zone, and the lookup costs
+// two requests, so it is worth doing once per run.
+func (n *nexdnsProvider) getZone(domain string) (*apiZone, error) {
+	if zone, ok := n.zones[domain]; ok {
+		return zone, nil
+	}
+
+	zone, err := n.client.getZone(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	n.zones[domain] = zone
+	return zone, nil
+}

--- a/providers/nexdns/nexdns_test.go
+++ b/providers/nexdns/nexdns_test.go
@@ -2,37 +2,12 @@ package nexdns
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/DNSControl/dnscontrol/v4/models"
 )
-
-func TestNewNexdns(t *testing.T) {
-	if _, err := newNexdns(map[string]string{}, json.RawMessage{}); err == nil {
-		t.Error("expected an error when api_token is missing")
-	}
-
-	p, err := newNexdns(map[string]string{"api_token": "nxd_notarealtoken"}, json.RawMessage{})
-	if err != nil {
-		t.Fatalf("newNexdns() error = %v", err)
-	}
-	if got := p.(*nexdnsProvider).client.baseURL; got != defaultAPIURL {
-		t.Errorf("baseURL = %q, want %q", got, defaultAPIURL)
-	}
-
-	p, err = newNexdns(map[string]string{"api_token": "nxd_notarealtoken", "api_url": "https://api.example.com/v1"}, json.RawMessage{})
-	if err != nil {
-		t.Fatalf("newNexdns() error = %v", err)
-	}
-	if got := p.(*nexdnsProvider).client.baseURL; got != "https://api.example.com/v1" {
-		t.Errorf("baseURL = %q, want the configured one", got)
-	}
-}
 
 func TestGetZoneRecords(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -76,65 +51,6 @@ func TestGetZoneRecords(t *testing.T) {
 	}
 }
 
-func TestGetNameservers(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/zones":
-			_, _ = w.Write([]byte(`{"status":"success","data":[{"id":"z1","name":"example.com"}]}`))
-		case "/zones/z1":
-			_, _ = w.Write([]byte(`{"status":"success","data":{"id":"z1","name":"example.com","nameservers":["ns1.example.net","ns2.example.net"]}}`))
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	nses, err := testProvider(server.URL).GetNameservers("example.com")
-	if err != nil {
-		t.Fatalf("GetNameservers() error = %v", err)
-	}
-	if len(nses) != 2 || nses[0].Name != "ns1.example.net" {
-		t.Errorf("GetNameservers() = %v, want the two nameservers of the zone", nses)
-	}
-}
-
-func TestListZonesPagesThroughTheAPI(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/zones" {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		// A full page must be followed by a request for the next one.
-		if r.URL.Query().Get("page") == "1" {
-			var sb strings.Builder
-			sb.WriteString(`{"status":"success","data":[`)
-			for i := range zonesPerPage {
-				if i > 0 {
-					sb.WriteString(",")
-				}
-				sb.WriteString(`{"id":"z1","name":"example.com"}`)
-			}
-			sb.WriteString(`]}`)
-			_, _ = w.Write([]byte(sb.String()))
-			return
-		}
-		_, _ = w.Write([]byte(`{"status":"success","data":[{"id":"z2","name":"example.net"}]}`))
-	}))
-	defer server.Close()
-
-	zones, err := testProvider(server.URL).ListZones()
-	if err != nil {
-		t.Fatalf("ListZones() error = %v", err)
-	}
-	if len(zones) != zonesPerPage+1 {
-		t.Fatalf("ListZones() returned %d zones, want %d", len(zones), zonesPerPage+1)
-	}
-	if zones[len(zones)-1] != "example.net" {
-		t.Errorf("last zone = %q, want the one from the second page", zones[len(zones)-1])
-	}
-}
-
 func TestEnsureZoneExists(t *testing.T) {
 	var created []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -170,134 +86,6 @@ func TestEnsureZoneExists(t *testing.T) {
 	}
 	if len(created) != 1 || created[0] != "new.example.com" {
 		t.Errorf("created = %v, want [new.example.com]", created)
-	}
-}
-
-// rateLimitedServer answers 429 for the first refusals requests, advertising
-// retryAfter each time, then succeeds.
-func rateLimitedServer(t *testing.T, refusals int, retryAfter string) (*apiClient, *[]time.Duration, *int) {
-	t.Helper()
-
-	var calls int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		if calls <= refusals {
-			w.Header().Set("Retry-After", retryAfter)
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(`{"status":"error","error":{"code":"rate_limit_exceeded","message":"Too many requests."}}`))
-			return
-		}
-		_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
-	}))
-	t.Cleanup(server.Close)
-
-	client := newAPIClient(server.URL, "nxd_notarealtoken")
-
-	slept := []time.Duration{}
-	client.sleep = func(d time.Duration) { slept = append(slept, d) }
-
-	return client, &slept, &calls
-}
-
-func TestDoRequestWaitsOutARateLimit(t *testing.T) {
-	client, _, calls := rateLimitedServer(t, 1, "0")
-
-	if _, err := client.listRecords("z1"); err != nil {
-		t.Fatalf("listRecords() error = %v", err)
-	}
-	if *calls != 2 {
-		t.Errorf("the request was attempted %d times, want 2", *calls)
-	}
-}
-
-// A sliding-window limiter can answer "retry after 1 second" while releasing
-// nothing until the window rolls over, so a client that takes the header
-// literally retries into the same refusal and gives up with the work half done.
-// The header is a lower bound; the wait has to grow on its own.
-func TestRateLimitBackoffGrowsBeyondTheAdvertisedRetryAfter(t *testing.T) {
-	client, slept, calls := rateLimitedServer(t, 4, "1")
-
-	if _, err := client.listRecords("z1"); err != nil {
-		t.Fatalf("listRecords() error = %v", err)
-	}
-	if *calls != 5 {
-		t.Errorf("the request was attempted %d times, want 5", *calls)
-	}
-
-	want := []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second}
-	if len(*slept) != len(want) {
-		t.Fatalf("waited %v, want %v", *slept, want)
-	}
-	for i, d := range want {
-		if (*slept)[i] != d {
-			t.Errorf("wait %d was %v, want %v", i+1, (*slept)[i], d)
-		}
-	}
-}
-
-// A longer Retry-After is still honoured: backing off must not shorten a wait
-// the server asked for.
-func TestRateLimitHonoursALongerRetryAfter(t *testing.T) {
-	client, slept, _ := rateLimitedServer(t, 1, "45")
-
-	if _, err := client.listRecords("z1"); err != nil {
-		t.Fatalf("listRecords() error = %v", err)
-	}
-	if len(*slept) != 1 || (*slept)[0] != 45*time.Second {
-		t.Errorf("waited %v, want [45s]", *slept)
-	}
-}
-
-// Retrying cannot go on forever: once the budget is spent the caller gets the
-// API's own error rather than a hang.
-func TestRateLimitGivesUpOnceTheWaitBudgetIsSpent(t *testing.T) {
-	client, slept, _ := rateLimitedServer(t, 1000, "1")
-
-	_, err := client.listRecords("z1")
-	if err == nil {
-		t.Fatal("listRecords() succeeded, want a rate-limit error")
-	}
-
-	var apiErr *apiError
-	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusTooManyRequests {
-		t.Fatalf("listRecords() error = %v, want an HTTP 429 apiError", err)
-	}
-
-	var total time.Duration
-	for _, d := range *slept {
-		total += d
-	}
-	if total > maxRateLimitWait {
-		t.Errorf("waited %v in total, which exceeds the %v budget", total, maxRateLimitWait)
-	}
-}
-
-func TestParseAPIError(t *testing.T) {
-	body := []byte(`{"status":"error","error":{"code":"validation_error","message":"Validation failed.","details":{"content":["Enter a valid IPv4 address."]}}}`)
-
-	err := parseAPIError(http.StatusBadRequest, body)
-	if err == nil {
-		t.Fatal("parseAPIError() returned no error")
-	}
-	if !strings.Contains(err.Error(), "Enter a valid IPv4 address.") {
-		t.Errorf("the field detail is missing from %q", err.Error())
-	}
-
-	// A body that is not the error envelope must still produce an error.
-	if err := parseAPIError(http.StatusInternalServerError, []byte("boom")); err == nil {
-		t.Error("parseAPIError() returned no error for an unrecognized body")
-	}
-}
-
-func TestIsNotFound(t *testing.T) {
-	if !isNotFound(&apiError{StatusCode: http.StatusNotFound}) {
-		t.Error("isNotFound() = false for a 404")
-	}
-	if isNotFound(&apiError{StatusCode: http.StatusInternalServerError}) {
-		t.Error("isNotFound() = true for a 500")
-	}
-	if isNotFound(errors.New("not an API error")) {
-		t.Error("isNotFound() = true for an unrelated error")
 	}
 }
 

--- a/providers/nexdns/nexdns_test.go
+++ b/providers/nexdns/nexdns_test.go
@@ -1,0 +1,309 @@
+package nexdns
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+func TestNewNexdns(t *testing.T) {
+	if _, err := newNexdns(map[string]string{}, json.RawMessage{}); err == nil {
+		t.Error("expected an error when api_token is missing")
+	}
+
+	p, err := newNexdns(map[string]string{"api_token": "nxd_notarealtoken"}, json.RawMessage{})
+	if err != nil {
+		t.Fatalf("newNexdns() error = %v", err)
+	}
+	if got := p.(*nexdnsProvider).client.baseURL; got != defaultAPIURL {
+		t.Errorf("baseURL = %q, want %q", got, defaultAPIURL)
+	}
+
+	p, err = newNexdns(map[string]string{"api_token": "nxd_notarealtoken", "api_url": "https://api.example.com/v1"}, json.RawMessage{})
+	if err != nil {
+		t.Fatalf("newNexdns() error = %v", err)
+	}
+	if got := p.(*nexdnsProvider).client.baseURL; got != "https://api.example.com/v1" {
+		t.Errorf("baseURL = %q, want the configured one", got)
+	}
+}
+
+func TestGetZoneRecords(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/zones":
+			_, _ = w.Write([]byte(`{"status":"success","data":[{"id":"z1","name":"example.com","unicode_name":"example.com"}]}`))
+		case "/zones/z1":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"id":"z1","name":"example.com","nameservers":["ns1.example.net","ns2.example.net"]}}`))
+		case "/zones/z1/records":
+			_, _ = w.Write([]byte(`{"status":"success","data":[
+				{"id":"r1","name":"@","type":"SOA","content":"ns1.example.net. hostmaster.example.net. 1 2 3 4 5","ttl":3600},
+				{"id":"r2","name":"@","type":"NS","content":"ns1.example.net.","ttl":3600},
+				{"id":"r3","name":"sub","type":"NS","content":"ns1.example.org.","ttl":3600},
+				{"id":"r4","name":"www","type":"A","content":"203.0.113.10","ttl":300}
+			]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	p := testProvider(server.URL)
+	recs, err := p.GetZoneRecords(&models.DomainConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("GetZoneRecords() error = %v", err)
+	}
+
+	// The SOA and the apex NS are maintained by the platform and must not be
+	// reported; the NS record of a delegated child must be.
+	if len(recs) != 2 {
+		t.Fatalf("GetZoneRecords() returned %d records, want 2: %v", len(recs), recs)
+	}
+	if recs[0].Type != "NS" || recs[0].GetLabel() != "sub" {
+		t.Errorf("first record = %s %s, want NS sub", recs[0].Type, recs[0].GetLabel())
+	}
+	if recs[1].Type != "A" || recs[1].GetTargetField() != "203.0.113.10" {
+		t.Errorf("second record = %s %s, want A 203.0.113.10", recs[1].Type, recs[1].GetTargetField())
+	}
+	if recs[1].Original.(apiRecord).ID != "r4" {
+		t.Errorf("record id was not carried over: %v", recs[1].Original)
+	}
+}
+
+func TestGetNameservers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/zones":
+			_, _ = w.Write([]byte(`{"status":"success","data":[{"id":"z1","name":"example.com"}]}`))
+		case "/zones/z1":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"id":"z1","name":"example.com","nameservers":["ns1.example.net","ns2.example.net"]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	nses, err := testProvider(server.URL).GetNameservers("example.com")
+	if err != nil {
+		t.Fatalf("GetNameservers() error = %v", err)
+	}
+	if len(nses) != 2 || nses[0].Name != "ns1.example.net" {
+		t.Errorf("GetNameservers() = %v, want the two nameservers of the zone", nses)
+	}
+}
+
+func TestListZonesPagesThroughTheAPI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// A full page must be followed by a request for the next one.
+		if r.URL.Query().Get("page") == "1" {
+			var sb strings.Builder
+			sb.WriteString(`{"status":"success","data":[`)
+			for i := range zonesPerPage {
+				if i > 0 {
+					sb.WriteString(",")
+				}
+				sb.WriteString(`{"id":"z1","name":"example.com"}`)
+			}
+			sb.WriteString(`]}`)
+			_, _ = w.Write([]byte(sb.String()))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":[{"id":"z2","name":"example.net"}]}`))
+	}))
+	defer server.Close()
+
+	zones, err := testProvider(server.URL).ListZones()
+	if err != nil {
+		t.Fatalf("ListZones() error = %v", err)
+	}
+	if len(zones) != zonesPerPage+1 {
+		t.Fatalf("ListZones() returned %d zones, want %d", len(zones), zonesPerPage+1)
+	}
+	if zones[len(zones)-1] != "example.net" {
+		t.Errorf("last zone = %q, want the one from the second page", zones[len(zones)-1])
+	}
+}
+
+func TestEnsureZoneExists(t *testing.T) {
+	var created []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/zones":
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			created = append(created, body["name"])
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"status":"success","data":{"id":"z9","name":"new.example.com"}}`))
+		case r.URL.Path == "/zones":
+			// The search matches on a substring, so a lookup of "ample.com"
+			// would see this zone too.
+			_, _ = w.Write([]byte(`{"status":"success","data":[{"id":"z1","name":"example.com"}]}`))
+		case r.URL.Path == "/zones/z1":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"id":"z1","name":"example.com"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	p := testProvider(server.URL)
+	if err := p.EnsureZoneExists(&models.DomainConfig{Name: "example.com"}); err != nil {
+		t.Fatalf("EnsureZoneExists() error = %v", err)
+	}
+	if len(created) != 0 {
+		t.Errorf("an existing zone was created again: %v", created)
+	}
+
+	if err := p.EnsureZoneExists(&models.DomainConfig{Name: "new.example.com"}); err != nil {
+		t.Fatalf("EnsureZoneExists() error = %v", err)
+	}
+	if len(created) != 1 || created[0] != "new.example.com" {
+		t.Errorf("created = %v, want [new.example.com]", created)
+	}
+}
+
+// rateLimitedServer answers 429 for the first refusals requests, advertising
+// retryAfter each time, then succeeds.
+func rateLimitedServer(t *testing.T, refusals int, retryAfter string) (*apiClient, *[]time.Duration, *int) {
+	t.Helper()
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls <= refusals {
+			w.Header().Set("Retry-After", retryAfter)
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"status":"error","error":{"code":"rate_limit_exceeded","message":"Too many requests."}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newAPIClient(server.URL, "nxd_notarealtoken")
+
+	slept := []time.Duration{}
+	client.sleep = func(d time.Duration) { slept = append(slept, d) }
+
+	return client, &slept, &calls
+}
+
+func TestDoRequestWaitsOutARateLimit(t *testing.T) {
+	client, _, calls := rateLimitedServer(t, 1, "0")
+
+	if _, err := client.listRecords("z1"); err != nil {
+		t.Fatalf("listRecords() error = %v", err)
+	}
+	if *calls != 2 {
+		t.Errorf("the request was attempted %d times, want 2", *calls)
+	}
+}
+
+// A sliding-window limiter can answer "retry after 1 second" while releasing
+// nothing until the window rolls over, so a client that takes the header
+// literally retries into the same refusal and gives up with the work half done.
+// The header is a lower bound; the wait has to grow on its own.
+func TestRateLimitBackoffGrowsBeyondTheAdvertisedRetryAfter(t *testing.T) {
+	client, slept, calls := rateLimitedServer(t, 4, "1")
+
+	if _, err := client.listRecords("z1"); err != nil {
+		t.Fatalf("listRecords() error = %v", err)
+	}
+	if *calls != 5 {
+		t.Errorf("the request was attempted %d times, want 5", *calls)
+	}
+
+	want := []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second}
+	if len(*slept) != len(want) {
+		t.Fatalf("waited %v, want %v", *slept, want)
+	}
+	for i, d := range want {
+		if (*slept)[i] != d {
+			t.Errorf("wait %d was %v, want %v", i+1, (*slept)[i], d)
+		}
+	}
+}
+
+// A longer Retry-After is still honoured: backing off must not shorten a wait
+// the server asked for.
+func TestRateLimitHonoursALongerRetryAfter(t *testing.T) {
+	client, slept, _ := rateLimitedServer(t, 1, "45")
+
+	if _, err := client.listRecords("z1"); err != nil {
+		t.Fatalf("listRecords() error = %v", err)
+	}
+	if len(*slept) != 1 || (*slept)[0] != 45*time.Second {
+		t.Errorf("waited %v, want [45s]", *slept)
+	}
+}
+
+// Retrying cannot go on forever: once the budget is spent the caller gets the
+// API's own error rather than a hang.
+func TestRateLimitGivesUpOnceTheWaitBudgetIsSpent(t *testing.T) {
+	client, slept, _ := rateLimitedServer(t, 1000, "1")
+
+	_, err := client.listRecords("z1")
+	if err == nil {
+		t.Fatal("listRecords() succeeded, want a rate-limit error")
+	}
+
+	var apiErr *apiError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("listRecords() error = %v, want an HTTP 429 apiError", err)
+	}
+
+	var total time.Duration
+	for _, d := range *slept {
+		total += d
+	}
+	if total > maxRateLimitWait {
+		t.Errorf("waited %v in total, which exceeds the %v budget", total, maxRateLimitWait)
+	}
+}
+
+func TestParseAPIError(t *testing.T) {
+	body := []byte(`{"status":"error","error":{"code":"validation_error","message":"Validation failed.","details":{"content":["Enter a valid IPv4 address."]}}}`)
+
+	err := parseAPIError(http.StatusBadRequest, body)
+	if err == nil {
+		t.Fatal("parseAPIError() returned no error")
+	}
+	if !strings.Contains(err.Error(), "Enter a valid IPv4 address.") {
+		t.Errorf("the field detail is missing from %q", err.Error())
+	}
+
+	// A body that is not the error envelope must still produce an error.
+	if err := parseAPIError(http.StatusInternalServerError, []byte("boom")); err == nil {
+		t.Error("parseAPIError() returned no error for an unrecognized body")
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	if !isNotFound(&apiError{StatusCode: http.StatusNotFound}) {
+		t.Error("isNotFound() = false for a 404")
+	}
+	if isNotFound(&apiError{StatusCode: http.StatusInternalServerError}) {
+		t.Error("isNotFound() = true for a 500")
+	}
+	if isNotFound(errors.New("not an API error")) {
+		t.Error("isNotFound() = true for an unrelated error")
+	}
+}
+
+func testProvider(baseURL string) *nexdnsProvider {
+	return &nexdnsProvider{
+		client: newAPIClient(baseURL, "nxd_notarealtoken"),
+		zones:  map[string]*apiZone{},
+	}
+}

--- a/providers/nexdns/records.go
+++ b/providers/nexdns/records.go
@@ -1,0 +1,129 @@
+package nexdns
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/diff2"
+	"github.com/DNSControl/dnscontrol/v4/pkg/printer"
+)
+
+// GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
+//
+// The SOA record and the NS records at the zone apex are left out: both are
+// maintained by the platform and rejected by the API, so reporting them would
+// make every run plan a change it cannot apply.
+func (n *nexdnsProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records, error) {
+	zone, err := n.getZone(dc.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	nativeRecs, err := n.client.listRecords(zone.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	recs := make(models.Records, 0, len(nativeRecs))
+	for _, nativeRec := range nativeRecs {
+		if nativeRec.Type == "SOA" {
+			continue
+		}
+		if nativeRec.Type == "NS" && nativeRec.Name == apexLabel {
+			continue
+		}
+
+		rc, err := toRecordConfig(nativeRec, dc.Name)
+		if err != nil {
+			return nil, fmt.Errorf("NEXDNS: %s %s: %w", nativeRec.Type, nativeRec.Name, err)
+		}
+		recs = append(recs, rc)
+	}
+
+	return recs, nil
+}
+
+// GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
+func (n *nexdnsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, int, error) {
+	zone, err := n.getZone(dc.Name)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	filterApexNS(dc)
+
+	instructions, actualChangeCount, err := diff2.ByRecord(existing, dc, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var corrections []*models.Correction
+	for _, inst := range instructions {
+		switch inst.Type {
+		case diff2.REPORT:
+			corrections = append(corrections, &models.Correction{
+				Msg: inst.MsgsJoined,
+			})
+
+		case diff2.CREATE:
+			newRec := inst.New[0]
+			corrections = append(corrections, &models.Correction{
+				Msg: inst.Msgs[0],
+				F: func() error {
+					return n.client.createRecord(zone.ID, fromRecordConfig(newRec))
+				},
+			})
+
+		case diff2.CHANGE:
+			oldID := inst.Old[0].Original.(apiRecord).ID
+			newRec := inst.New[0]
+			corrections = append(corrections, &models.Correction{
+				Msg: inst.Msgs[0],
+				F: func() error {
+					return n.client.updateRecord(zone.ID, oldID, fromRecordConfig(newRec))
+				},
+			})
+
+		case diff2.DELETE:
+			oldID := inst.Old[0].Original.(apiRecord).ID
+			corrections = append(corrections, &models.Correction{
+				Msg: inst.Msgs[0],
+				F: func() error {
+					return n.client.deleteRecord(zone.ID, oldID)
+				},
+			})
+
+		default:
+			panic(fmt.Sprintf("unhandled inst.Type %s", inst.Type))
+		}
+	}
+
+	return corrections, actualChangeCount, nil
+}
+
+// filterApexNS removes the NS records at the zone apex from dc.Records.
+// The apex NS set is the delegation the platform serves and the API rejects a
+// write to it, so DNSControl cannot manage it. A record that repeats one of the
+// zone's declared nameservers is dropped silently; any other apex NS record is
+// dropped with a warning, because the user asked for something that will not
+// happen.
+func filterApexNS(dc *models.DomainConfig) {
+	declared := make(map[string]bool, len(dc.Nameservers))
+	for _, ns := range dc.Nameservers {
+		declared[strings.TrimSuffix(ns.Name, ".")] = true
+	}
+
+	kept := make([]*models.RecordConfig, 0, len(dc.Records))
+	for _, rec := range dc.Records {
+		if rec.Type == "NS" && rec.GetLabel() == apexLabel {
+			target := strings.TrimSuffix(rec.GetTargetField(), ".")
+			if !declared[target] {
+				printer.Warnf("NEXDNS does not support changing the NS records at the zone apex. %s will not be added.\n", rec.GetTargetField())
+			}
+			continue
+		}
+		kept = append(kept, rec)
+	}
+	dc.Records = kept
+}


### PR DESCRIPTION
- [x] Invite accepted
- [x] Email to Faisal received
- [x] Remaining PR notes resolved

Adds a DNS provider for NexDNS. I run the service and will maintain the provider.

The API addresses one record value at a time, so the provider uses diff2.ByRecord(). A record's id is derived from its name, type and content, so an id stops resolving as soon as the record it names changes; each correction therefore uses only the id it read from the zone it is about to modify.

Supported: A, AAAA, ALIAS, CAA, CNAME, DNAME, DS, MX, NS, PTR, SRV, TLSA, TXT. The SOA record and the apex NS records are maintained by the platform and rejected by the API, so both are left out of the zone contents and the desired state, and DocDualHost is Cannot.

The integration suite passes: 249 cases, 0 failures. It needed two changes in integrationTest/integration_test.go, and I would rather flag them than have you find them.

NEXDNS is added to the not(...) list of the apex-NS group: the apex NS records follow the zone's nameserver group and the API rejects an edit, which is what NAMEDOTCOM and NETCUP are excluded for.

In "IGNORE with modify", one address changes from 10.10.10.10 to 9.9.9.9. That value is only the "before" of the change the following cases make (10 -> 11 -> 12 -> 13), so the range looks incidental to what the test checks, while an RFC 1918 address is refused outright by any provider serving public zones only; 9.9.9.9 is already used elsewhere in the same file. Happy to exclude NEXDNS from the group instead if you prefer, but that would drop the whole of the IGNORE semantics from this provider's coverage over one value the test does not depend on.

Please create the GitHub label 'provider-NEXDNS'.