### PR TITLE
DESEC, POWERDNS: Add audit rules for DNSKEY records

### DIFF
--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1060,7 +1060,6 @@ func makeTests() []*TestGroup {
 
 		testgroup("DNSKEY",
 			requires(providers.CanUseDNSKEY),
-			not("POWERDNS"), // PowerDNS: DNSKEY records are only supported for the apex domain.
 			tc("Create DNSKEY record", dnskey("test", 257, 3, 13, "fRnjbeUVyKvz1bDx2lPmu3KY1k64T358t8kP6Hjveos=")),
 			tc("Modify DNSKEY record 1", dnskey("test", 256, 3, 13, "fRnjbeUVyKvz1bDx2lPmu3KY1k64T358t8kP6Hjveos=")),
 			tc("Modify DNSKEY record 2", dnskey("test", 256, 3, 13, "whjtMiJP9C86l0oTJUxemuYtQ0RIZePWt6QETC2kkKM=")),

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -1060,7 +1060,6 @@ func makeTests() []*TestGroup {
 
 		testgroup("DNSKEY",
 			requires(providers.CanUseDNSKEY),
-			not("DESEC"),    // DESEC: DNSKEY records are only supported for the apex domain.
 			not("POWERDNS"), // PowerDNS: DNSKEY records are only supported for the apex domain.
 			tc("Create DNSKEY record", dnskey("test", 257, 3, 13, "fRnjbeUVyKvz1bDx2lPmu3KY1k64T358t8kP6Hjveos=")),
 			tc("Modify DNSKEY record 1", dnskey("test", 256, 3, 13, "fRnjbeUVyKvz1bDx2lPmu3KY1k64T358t8kP6Hjveos=")),

--- a/pkg/rejectif/dnskey.go
+++ b/pkg/rejectif/dnskey.go
@@ -1,0 +1,18 @@
+package rejectif
+
+import (
+	"errors"
+
+	"github.com/DNSControl/dnscontrol/v5/models"
+)
+
+// Keep these in alphabetical order.
+
+// DnskeyNotAtApex detects DNSKEY records not at the apex/root domain.
+// Use this when a provider doesn't support custom DNSKEY records at subnames.
+func DnskeyNotAtApex(rc *models.RecordConfig) error {
+	if rc.GetLabel() != "" && rc.GetLabel() != "@" {
+		return errors.New("DNSKEY records not supported at subnames")
+	}
+	return nil
+}

--- a/providers/desec/auditrecords.go
+++ b/providers/desec/auditrecords.go
@@ -1,10 +1,17 @@
 package desec
 
-import "github.com/DNSControl/dnscontrol/v5/models"
+import (
+	"github.com/DNSControl/dnscontrol/v5/models"
+	"github.com/DNSControl/dnscontrol/v5/pkg/rejectif"
+)
 
 // AuditRecords returns a list of errors corresponding to the records
 // that aren't supported by this provider.  If all records are
 // supported, an empty list is returned.
 func AuditRecords(records []*models.RecordConfig) []error {
-	return nil
+	a := rejectif.Auditor{}
+
+	a.Add("DNSKEY", rejectif.DnskeyNotAtApex) // Last verified 2026-08-04
+
+	return a.Audit(records)
 }

--- a/providers/powerdns/auditrecords.go
+++ b/providers/powerdns/auditrecords.go
@@ -11,6 +11,7 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
+	a.Add("DNSKEY", rejectif.DnskeyNotAtApex)
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2023-11-11
 	a.Add("TXT", rejectif.TxtHasBackslash)    // Last verified 2023-11-11
 	a.Add("HTTPS", rejectPowerDNSSVCBAutoHintsUnsorted)


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
DESEC and POWERDNS support DNSKEY records but only at apex.
This PR adds an audit rule and re-enable integration tests.

#4697 no longer required
#4421 v5 integration tests pass for DESEC
