### PR TITLE
REFACTOR: Optimize switch on .Type to be .TypeNum

### DIFF
--- a/models/record.go
+++ b/models/record.go
@@ -450,10 +450,10 @@ func Downcase(recs []*RecordConfig) {
 				panic(fmt.Sprintf("assertion failed: Downcase: %q != %q", r0, r1))
 			}
 			// BUGFIX(tlim): isn't ALIAS in the wrong case statement?
-		case "A", "CAA", "CLOUDFLAREAPI_SINGLE_REDIRECT", "CF_REDIRECT", "CF_TEMP_REDIRECT", "CF_WORKER_ROUTE", "DHCID", "IMPORT_TRANSFORM", "LOC", "OPENPGPKEY", "SSHFP", "TXT", "ADGUARDHOME_A_PASSTHROUGH", "ADGUARDHOME_AAAA_PASSTHROUGH":
-			// Do nothing. (IP address or case sensitive target)
-		case "AZURE_ALIAS":
-			// do nothing.
+		// case "A", "CAA", "CLOUDFLAREAPI_SINGLE_REDIRECT", "CF_REDIRECT", "CF_TEMP_REDIRECT", "CF_WORKER_ROUTE", "DHCID", "IMPORT_TRANSFORM", "LOC", "OPENPGPKEY", "SSHFP", "TXT", "ADGUARDHOME_A_PASSTHROUGH", "ADGUARDHOME_AAAA_PASSTHROUGH":
+		// 	// Do nothing. (IP address or case sensitive target)
+		// case "AZURE_ALIAS":
+		// 	// do nothing.
 		default:
 			// TODO: we'd like to panic here, but custom record types complicate things.
 		}
@@ -469,8 +469,8 @@ func CanonicalizeTargets(recs []*RecordConfig, origin string) {
 		case "ALIAS", "ANAME", "CNAME", "DNAME", "DS", "DNSKEY", "MX", "NS", "NAPTR", "PTR", "SRV":
 			// Target is a hostname that might be a shortname. Turn it into a FQDN.
 			r.target = nameutil.ToFqdnWithDot(r.target, originFQDN)
-		case "A", "AKAMAICDN", "AKAMAITLC", "CAA", "DHCID", "CLOUDFLAREAPI_SINGLE_REDIRECT", "CF_REDIRECT", "CF_TEMP_REDIRECT", "CF_WORKER_ROUTE", "HTTPS", "IMPORT_TRANSFORM", "LOC", "OPENPGPKEY", "SMIMEA", "SSHFP", "SVCB", "TLSA", "TXT", "ADGUARDHOME_A_PASSTHROUGH", "ADGUARDHOME_AAAA_PASSTHROUGH":
-			// Do nothing.
+		// case "A", "AKAMAICDN", "AKAMAITLC", "CAA", "DHCID", "CLOUDFLAREAPI_SINGLE_REDIRECT", "CF_REDIRECT", "CF_TEMP_REDIRECT", "CF_WORKER_ROUTE", "HTTPS", "IMPORT_TRANSFORM", "LOC", "OPENPGPKEY", "SMIMEA", "SSHFP", "SVCB", "TLSA", "TXT", "ADGUARDHOME_A_PASSTHROUGH", "ADGUARDHOME_AAAA_PASSTHROUGH":
+		// 	// Do nothing.
 		default:
 			// TODO: we'd like to panic here, but custom record types complicate things.
 		}

--- a/models/target.go
+++ b/models/target.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	dnsrdatav2 "codeberg.org/miekg/dns/rdata"
 	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
 )
@@ -140,14 +141,14 @@ func (rc *RecordConfig) MustSetTarget(target string) {
 func (rc *RecordConfig) SetTargetIP(ip netip.Addr) error {
 	// TODO(tlim): Verify the rtype is appropriate for an IP.
 	//return rc.SetTarget(ip.String())
-	switch rc.Type {
-	case "A":
+	switch rc.TypeNum {
+	case dnsv2.TypeA:
 		rd, err := MakeA("", nil, nrc.Flags{}, ip)
 		if err != nil {
 			return err
 		}
 		rc.SetRDATA(rd)
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		rd, err := MakeAAAA("", nil, nrc.Flags{}, ip)
 		if err != nil {
 			return err

--- a/pkg/prettyzone/sorting.go
+++ b/pkg/prettyzone/sorting.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -38,20 +39,20 @@ func (z *ZoneGenData) Less(i, j int) bool {
 	}
 
 	// sub-sort within type:
-	switch a.Type {
-	case "A":
+	switch a.TypeNum {
+	case dnsv2.TypeA:
 		ta2, tb2 := a.GetTargetIP(), b.GetTargetIP()
 		if ta2.Is4() && tb2.Is4() {
 			return bytes.Compare(ta2.AsSlice(), tb2.AsSlice()) == -1
 		}
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		ta2, tb2 := a.GetTargetIP(), b.GetTargetIP()
 		if !ta2.Is6() || !tb2.Is6() {
 			log.Fatalf("should not happen: Invalid IPv6 address: %s %s",
 				a.GetTargetIP().String(), b.GetTargetIP().String())
 		}
 		return ta2.Compare(tb2) == -1
-	case "MX":
+	case dnsv2.TypeMX:
 		// sort by priority. If they are equal, sort by Mx.
 		fa := a.AsMX()
 		fb := b.AsMX()
@@ -59,7 +60,7 @@ func (z *ZoneGenData) Less(i, j int) bool {
 			return fa.Preference < fb.Preference
 		}
 		return fa.Mx < fb.Mx
-	case "SRV":
+	case dnsv2.TypeSRV:
 		fa := a.AsSRV()
 		fb := b.AsSRV()
 		pa, pb := fa.Priority, fb.Priority
@@ -75,7 +76,7 @@ func (z *ZoneGenData) Less(i, j int) bool {
 			return ppa < ppb
 		}
 		return fa.Target < fb.Target
-	case "SVCB", "HTTPS":
+	case dnsv2.TypeSVCB, dnsv2.TypeHTTPS:
 		fa := a.AsSVCB()
 		fb := b.AsSVCB()
 		// sort by priority. If they are equal, sort by ASCII
@@ -85,7 +86,7 @@ func (z *ZoneGenData) Less(i, j int) bool {
 		if fa.Target != fb.Target {
 			return fa.Target < fb.Target
 		}
-	case "PTR":
+	case dnsv2.TypePTR:
 		fa := a.AsPTR()
 		fb := b.AsPTR()
 		// TODO(tlim): Sort by fancy host sort.
@@ -93,7 +94,7 @@ func (z *ZoneGenData) Less(i, j int) bool {
 		if pa != pb {
 			return pa < pb
 		}
-	case "CAA":
+	case dnsv2.TypeCAA:
 		// ta2, tb2 := a.(*dns.CAA), b.(*dns.CAA)
 		// sort by tag
 		fa := a.AsCAA()
@@ -108,14 +109,14 @@ func (z *ZoneGenData) Less(i, j int) bool {
 			// flag set goes before ones without flag set
 			return flaga > flagb
 		}
-	case "DS":
+	case dnsv2.TypeDS:
 		fa := a.AsDS()
 		fb := b.AsDS()
 		pa, pb := fa.KeyTag, fb.KeyTag
 		if pa != pb {
 			return pa < pb
 		}
-	case "DNSKEY":
+	case dnsv2.TypeDNSKEY:
 		fa := a.AsDNSKEY()
 		fb := b.AsDNSKEY()
 		flga, flgb := fa.Flags, fb.Flags

--- a/providers/adguardhome/adguardHomeProvider.go
+++ b/providers/adguardhome/adguardHomeProvider.go
@@ -159,22 +159,22 @@ func toRewriteEntry(dc *models.DomainConfig, rc *models.RecordConfig) (rewriteEn
 	re := rewriteEntry{
 		Domain: rc.NameFQDN,
 	}
-	switch rc.Type {
-	case "A":
+	switch rc.TypeNum {
+	case dnsv2.TypeA:
 		re.Answer = rc.AsA().Addr.String()
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		re.Answer = rc.AsAAAA().Addr.String()
 
-	case "ALIAS":
+	case privatetypes.TypeALIAS:
 		re.Answer = dc.ToShort(rc.AsALIAS().Target)
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		re.Answer = dc.ToShort(rc.AsCNAME().Target)
 
-	case "ADGUARDHOME_A_PASSTHROUGH":
+	case privatetypes.TypeADGUARDHOMEAPASSTHROUGH:
 		re.Answer = "A"
 
-	case "ADGUARDHOME_AAAA_PASSTHROUGH":
+	case privatetypes.TypeADGUARDHOMEAAAAPASSTHROUGH:
 		re.Answer = "AAAA"
 
 	default:

--- a/providers/autodns/autoDnsProvider.go
+++ b/providers/autodns/autoDnsProvider.go
@@ -231,11 +231,11 @@ func recordsToNative(recs models.Records) ([]*models.Nameserver, uint32, []*Reso
 				//resourceRecord.Pref = int32(f.Preference)
 				//resourceRecord.Value = f.Mx
 
-			case dnsv2.TypeSRV:
-				resourceRecord.Value = rc.GetRDATA().String()
+			// case dnsv2.TypeSRV:
+			// 	resourceRecord.Value = rc.GetRDATA().String()
 
-			case dnsv2.TypeCAA:
-				resourceRecord.Value = rc.GetRDATA().String()
+			// case dnsv2.TypeCAA:
+			// 	resourceRecord.Value = rc.GetRDATA().String()
 
 			default:
 				resourceRecord.Value = rc.GetRDATA().String()

--- a/providers/azureprivatedns/azurePrivateDnsProvider.go
+++ b/providers/azureprivatedns/azurePrivateDnsProvider.go
@@ -367,16 +367,16 @@ func nativeToRecordTypeDiff(recordType *string) (adns.RecordType, error) {
 		return adns.RecordTypeA, nil
 	case "AAAA", "AZURE_ALIAS_AAAA":
 		return adns.RecordTypeAAAA, nil
-	case "CAA":
-		// CAA doesn't make any senese in a private dns zone in azure
-		return adns.RecordTypeA, fmt.Errorf("nativeToRecordTypeDiff RTYPE %v UNIMPLEMENTED", *recordType)
+	// case "CAA":
+	// 	// CAA doesn't make any senese in a private dns zone in azure
+	// 	return adns.RecordTypeA, fmt.Errorf("nativeToRecordTypeDiff RTYPE %v UNIMPLEMENTED", *recordType)
 	case "CNAME", "AZURE_ALIAS_CNAME":
 		return adns.RecordTypeCNAME, nil
 	case "MX":
 		return adns.RecordTypeMX, nil
-	case "NS":
-		// NS record types don't make any sense in a private azure dns zone
-		return adns.RecordTypeA, fmt.Errorf("nativeToRecordTypeDiff RTYPE %v UNIMPLEMENTED", *recordType)
+	// case "NS":
+	// 	// NS record types don't make any sense in a private azure dns zone
+	// 	return adns.RecordTypeA, fmt.Errorf("nativeToRecordTypeDiff RTYPE %v UNIMPLEMENTED", *recordType)
 	case "PTR":
 		return adns.RecordTypePTR, nil
 	case "SRV":
@@ -505,8 +505,8 @@ func (a *azurednsProvider) recordToNativeDiff2(recordKey models.RecordKey, recor
 			f := rec.AsSRV()
 			recordSet.Properties.SrvRecords = append(recordSet.Properties.SrvRecords, &adns.SrvRecord{Target: new(f.Target), Port: new(int32(f.Port)), Weight: new(int32(f.Weight)), Priority: new(int32(f.Priority))})
 			/* CAA records don't work in a private zone */
-		case "AZURE_ALIAS_A", "AZURE_ALIAS_AAAA", "AZURE_ALIAS_CNAME":
-			return nil, adns.RecordTypeA, fmt.Errorf("recordToNativeDiff2 RTYPE %v UNIMPLEMENTED", recordKeyType) // ands.A is a placeholder
+		// case "AZURE_ALIAS_A", "AZURE_ALIAS_AAAA", "AZURE_ALIAS_CNAME":
+		// 	return nil, adns.RecordTypeA, fmt.Errorf("recordToNativeDiff2 RTYPE %v UNIMPLEMENTED", recordKeyType) // ands.A is a placeholder
 		default:
 			return nil, adns.RecordTypeA, fmt.Errorf("recordToNativeDiff2 RTYPE %v UNIMPLEMENTED", recordKeyType) // ands.A is a placeholder
 		}

--- a/providers/bunnydns/convert.go
+++ b/providers/bunnydns/convert.go
@@ -43,8 +43,8 @@ func fromRecordConfig(rc *models.RecordConfig) (*record, error) {
 		rd := rc.GetRDATA().(dnsrdatav2.SVCB)
 		r.Priority = rd.Priority
 		r.Value = rd.Target
-	case recordTypeTLSA:
-		r.Value = rc.GetRDATA().String()
+	// case recordTypeTLSA:
+	// 	r.Value = rc.GetRDATA().String()
 	case recordTypePullZone:
 		// When creating Pull Zone records, the API expects an integer PullZoneId field,
 		// while the Value field should be empty.

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
+	privatetypes "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes"
 	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
 	"github.com/DNSControl/dnscontrol/v5/pkg/transform"
@@ -385,15 +386,15 @@ func genComparableWithMgmt(rec *models.RecordConfig, manageComments, manageTags 
 }
 
 func (c *cloudflareProvider) mkCreateCorrection(newrec *models.RecordConfig, domainID, msg string) []*models.Correction {
-	switch newrec.Type {
-	case "CF_WORKER_ROUTE":
+	switch newrec.TypeNum {
+	case privatetypes.TypeCFWORKERROUTE:
 		return []*models.Correction{{
 			Msg: msg,
 			F: func() error {
 				return c.createWorkerRoute(domainID, newrec.GetRDATA())
 			},
 		}}
-	case "CLOUDFLAREAPI_SINGLE_REDIRECT":
+	case privatetypes.TypeCLOUDFLAREAPISINGLEREDIRECT:
 		return []*models.Correction{{
 			Msg: msg,
 			F: func() error {
@@ -408,25 +409,25 @@ func (c *cloudflareProvider) mkCreateCorrection(newrec *models.RecordConfig, dom
 
 func (c *cloudflareProvider) mkChangeCorrection(oldrec, newrec *models.RecordConfig, domainID string, msg string) []*models.Correction {
 	var idTxt string
-	switch oldrec.Type {
-	case "CF_WORKER_ROUTE":
+	switch oldrec.TypeNum {
+	case privatetypes.TypeCFWORKERROUTE:
 		idTxt = oldrec.Original.(cloudflare.WorkerRoute).ID
-	case "CLOUDFLAREAPI_SINGLE_REDIRECT":
+	case privatetypes.TypeCLOUDFLAREAPISINGLEREDIRECT:
 		idTxt = oldrec.AsCLOUDFLAREAPISINGLEREDIRECT().RT_SRRRulesetID
 	default:
 		idTxt = oldrec.Original.(cloudflare.DNSRecord).ID
 	}
 	msg = msg + color.YellowString(" id=%v", idTxt)
 
-	switch newrec.Type {
-	case "CLOUDFLAREAPI_SINGLE_REDIRECT":
+	switch newrec.TypeNum {
+	case privatetypes.TypeCLOUDFLAREAPISINGLEREDIRECT:
 		return []*models.Correction{{
 			Msg: msg,
 			F: func() error {
 				return c.updateSingleRedirect(domainID, oldrec, newrec)
 			},
 		}}
-	case "CF_WORKER_ROUTE":
+	case privatetypes.TypeCFWORKERROUTE:
 		return []*models.Correction{{
 			Msg: msg,
 			F: func() error {
@@ -663,8 +664,8 @@ func (c *cloudflareProvider) preprocessConfig(dc *models.DomainConfig) error {
 			return fmt.Errorf("CNAME record %#v has both CF_PROXY_ON and CF_CNAME_FLATTEN_ON set, but these are mutually exclusive; Cloudflare ignores CNAME flattening when proxy is enabled", rec.GetLabel())
 		}
 
-		switch rec.Type {
-		case "CLOUDFLAREAPI_SINGLE_REDIRECT":
+		switch rec.TypeNum {
+		case privatetypes.TypeCLOUDFLAREAPISINGLEREDIRECT:
 			// SINGLEREDIRECT record types. Verify they are enabled.
 			if !c.manageSingleRedirects {
 				return errors.New("you must add 'manage_single_redirects: true' metadata to cloudflare provider to use CLOUDFLAREAPI_SINGLE_REDIRECT records")

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -191,10 +191,10 @@ func (c *cloudflareProvider) createRecDiff2(rec *models.RecordConfig, domainID s
 		priorityNum = f.Preference
 		prio = fmt.Sprintf(" %d ", priorityNum)
 		content = f.Mx
-	case "TXT":
-		content = rec.GetRDATA().String()
-	case "DS":
-		content = rec.GetRDATA().String()
+	// case "TXT":
+	// 	content = rec.GetRDATA().String()
+	// case "DS":
+	// 	content = rec.GetRDATA().String()
 	default:
 		content = rec.GetRDATA().String()
 	}
@@ -308,8 +308,8 @@ func (c *cloudflareProvider) modifyRecord(domainID, recID string, proxied bool, 
 	}
 
 	switch rec.Type {
-	case "TXT":
-		r.Content = rec.GetRDATA().String()
+	// case "TXT":
+	// 	r.Content = rec.GetRDATA().String()
 	case "MX":
 		f := rec.AsMX()
 		r.Priority = new(f.Preference)

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -185,8 +185,8 @@ func (c *cloudflareProvider) createRecDiff2(rec *models.RecordConfig, domainID s
 	var content string
 	prio := ""
 	priorityNum := uint16(0)
-	switch rec.Type {
-	case "MX":
+	switch rec.TypeNum {
+	case dnsv2.TypeMX:
 		f := rec.AsMX()
 		priorityNum = f.Preference
 		prio = fmt.Sprintf(" %d ", priorityNum)
@@ -239,30 +239,30 @@ func (c *cloudflareProvider) createRecDiff2(rec *models.RecordConfig, domainID s
 				flatten := true
 				cf.Settings = cloudflare.DNSRecordSettings{FlattenCNAME: &flatten}
 			}
-			switch rec.Type {
-			case "SRV":
+			switch rec.TypeNum {
+			case dnsv2.TypeSRV:
 				cf.Data = cfSrvData(rec)
 				cf.Name = rec.GetLabelFQDN()
-			case "CAA":
+			case dnsv2.TypeCAA:
 				cf.Data = cfCaaData(rec)
 				cf.Name = rec.GetLabelFQDN()
 				cf.Content = ""
-			case "TLSA":
+			case dnsv2.TypeTLSA:
 				cf.Data = cfTlsaData(rec)
 				cf.Name = rec.GetLabelFQDN()
-			case "SSHFP":
+			case dnsv2.TypeSSHFP:
 				cf.Data = cfSshfpData(rec)
 				cf.Name = rec.GetLabelFQDN()
-			case "DNSKEY":
+			case dnsv2.TypeDNSKEY:
 				cf.Data = cfDnskeyData(rec)
-			case "DS":
+			case dnsv2.TypeDS:
 				cf.Data = cfDSData(rec)
-			case "NAPTR":
+			case dnsv2.TypeNAPTR:
 				cf.Data = cfNaptrData(rec)
 				cf.Name = rec.GetLabelFQDN()
-			case "HTTPS", "SVCB":
+			case dnsv2.TypeHTTPS, dnsv2.TypeSVCB:
 				cf.Data = cfSvcbData(rec)
-			case "LOC":
+			case dnsv2.TypeLOC:
 				cf.Data = cfLocData(rec)
 			}
 			resp, err := c.cfClient.CreateDNSRecord(context.Background(), cloudflare.ZoneIdentifier(domainID), cf)
@@ -307,48 +307,48 @@ func (c *cloudflareProvider) modifyRecord(domainID, recID string, proxied bool, 
 		}
 	}
 
-	switch rec.Type {
+	switch rec.TypeNum {
 	// case "TXT":
 	// 	r.Content = rec.GetRDATA().String()
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rec.AsMX()
 		r.Priority = new(f.Preference)
 		r.Content = f.Mx
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		// Handle CNAME flattening setting
 		flatten := rec.Metadata[metaCNAMEFlatten] == "on"
 		r.Settings = cloudflare.DNSRecordSettings{FlattenCNAME: &flatten}
 		r.Content = rec.AsCNAME().Target
-	case "SRV":
+	case dnsv2.TypeSRV:
 		r.Data = cfSrvData(rec)
 		r.Name = rec.GetLabelFQDN()
 		r.Content = rec.GetRDATA().String()
-	case "CAA":
+	case dnsv2.TypeCAA:
 		r.Data = cfCaaData(rec)
 		r.Name = rec.GetLabelFQDN()
 		r.Content = ""
-	case "TLSA":
+	case dnsv2.TypeTLSA:
 		r.Data = cfTlsaData(rec)
 		r.Name = rec.GetLabelFQDN()
 		r.Content = rec.GetRDATA().String()
-	case "SSHFP":
+	case dnsv2.TypeSSHFP:
 		r.Data = cfSshfpData(rec)
 		r.Name = rec.GetLabelFQDN()
 		r.Content = rec.GetRDATA().String()
-	case "DNSKEY":
+	case dnsv2.TypeDNSKEY:
 		r.Data = cfDnskeyData(rec)
 		r.Content = ""
-	case "DS":
+	case dnsv2.TypeDS:
 		r.Data = cfDSData(rec)
 		r.Content = ""
-	case "NAPTR":
+	case dnsv2.TypeNAPTR:
 		r.Data = cfNaptrData(rec)
 		r.Name = rec.GetLabelFQDN()
 		r.Content = rec.GetRDATA().String()
-	case "HTTPS", "SVCB":
+	case dnsv2.TypeHTTPS, dnsv2.TypeSVCB:
 		r.Data = cfSvcbData(rec)
 		r.Content = rec.GetRDATA().String()
-	case "LOC":
+	case dnsv2.TypeLOC:
 		r.Data = cfLocData(rec)
 		r.Content = rec.GetRDATA().String()
 	default:

--- a/providers/cloudns/cloudnsProvider.go
+++ b/providers/cloudns/cloudnsProvider.go
@@ -243,10 +243,10 @@ func (c *cloudnsProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exi
 		// A & AAAA need to be created before NS #2244
 		// NS need to be created before DS #1018
 		// or else errors will be thrown
-		switch m.Desired.Type {
-		case "A", "AAAA":
+		switch m.Desired.TypeNum {
+		case dnsv2.TypeA, dnsv2.TypeAAAA:
 			createARecordCorrections = append(createARecordCorrections, corr)
-		case "NS":
+		case dnsv2.TypeNS:
 			createNSRecordCorrections = append(createNSRecordCorrections, corr)
 		default:
 			createCorrections = append(createCorrections, corr)
@@ -526,45 +526,45 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 		req["geodns-code"] = geodnsCodeFromMetadataValue
 	}
 
-	switch rc.Type {
-	case "CLOUDNS_WR":
+	switch rc.TypeNum {
+	case privatetypes.TypeCLOUDNSWR:
 		f := rc.AsCLOUDNSWR()
 		req["record-type"] = "WR"
 		req["record"] = f.Target
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		req["priority"] = strconv.Itoa(int(f.Preference))
 		req["record"] = f.Mx
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		req["priority"] = strconv.Itoa(int(f.Priority))
 		req["weight"] = strconv.Itoa(int(f.Weight))
 		req["port"] = strconv.Itoa(int(f.Port))
 		req["record"] = f.Target
-	case "CAA":
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		req["caa_flag"] = strconv.Itoa(int(f.Flag))
 		req["caa_type"] = f.Tag
 		req["caa_value"] = f.Value
 		req["record"] = rc.GetRDATA().String()
-	case "TLSA":
+	case dnsv2.TypeTLSA:
 		f := rc.AsTLSA()
 		req["tlsa_usage"] = strconv.Itoa(int(f.Usage))
 		req["tlsa_selector"] = strconv.Itoa(int(f.Selector))
 		req["tlsa_matching_type"] = strconv.Itoa(int(f.MatchingType))
 		req["record"] = f.Certificate
-	case "SSHFP":
+	case dnsv2.TypeSSHFP:
 		f := rc.AsSSHFP()
 		req["algorithm"] = strconv.Itoa(int(f.Algorithm))
 		req["fptype"] = strconv.Itoa(int(f.Type))
 		req["record"] = f.FingerPrint
-	case "DS":
+	case dnsv2.TypeDS:
 		f := rc.AsDS()
 		req["key-tag"] = strconv.Itoa(int(f.KeyTag))
 		req["algorithm"] = strconv.Itoa(int(f.Algorithm))
 		req["digest-type"] = strconv.Itoa(int(f.DigestType))
 		req["record"] = f.Digest
-	case "LOC":
+	case dnsv2.TypeLOC:
 		parts := strings.Fields(rc.GetRDATA().String())
 		req["lat-deg"] = parts[0]
 		req["lat-min"] = parts[1]
@@ -579,7 +579,7 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 		req["h-precision"] = formatLocParam(parts[10])
 		req["v-precision"] = formatLocParam(parts[11])
 		req["record"] = rc.GetRDATA().String()
-	case "NAPTR":
+	case dnsv2.TypeNAPTR:
 		f := rc.AsNAPTR()
 		req["order"] = strconv.Itoa(int(f.Order))
 		req["pref"] = strconv.Itoa(int(f.Preference))
@@ -588,7 +588,7 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 		req["regexp"] = f.Regexp
 		req["replace"] = f.Replacement
 		req["record"] = rc.GetRDATA().String()
-	case "TXT":
+	case dnsv2.TypeTXT:
 		req["record"] = rc.GetTargetTXTJoined()
 	default:
 		req["record"] = rc.GetRDATA().String()

--- a/providers/cnr/records.go
+++ b/providers/cnr/records.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
@@ -285,25 +286,25 @@ func (client *Client) createRecordString(rc *models.RecordConfig, domain string)
 
 	var answer string
 
-	switch rc.Type { // #rtype_variations
-	case "LOC":
+	switch rc.TypeNum { // #rtype_variations
+	case dnsv2.TypeLOC:
 		answer = rc.AsLOC().String()
-	case "SVCB", "HTTPS":
+	case dnsv2.TypeSVCB, dnsv2.TypeHTTPS:
 		answer = rc.GetRDATA().String()
 		answer = strings.ReplaceAll(answer, `"`, ``)
-	case "SSHFP":
+	case dnsv2.TypeSSHFP:
 		f := rc.AsSSHFP()
 		answer = fmt.Sprintf(`%v %v %s`, f.Algorithm, f.Type, f.FingerPrint)
-	case "NAPTR":
+	case dnsv2.TypeNAPTR:
 		f := rc.AsNAPTR()
 		answer = fmt.Sprintf(`%v %v "%v" "%v" "%v" %v`, f.Order, f.Preference, f.Flags, f.Service, f.Regexp, f.Replacement)
-	case "TLSA":
+	case dnsv2.TypeTLSA:
 		f := rc.AsTLSA()
 		answer = fmt.Sprintf(`%v %v %v %s`, f.Usage, f.Selector, f.MatchingType, f.Certificate)
-	case "SMIMEA":
+	case dnsv2.TypeSMIMEA:
 		f := rc.AsSMIMEA()
 		answer = fmt.Sprintf(`%v %v %v %s`, f.Usage, f.Selector, f.MatchingType, f.Certificate)
-	case "CAA":
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		answer = fmt.Sprintf(`%v %s "%s"`, f.Flag, f.Tag, f.Value)
 	default:
@@ -320,16 +321,16 @@ func (client *Client) createRecordString(rc *models.RecordConfig, domain string)
 
 // deleteRecordString constructs the record string based on the provided Record.
 func deleteRecordString(rc *models.RecordConfig) string {
-	switch rc.Type {
-	case "MX":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
 		return fmt.Sprintf("%s %d IN MX %s", rc.GetLabel(), rc.TTL, rc.AsMX().Mx)
-	case "NS":
+	case dnsv2.TypeNS:
 		return fmt.Sprintf("%s %d NS %s", rc.GetLabel(), rc.TTL, rc.AsNS().Ns)
-	case "SVCB", "HTTPS":
+	case dnsv2.TypeSVCB, dnsv2.TypeHTTPS:
 		d := rc.GetRDATA().String()
 		d = strings.ReplaceAll(d, `"`, ``)
 		return fmt.Sprintf("%s %d IN %s %s", rc.GetLabel(), rc.TTL, rc.Type, d)
-	case "TLSA":
+	case dnsv2.TypeTLSA:
 		d := rc.GetRDATA().String()
 		d = strings.ToLower(d)
 		return fmt.Sprintf("%s %d IN %s %s", rc.GetLabel(), rc.TTL, rc.Type, d)

--- a/providers/cscglobal/dns.go
+++ b/providers/cscglobal/dns.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 )
@@ -127,8 +128,8 @@ func (client *providerClient) GetZoneRecordsCorrections(dc *models.DomainConfig,
 func makePurge(existing *models.RecordConfig) zoneResourceRecordEdit {
 	var existingTarget string
 
-	switch existing.Type {
-	case "TXT":
+	switch existing.TypeNum {
+	case dnsv2.TypeTXT:
 		existingTarget = existing.GetTargetTXTJoined()
 	default:
 		existingTarget = existing.GetRDATA().String()
@@ -159,25 +160,25 @@ func makeAdd(rec *models.RecordConfig) zoneResourceRecordEdit {
 		NewTTL:     rec.TTL,
 	}
 
-	switch rec.Type {
-	case "CAA":
+	switch rec.TypeNum {
+	case dnsv2.TypeCAA:
 		f := rec.AsCAA()
 		tagValue := f.Tag
 		flagValue := f.Flag
 		zer.NewTag = &tagValue
 		zer.NewFlag = &flagValue
 		zer.NewValue = f.Value
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rec.AsMX()
 		zer.NewPriority = f.Preference
 		zer.NewValue = f.Mx
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rec.AsSRV()
 		zer.NewPriority = f.Priority
 		zer.NewWeight = f.Weight
 		zer.NewPort = f.Port
 		zer.NewValue = f.Target
-	case "TXT":
+	case dnsv2.TypeTXT:
 		zer.NewValue = rec.GetTargetTXTJoined()
 	default:
 		zer.NewValue = rec.GetRDATA().String()
@@ -195,8 +196,8 @@ func makeEdit(old, rec *models.RecordConfig) zoneResourceRecordEdit {
 	}
 
 	var oldTarget, recTarget string
-	switch old.Type {
-	case "TXT":
+	switch old.TypeNum {
+	case dnsv2.TypeTXT:
 		oldTarget = old.GetTargetTXTJoined()
 		recTarget = rec.GetTargetTXTJoined()
 	default:
@@ -217,8 +218,8 @@ func makeEdit(old, rec *models.RecordConfig) zoneResourceRecordEdit {
 		zer.NewTTL = rec.TTL
 	}
 
-	switch old.Type {
-	case "CAA":
+	switch old.TypeNum {
+	case dnsv2.TypeCAA:
 		of := old.AsCAA()
 		tagValue := of.Tag
 		zer.CurrentTag = &tagValue
@@ -228,11 +229,11 @@ func makeEdit(old, rec *models.RecordConfig) zoneResourceRecordEdit {
 			zer.NewTag = new(rec.AsCAA().Tag)
 			zer.NewFlag = new(rec.AsCAA().Flag)
 		}
-	case "MX":
+	case dnsv2.TypeMX:
 		if old.AsMX().Preference != rec.AsMX().Preference {
 			zer.NewPriority = rec.AsMX().Preference
 		}
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rec.AsSRV()
 		zer.NewWeight = f.Weight
 		zer.NewPort = f.Port

--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -360,8 +360,8 @@ func toReq(rc *models.RecordConfig) *godo.DomainRecordEditRequest {
 		TTL:  int(rc.TTL),
 	}
 
-	switch rc.Type {
-	case "CAA":
+	switch rc.TypeNum {
+	case dnsv2.TypeCAA:
 		// DO API requires that a CAA target ends in dot.
 		// Interestingly enough, the value returned from API doesn't
 		// contain a trailing dot.
@@ -370,19 +370,19 @@ func toReq(rc *models.RecordConfig) *godo.DomainRecordEditRequest {
 		r.Tag = f.Tag
 		r.Flags = int(f.Flag)
 		r.Data = f.Value + "."
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		// DO uses the same field for MX and SRV priority
 		r.Priority = int(f.Preference)
 		r.Data = f.Mx
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		// DO uses the same field for MX and SRV priority
 		r.Priority = int(f.Priority)
 		r.Weight = int(f.Weight)
 		r.Port = int(f.Port)
 		r.Data = f.Target
-	case "TXT":
+	case dnsv2.TypeTXT:
 		// TXT records are the one place where DO combines many items into one field.
 		r.Data = rc.GetTargetTXTJoined()
 	default:

--- a/providers/dnscale/dnscaleProvider.go
+++ b/providers/dnscale/dnscaleProvider.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"time"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
+	privatetypes "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
 )
 
@@ -537,11 +539,13 @@ func fromRecordConfig(rc *models.RecordConfig) Record {
 	var content string
 	priority := 0
 
-	switch rc.Type {
-	case "CNAME", "NS", "PTR", "ALIAS":
+	switch rc.TypeNum {
+	case dnsv2.TypeCNAME, dnsv2.TypeNS, dnsv2.
 		// Remove trailing dot for DNScale API
+		TypePTR, privatetypes.TypeALIAS:
+
 		content = strings.TrimSuffix(content, ".")
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		priority = int(f.Preference)
 		content = strings.TrimSuffix(f.Mx, ".")
@@ -567,13 +571,14 @@ func fromRecordConfig(rc *models.RecordConfig) Record {
 	// 	// TODO(tlim): Remove commented out code if new code works.
 	// 	//content = fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.Get|TargetField())
 	// 	content = rc.GetRDATA().String()
-	case "HTTPS", "SVCB":
+	case dnsv2.TypeHTTPS, dnsv2.TypeSVCB:
 		// Use GetRDATA().String() which formats SVCB/HTTPS records correctly via miekg/dns
 		// DNScale API requires selective quote handling for SVCB params:
 		// - alpn="h2,h3" must become alpn=h2,h3 (quotes stripped)
 		// - ech="base64..." must keep quotes (required for base64 values)
+
 		content = stripSvcbQuotesExceptEch(rc.GetRDATA().String())
-	case "TXT":
+	case dnsv2.TypeTXT:
 		content = rc.GetTargetTXTJoined()
 	default:
 		content = rc.GetRDATA().String()

--- a/providers/dnscale/dnscaleProvider.go
+++ b/providers/dnscale/dnscaleProvider.go
@@ -545,28 +545,28 @@ func fromRecordConfig(rc *models.RecordConfig) Record {
 		f := rc.AsMX()
 		priority = int(f.Preference)
 		content = strings.TrimSuffix(f.Mx, ".")
-	case "SRV":
-		// TODO(tlim): Remove commented out code if new code works.
-		// DNScale API expects full content: "priority weight port target"
-		// target := rc.Get|TargetField()
-		// if !strings.HasSuffix(target, ".") {
-		// 	target = target + "."
-		// }
-		// content = fmt.Sprintf("%d %d %d %s", rc.SrvPriority, rc.SrvWeight, rc.SrvPort, target)
-		content = rc.GetRDATA().String()
+	// case "SRV":
+	// 	// TODO(tlim): Remove commented out code if new code works.
+	// 	// DNScale API expects full content: "priority weight port target"
+	// 	// target := rc.Get|TargetField()
+	// 	// if !strings.HasSuffix(target, ".") {
+	// 	// 	target = target + "."
+	// 	// }
+	// 	// content = fmt.Sprintf("%d %d %d %s", rc.SrvPriority, rc.SrvWeight, rc.SrvPort, target)
+	// 	content = rc.GetRDATA().String()
 
-	case "CAA":
-		// TODO(tlim): Remove commented out code if new code works.
-		//content = fmt.Sprintf("%d %s \"%s\"", rc.CaaFlag, rc.CaaTag, rc.Get|TargetField())
-		content = rc.GetRDATA().String()
-	case "TLSA":
-		// TODO(tlim): Remove commented out code if new code works.
-		//content = fmt.Sprintf("%d %d %d %s", rc.TlsaUsage, rc.TlsaSelector, rc.TlsaMatchingType, rc.Get|TargetField())
-		content = rc.GetRDATA().String()
-	case "SSHFP":
-		// TODO(tlim): Remove commented out code if new code works.
-		//content = fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.Get|TargetField())
-		content = rc.GetRDATA().String()
+	// case "CAA":
+	// 	// TODO(tlim): Remove commented out code if new code works.
+	// 	//content = fmt.Sprintf("%d %s \"%s\"", rc.CaaFlag, rc.CaaTag, rc.Get|TargetField())
+	// 	content = rc.GetRDATA().String()
+	// case "TLSA":
+	// 	// TODO(tlim): Remove commented out code if new code works.
+	// 	//content = fmt.Sprintf("%d %d %d %s", rc.TlsaUsage, rc.TlsaSelector, rc.TlsaMatchingType, rc.Get|TargetField())
+	// 	content = rc.GetRDATA().String()
+	// case "SSHFP":
+	// 	// TODO(tlim): Remove commented out code if new code works.
+	// 	//content = fmt.Sprintf("%d %d %s", rc.SshfpAlgorithm, rc.SshfpFingerprint, rc.Get|TargetField())
+	// 	content = rc.GetRDATA().String()
 	case "HTTPS", "SVCB":
 		// Use GetRDATA().String() which formats SVCB/HTTPS records correctly via miekg/dns
 		// DNScale API requires selective quote handling for SVCB params:

--- a/providers/dnsimple/dnsimpleProvider.go
+++ b/providers/dnsimple/dnsimpleProvider.go
@@ -681,9 +681,9 @@ func getTargetRecordPriority(rc *models.RecordConfig) int {
 		return int(rc.AsMX().Preference)
 	case dnsv2.TypeSRV:
 		return int(rc.AsSRV().Priority)
-	case dnsv2.TypeNAPTR:
-		// Neither order nor preference
-		return 0
+	// case dnsv2.TypeNAPTR:
+	// 	// Neither order nor preference
+	// 	return 0
 	default:
 		return 0
 	}

--- a/providers/domainnameshop/convert.go
+++ b/providers/domainnameshop/convert.go
@@ -14,8 +14,8 @@ func toRecordConfig(dc *models.DomainConfig, currentRecord *domainNameShopRecord
 	var rc *models.RecordConfig
 	var err error
 	switch currentRecord.Type {
-	case "TXT":
-		rc, err = dc.NewRecordConfig(label, ttl, currentRecord.Type, target)
+	// case "TXT":
+	// 	rc, err = dc.NewRecordConfig(label, ttl, currentRecord.Type, target)
 	case "MX":
 		rc, err = dc.NewRecordConfig(label, ttl, currentRecord.Type, currentRecord.ActualPriority, target)
 	case "SRV":

--- a/providers/domainnameshop/convert.go
+++ b/providers/domainnameshop/convert.go
@@ -3,6 +3,7 @@ package domainnameshop
 import (
 	"strconv"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -55,8 +56,8 @@ func (api *domainNameShopProvider) fromRecordConfig(domainName string, rc *model
 		DomainID: domainID,
 	}
 
-	switch rc.Type {
-	case "CAA":
+	switch rc.TypeNum {
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		// Actual CAA FLAG
 		switch f.Tag {
@@ -70,11 +71,11 @@ func (api *domainNameShopProvider) fromRecordConfig(domainName string, rc *model
 		dnsR.CAAFlag = uint64(int(f.Flag))
 		dnsR.ActualCAAFlag = strconv.Itoa(int(f.Flag))
 		dnsR.Data = f.Value
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		dnsR.Priority = strconv.Itoa(int(f.Preference))
 		dnsR.Data = f.Mx
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		dnsR.Priority = strconv.Itoa(int(f.Priority))
 		dnsR.Weight = strconv.Itoa(int(f.Weight))
@@ -82,7 +83,7 @@ func (api *domainNameShopProvider) fromRecordConfig(domainName string, rc *model
 		dnsR.ActualWeight = f.Weight
 		dnsR.ActualPort = f.Port
 		dnsR.Data = f.Target
-	case "TXT":
+	case dnsv2.TypeTXT:
 		dnsR.Data = rc.GetTargetTXTJoined()
 	default:
 		dnsR.Data = rc.GetRDATA().String()

--- a/providers/dynu/dynuProvider.go
+++ b/providers/dynu/dynuProvider.go
@@ -332,12 +332,12 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		TTL:        int(rc.TTL),
 		State:      true,
 	}
-	switch rc.Type {
-	case "A":
+	switch rc.TypeNum {
+	case dnsv2.TypeA:
 		req.IPv4Address = rc.AsA().String()
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		req.IPv6Address = rc.AsAAAA().String()
-	case "AFSDB":
+	case dnsv2.TypeAFSDB:
 		// Target: "<subtype> <hostname>."
 
 		// parts := strings.Fields(rc.GetTargetField())
@@ -350,13 +350,13 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		f := rc.AsAFSDB()
 		req.SubType = new(int(f.Subtype))
 		req.Host = strings.TrimSuffix(f.Hostname, ".")
-	case "CAA":
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		flags := int(f.Flag)
 		req.Flags = &flags
 		req.Tag = f.Tag
 		req.Value = f.Value
-	case "CERT":
+	case dnsv2.TypeCERT:
 
 		// Target: "<type> <keytag> <algorithm> <cert-base64>"
 		// parts := strings.Fields(rc.GetTargetField())
@@ -376,12 +376,12 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		req.Algorithm = new(int(f.Algorithm))
 		req.Certificate = f.Certificate
 
-	case "CNAME", "NS", "PTR", "DNAME":
+	case dnsv2.TypeCNAME, dnsv2.TypeNS, dnsv2.TypePTR, dnsv2.TypeDNAME:
 		req.Host = strings.TrimSuffix(rc.GetRDATA().String(), ".")
-	case "DHCID":
+	case dnsv2.TypeDHCID:
 		// Target is the base64-encoded DHCID data (zone-file format == API format).
 		req.RecordData = rc.AsDHCID().Digest
-	case "HINFO":
+	case dnsv2.TypeHINFO:
 
 		// Target: "<"cpu"> <"os">" — parse the two quoted character-strings.
 		// cpu, os := parseCharStrings(rc.GetTargetField())
@@ -390,7 +390,7 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 
 		req.CPU = rc.AsHINFO().Cpu
 		req.OperatingSystem = rc.AsHINFO().Os
-	case "HTTPS":
+	case dnsv2.TypeHTTPS:
 		f := rc.AsHTTPS()
 		req.SvcPriority = new(int(f.Priority)) // ignore:legacyfield
 		// Preserve "." for the null target; strip trailing dot from real hostnames.
@@ -400,7 +400,7 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		}
 		req.TargetName = target
 		req.SvcParams = parseSvcParams(models.Svcbv2ValueToString(f.Value)) // ignore:legacyfield
-	case "KEY":
+	case dnsv2.TypeKEY:
 		// Target: "<flags> <protocol> <algorithm> <pubkey-base64>"
 
 		// parts := strings.Fields(rc.GetTargetField())
@@ -420,7 +420,7 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		req.Algorithm = new(int(f.Algorithm))
 		req.PublicKey = f.PublicKey
 
-	case "LOC":
+	case dnsv2.TypeLOC:
 		// Convert DNSControl's packed binary LOC fields to Dynu's decimal-degree format.
 		// The packed values are integer arc-milliseconds. We compute total ms first
 		// (avoiding intermediate fractional divisions), then add a +0.5 ms bias before
@@ -451,12 +451,12 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		req.Size = &size
 		req.HorizontalPrecision = &horizPre
 		req.VerticalPrecision = &vertPre
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		req.Host = strings.TrimSuffix(f.Mx, ".")
 		pref := int(f.Preference)
 		req.Priority = &pref
-	case "NAPTR":
+	case dnsv2.TypeNAPTR:
 		f := rc.AsNAPTR()
 		order := int(f.Order)
 		pref := int(f.Preference)
@@ -471,14 +471,14 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 			naptrTarget = strings.TrimSuffix(naptrTarget, ".")
 		}
 		req.Replacement = naptrTarget
-	case "OPENPGPKEY":
+	case dnsv2.TypeOPENPGPKEY:
 		// Target is the base64-encoded public key (zone-file format == API format).
 		req.PublicKey = rc.AsOPENPGPKEY().PublicKey
-	case "RP":
+	case dnsv2.TypeRP:
 		rd := rc.AsRP()
 		req.MailBox = rd.Mbox
 		req.TxtDomainName = rd.Txt
-	case "SMIMEA":
+	case dnsv2.TypeSMIMEA:
 
 		// usage := int(rc.SmimeaUsage)
 		// selector := int(rc.SmimeaSelector)
@@ -496,7 +496,7 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		req.Selector = &selector
 		req.MatchingType = &mtype
 		req.CertificateAssociatedData = hexToBase64(f.Certificate)
-	case "SRV":
+	case dnsv2.TypeSRV:
 		// Preserve "." for the null target; strip trailing dot from real hostnames.
 		f := rc.AsSRV()
 		srvTarget := strings.TrimSuffix(f.Target, ".")
@@ -510,14 +510,14 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		req.Priority = &prio
 		req.Weight = &weight
 		req.Port = &port
-	case "SSHFP":
+	case dnsv2.TypeSSHFP:
 		f := rc.AsSSHFP()
 		algo := int(f.Algorithm)
 		fptype := int(f.Type)
 		req.Algorithm = &algo
 		req.FingerPrintType = &fptype
 		req.FingerPrint = hexToBase64(f.FingerPrint)
-	case "SVCB":
+	case dnsv2.TypeSVCB:
 		f := rc.AsSVCB()
 		req.SvcPriority = new(int(f.Priority)) // ignore:legacyfield
 		target := strings.TrimSuffix(f.Target, ".")
@@ -526,7 +526,7 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		}
 		req.TargetName = target
 		req.SvcParams = parseSvcParams(models.Svcbv2ValueToString(f.Value)) // ignore:legacyfield
-	case "TLSA":
+	case dnsv2.TypeTLSA:
 		f := rc.AsTLSA()
 		usage := int(f.Usage)
 		selector := int(f.Selector)
@@ -535,9 +535,9 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		req.Selector = &selector
 		req.MatchingType = &mtype
 		req.CertificateAssociatedData = hexToBase64(f.Certificate)
-	case "TXT":
+	case dnsv2.TypeTXT:
 		req.TextData = rc.GetTargetTXTJoined()
-	case "URI":
+	case dnsv2.TypeURI:
 		// Target: "<priority> <weight> "<target-uri>""
 
 		// parts := strings.SplitN(strings.TrimSpace(rc.GetTargetField()), " ", 3)

--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	dnsrdatav2 "codeberg.org/miekg/dns/rdata"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
@@ -233,12 +234,12 @@ func (provider *exoscaleProvider) createRecordFunc(
 		var prio int64
 
 		var target string
-		switch recordConfig.Type {
-		case "MX":
+		switch recordConfig.TypeNum {
+		case dnsv2.TypeMX:
 			f := recordConfig.AsMX()
 			target = f.Mx
 			prio = int64(f.Preference)
-		case "SRV":
+		case dnsv2.TypeSRV:
 			f := recordConfig.AsSRV()
 			prio = int64(f.Priority)
 			target = fmt.Sprintf("%d %d %s", f.Weight, f.Port, f.Target)
@@ -294,12 +295,12 @@ func (provider *exoscaleProvider) updateRecordFunc(
 		name := rc.GetLabel()
 
 		var target string
-		switch rc.Type {
-		case "MX":
+		switch rc.TypeNum {
+		case dnsv2.TypeMX:
 			mx := rc.GetRDATA().(dnsrdatav2.MX)
 			target = mx.Mx
 			record.Priority = int64(mx.Preference)
-		case "SRV":
+		case dnsv2.TypeSRV:
 			// API wants priority as separate argument. The target contains the weight, port, target.
 			srv := rc.GetRDATA().(dnsrdatav2.SRV)
 			target = fmt.Sprintf("%d %d %s", srv.Weight, srv.Port, srv.Target)

--- a/providers/fortigate/auditrecords.go
+++ b/providers/fortigate/auditrecords.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -12,13 +13,15 @@ func AuditRecords(records []*models.RecordConfig) []error {
 	var problems []error
 
 	for _, rc := range records {
-		switch rc.Type {
-		case "A", "AAAA", "CNAME":
+		switch rc.TypeNum {
+		case dnsv2.TypeA, dnsv2.TypeAAAA,
 			// Supported
-		// case "PTR":
-		// 	// FortiGate limitations: these record types are not fully supported.
-		// 	problems = append(problems,
-		// 		fmt.Errorf("record type %s is not supported by FortiGate provider (name: %s)", rc.Type, rc.GetLabelFQDN()))
+			// case "PTR":
+			// 	// FortiGate limitations: these record types are not fully supported.
+			// 	problems = append(problems,
+			// 		fmt.Errorf("record type %s is not supported by FortiGate provider (name: %s)", rc.Type, rc.GetLabelFQDN()))
+			dnsv2.TypeCNAME:
+
 		default:
 			problems = append(problems,
 				fmt.Errorf("record type %s is not supported by FortiGate provider (name: %s)", rc.Type, rc.GetLabelFQDN()))

--- a/providers/fortigate/auditrecords.go
+++ b/providers/fortigate/auditrecords.go
@@ -15,10 +15,10 @@ func AuditRecords(records []*models.RecordConfig) []error {
 		switch rc.Type {
 		case "A", "AAAA", "CNAME":
 			// Supported
-		case "PTR":
-			// FortiGate limitations: these record types are not fully supported.
-			problems = append(problems,
-				fmt.Errorf("record type %s is not supported by FortiGate provider (name: %s)", rc.Type, rc.GetLabelFQDN()))
+		// case "PTR":
+		// 	// FortiGate limitations: these record types are not fully supported.
+		// 	problems = append(problems,
+		// 		fmt.Errorf("record type %s is not supported by FortiGate provider (name: %s)", rc.Type, rc.GetLabelFQDN()))
 		default:
 			problems = append(problems,
 				fmt.Errorf("record type %s is not supported by FortiGate provider (name: %s)", rc.Type, rc.GetLabelFQDN()))

--- a/providers/gidinet/auditrecords_test.go
+++ b/providers/gidinet/auditrecords_test.go
@@ -76,8 +76,8 @@ func makeRC(rtype, label, target string) *models.RecordConfig {
 	switch rtype {
 	case "SRV":
 		return dc.MustNewRecordConfig(label, 300, rtype, 0, 0, 0, target)
-	case "TXT":
-		return dc.MustNewRecordConfig(label, 300, rtype, target)
+	// case "TXT":
+	// 	return dc.MustNewRecordConfig(label, 300, rtype, target)
 	default:
 		return dc.MustNewRecordConfig(label, 300, rtype, target)
 	}

--- a/providers/gidinet/gidinetProvider.go
+++ b/providers/gidinet/gidinetProvider.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
@@ -310,15 +311,15 @@ func toGidinetRecord(domain string, rc *models.RecordConfig) *DNSRecord {
 		Priority:   0,
 	}
 
-	switch rc.Type {
-	case "MX":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		rec.Priority = int(f.Preference)
 		// Remove trailing dot from target
 		target := f.Mx
 		rec.Data = strings.TrimSuffix(target, ".")
 
-	case "SRV":
+	case dnsv2.TypeSRV:
 		// SRV Data format: priority weight port target (with trailing dot per Gidinet spec)
 		// The Priority field is only for MX records
 		f := rc.AsSRV()
@@ -329,17 +330,17 @@ func toGidinetRecord(domain string, rc *models.RecordConfig) *DNSRecord {
 		}
 		rec.Data = fmt.Sprintf("%d %d %d %s", f.Priority, f.Weight, f.Port, target)
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		// Remove trailing dot from target
 		target := rc.AsCNAME().Target
 		rec.Data = strings.TrimSuffix(target, ".")
 
-	case "NS":
+	case dnsv2.TypeNS:
 		// Remove trailing dot from target
 		target := rc.AsNS().Ns
 		rec.Data = strings.TrimSuffix(target, ".")
 
-	case "TXT":
+	case dnsv2.TypeTXT:
 		// Chunk long TXT values into quoted segments for the API
 		rec.Data = chunkTXT(rc.GetTargetTXTJoined())
 

--- a/providers/gigahost/gigahostProvider.go
+++ b/providers/gigahost/gigahostProvider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
@@ -283,8 +284,8 @@ func recordConfigToRequest(rc *models.RecordConfig) *recordRequest {
 		RecordType: rc.Type,
 		RecordTTL:  rc.TTL,
 	}
-	switch rc.Type {
-	case "MX":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		r.RecordPrio = new(f.Preference)
 		r.RecordValue = strings.TrimSuffix(f.Mx, ".")
@@ -292,7 +293,7 @@ func recordConfigToRequest(rc *models.RecordConfig) *recordRequest {
 	// 	// Send hostname targets without a trailing dot; the API normalizes as
 	// 	// needed and reads are re-dotted in nativeToRecordConfig.
 	// 	r.RecordValue = strings.TrimSuffix(rc.GetTargetField(), ".")
-	case "TXT":
+	case dnsv2.TypeTXT:
 		// txt := rc.GetTargetTXTJoined()
 		// // The API requires values over 255 octets to be sent as RFC1035
 		// // quoted 255-octet chunks: `"aaa...aaa" "bbb"`. Shorter values are

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -759,12 +759,12 @@ func (c *hednsProvider) editZoneRecord(zoneID uint64, recordID uint64, rc *model
 	}
 
 	// Work out the content
-	switch rc.Type {
-	case "MX":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		values.Set("Priority", strconv.FormatUint(uint64(f.Preference), 10))
 		values.Set("Content", f.Mx)
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		values.Del("Content")
 		values.Set("Target", f.Target)

--- a/providers/hostingde/types.go
+++ b/providers/hostingde/types.go
@@ -6,6 +6,7 @@ import (
 	"net" // Needed for communicating with provider API.
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/pkg/errors"
 )
@@ -177,8 +178,8 @@ func recordToNative(rc *models.RecordConfig) *record {
 		TTL:     rc.TTL,
 	}
 
-	switch rc.Type {
-	case "TXT":
+	switch rc.TypeNum {
+	case dnsv2.TypeTXT:
 		// TODO(tlim): I think all of this can be replaced by:
 		// record.Content = rc.AsTXT().String()
 
@@ -192,7 +193,7 @@ func recordToNative(rc *models.RecordConfig) *record {
 		}
 
 		record.Content = strings.Join(txtStrings, " ")
-	case "MX":
+	case dnsv2.TypeMX:
 		mx := rc.AsMX()
 		record.Priority = mx.Preference
 		record.Content = strings.TrimSuffix(mx.Mx, ".")
@@ -200,7 +201,7 @@ func recordToNative(rc *models.RecordConfig) *record {
 			record.Type = "NULLMX"
 			record.Priority = 10
 		}
-	case "SRV":
+	case dnsv2.TypeSRV:
 		srv := rc.AsSRV()
 		record.Priority = srv.Priority
 		record.Content = fmt.Sprintf("%d %d %s", srv.Weight, srv.Port, strings.TrimSuffix(srv.Target, "."))

--- a/providers/infomaniak/infomaniakProvider.go
+++ b/providers/infomaniak/infomaniakProvider.go
@@ -84,8 +84,8 @@ func toRecordConfig(dc *models.DomainConfig, r dnsRecord) (*models.RecordConfig,
 	var rc *models.RecordConfig
 	var err error
 	switch rtype {
-	case "A", "AAAA":
-		rc, err = dc.NewRecordConfig(label, ttl, rtype, target)
+	// case "A", "AAAA":
+	// 	rc, err = dc.NewRecordConfig(label, ttl, rtype, target)
 
 	case "CNAME", "NS", "DNAME":
 		rc, err = dc.NewRecordConfig(label, ttl, rtype, addTrailingDot(target))

--- a/providers/infomaniak/infomaniakProvider.go
+++ b/providers/infomaniak/infomaniakProvider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
@@ -164,28 +165,28 @@ func fromRecordConfig(rc *models.RecordConfig) *dnsRecordCreate {
 
 	// Get the target in the format expected by Infomaniak API
 	var target string
-	switch rc.Type {
+	switch rc.TypeNum {
 	// case "A":
 	// 	target = rc.AsA().Addr.String()
 	// case "AAAA":
 	// 	target = rc.AsAAAA().Addr.String()
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		target = strings.TrimSuffix(rc.AsCNAME().Target, ".")
-	case "NS":
+	case dnsv2.TypeNS:
 		target = strings.TrimSuffix(rc.AsNS().Ns, ".")
-	case "DNAME":
+	case dnsv2.TypeDNAME:
 		target = strings.TrimSuffix(rc.AsDNAME().Target, ".")
 
-	case "MX":
+	case dnsv2.TypeMX:
 		// Format: "priority target" (without trailing dot)
 		f := rc.AsMX()
 		target = fmt.Sprintf("%d %s", f.Preference, strings.TrimSuffix(f.Mx, "."))
 
-	case "TXT":
+	case dnsv2.TypeTXT:
 		target = rc.GetTargetTXTJoined()
 
-	case "SRV":
+	case dnsv2.TypeSRV:
 		// Format: "priority weight port target" (without trailing dot)
 		f := rc.AsSRV()
 		target = fmt.Sprintf("%d %d %d %s", f.Priority, f.Weight, f.Port, strings.TrimSuffix(f.Target, "."))
@@ -224,51 +225,51 @@ func fromRecordConfig(rc *models.RecordConfig) *dnsRecordCreate {
 func toRecordUpdate(rc *models.RecordConfig) *dnsRecordUpdate {
 	// Get the target in the format expected by Infomaniak API
 	var target string
-	switch rc.Type {
-	case "A":
+	switch rc.TypeNum {
+	case dnsv2.TypeA:
 		target = rc.AsA().Addr.String()
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		target = rc.AsAAAA().Addr.String()
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		// Remove trailing dot for the API
 		target = strings.TrimSuffix(rc.AsCNAME().Target, ".")
-	case "NS":
+	case dnsv2.TypeNS:
 		target = strings.TrimSuffix(rc.AsNS().Ns, ".")
-	case "DNAME":
+	case dnsv2.TypeDNAME:
 		target = strings.TrimSuffix(rc.AsDNAME().Target, ".")
 
-	case "MX":
+	case dnsv2.TypeMX:
 		// Format: "priority target" (without trailing dot)
 		f := rc.AsMX()
 		target = fmt.Sprintf("%d %s", f.Preference, strings.TrimSuffix(f.Mx, "."))
 
-	case "TXT":
+	case dnsv2.TypeTXT:
 		target = rc.GetTargetTXTJoined()
 
-	case "SRV":
+	case dnsv2.TypeSRV:
 		// Format: "priority weight port target" (without trailing dot)
 		f := rc.AsSRV()
 		target = fmt.Sprintf("%d %d %d %s", f.Priority, f.Weight, f.Port, strings.TrimSuffix(f.Target, "."))
 
-	case "CAA":
+	case dnsv2.TypeCAA:
 		// Format: "flags tag value"
 		f := rc.AsCAA()
 		target = fmt.Sprintf("%d %s %s", f.Flag, f.Tag, f.Value)
 
-	case "DS":
+	case dnsv2.TypeDS:
 		// Format: "keytag algorithm digesttype digest"
 		f := rc.AsDS()
 		target = fmt.Sprintf("%d %d %d %s", f.KeyTag, f.Algorithm, f.DigestType, f.Digest)
 
-	case "SSHFP":
+	case dnsv2.TypeSSHFP:
 		// Format: "algorithm fingerprint_type fingerprint"
 		f := rc.AsSSHFP()
 		target = f.String()
 		// If that doesn't work, try this:
 		//target = fmt.Sprintf("%d %d %s", f.Algorithm, f.Type, f.FingerPrint)
 
-	case "TLSA":
+	case dnsv2.TypeTLSA:
 		// Format: "usage selector matching_type certificate"
 		f := rc.AsTLSA()
 		target = fmt.Sprintf("%d %d %d %s", f.Usage, f.Selector, f.MatchingType, f.Certificate)

--- a/providers/inwx/inwxProvider.go
+++ b/providers/inwx/inwxProvider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
+	privatetypes "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
 	"github.com/fatih/color"
 	"github.com/nrdcg/goinwx"
@@ -207,7 +208,7 @@ func makeNameserverRecordRequest(domain string, rec *models.RecordConfig) *goinw
 		TTL:    int(rec.TTL),
 	}
 
-	switch rType := rec.Type; rType {
+	switch rType := rec.TypeNum; rType {
 	/*
 	   INWX is a little bit special for CNAME, NS, MX and SRV records:
 	   The API will not accept any target with a final dot but will
@@ -215,19 +216,19 @@ func makeNameserverRecordRequest(domain string, rec *models.RecordConfig) *goinw
 	   Records with empty targets (i.e., records with target ".")
 	   are allowed.
 	*/
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		f := rec.AsCNAME()
 		content := f.Target
 		req.Content = content[:len(content)-1]
-	case "NS":
+	case dnsv2.TypeNS:
 		f := rec.AsNS()
 		content := f.Ns
 		req.Content = content[:len(content)-1]
-	case "ALIAS":
+	case privatetypes.TypeALIAS:
 		f := rec.AsALIAS()
 		content := f.Target
 		req.Content = content[:len(content)-1]
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rec.AsMX()
 		req.Priority = int(f.Preference)
 		content := f.Mx
@@ -236,7 +237,7 @@ func makeNameserverRecordRequest(domain string, rec *models.RecordConfig) *goinw
 		} else {
 			req.Content = content[:len(content)-1]
 		}
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rec.AsSRV()
 		req.Priority = int(f.Priority)
 		content := f.Target
@@ -245,7 +246,7 @@ func makeNameserverRecordRequest(domain string, rec *models.RecordConfig) *goinw
 		} else {
 			req.Content = fmt.Sprintf("%d %d %v", f.Weight, f.Port, content[:len(content)-1])
 		}
-	case "TXT":
+	case dnsv2.TypeTXT:
 		req.Content = rec.GetTargetTXTJoined()
 
 	default:

--- a/providers/joker/records.go
+++ b/providers/joker/records.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 )
@@ -324,21 +325,21 @@ func (api *jokerProvider) recordsToZoneFormat(_ string, records models.Records) 
 		// Using that would simplify many of the cases. I've modified the easy ones.
 
 		// Joker format: <label> <type> <pri> <target> <ttl> (valid-from/valid-to omitted when 0)
-		switch rc.Type {
-		case "A", "AAAA":
+		switch rc.TypeNum {
+		case dnsv2.TypeA, dnsv2.TypeAAAA:
 			line := fmt.Sprintf("%s %s 0 %s %d", label, rc.Type, rc.GetRDATA().String(), rc.TTL)
 			lines = append(lines, line)
-		case "CNAME":
+		case dnsv2.TypeCNAME:
 			line := fmt.Sprintf("%s %s 0 %s %d", label, rc.Type, rc.AsCNAME().Target, rc.TTL)
 			lines = append(lines, line)
-		case "NS":
+		case dnsv2.TypeNS:
 			line := fmt.Sprintf("%s %s 0 %s %d", label, rc.Type, rc.AsNS().Ns, rc.TTL)
 			lines = append(lines, line)
-		case "MX":
+		case dnsv2.TypeMX:
 			f := rc.AsMX()
 			line := fmt.Sprintf("%s %s %d %s %d", label, rc.Type, f.Preference, f.Mx, rc.TTL)
 			lines = append(lines, line)
-		case "TXT":
+		case dnsv2.TypeTXT:
 			// Fix TXT record escaping - escape backslashes first, then quotes
 			content := rc.GetTargetTXTJoined()
 			content = strings.ReplaceAll(content, "\\", "\\\\")
@@ -351,17 +352,17 @@ func (api *jokerProvider) recordsToZoneFormat(_ string, records models.Records) 
 			// line := fmt.Sprintf("%s TXT 0 \"%s\" %d", label, ts, rc.TTL)
 
 			lines = append(lines, line)
-		case "SRV":
+		case dnsv2.TypeSRV:
 			f := rc.AsSRV()
 			target := fmt.Sprintf("%s:%d", f.Target, f.Port)
 			priority := fmt.Sprintf("%d/%d", f.Priority, f.Weight)
 			line := fmt.Sprintf("%s %s %s %s %d", label, rc.Type, priority, target, rc.TTL)
 			lines = append(lines, line)
-		case "CAA":
+		case dnsv2.TypeCAA:
 			f := rc.AsCAA()
 			line := fmt.Sprintf("%s %s %d %s \"%s\" %d", label, rc.Type, f.Flag, f.Tag, f.Value, rc.TTL)
 			lines = append(lines, line)
-		case "NAPTR":
+		case dnsv2.TypeNAPTR:
 			// NAPTR format for Joker: order/preference replacement ttl 0 0 "flags" "service" "regex"
 			f := rc.AsNAPTR()
 			priority := fmt.Sprintf("%d/%d", f.Order, f.Preference)

--- a/providers/linode/linodeProvider.go
+++ b/providers/linode/linodeProvider.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
@@ -338,8 +339,8 @@ func toReq(dc *models.DomainConfig, rc *models.RecordConfig) (*recordEditRequest
 	}
 
 	// Linode uses the same property for MX and SRV priority
-	switch rc.Type {
-	case "MX":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		req.Priority = new(int(f.Preference))
 		target := fixTarget(f.Mx, dc.Name)
@@ -349,7 +350,7 @@ func toReq(dc *models.DomainConfig, rc *models.RecordConfig) (*recordEditRequest
 		}
 		req.Target = target
 
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		req.Priority = new(int(f.Priority))
 		req.Weight = int(f.Weight)
@@ -368,14 +369,14 @@ func toReq(dc *models.DomainConfig, rc *models.RecordConfig) (*recordEditRequest
 		req.Name = ""
 		req.Target = f.Target
 
-	case "TXT":
+	case dnsv2.TypeTXT:
 		req.Target = rc.GetTargetTXTJoined()
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		f := rc.AsCNAME()
 		req.Target = fixTarget(f.Target, dc.Name)
 
-	case "CAA":
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		req.Tag = f.Tag
 		req.Target = f.Value

--- a/providers/loopia/client.go
+++ b/providers/loopia/client.go
@@ -115,8 +115,8 @@ func NewClient(apiUser, apiPassword string, region string, modifyns bool, fetchn
 		DefaultBaseURL = DefaultBaseNOURL
 	case "rs":
 		DefaultBaseURL = DefaultBaseRSURL
-	case "se":
-		DefaultBaseURL = DefaultBaseSEURL
+	// case "se":
+	// 	DefaultBaseURL = DefaultBaseSEURL
 	default:
 		DefaultBaseURL = DefaultBaseSEURL
 	}

--- a/providers/loopia/convert.go
+++ b/providers/loopia/convert.go
@@ -15,13 +15,13 @@ func nativeToRecord(zr zoneRecord, dc *models.DomainConfig, subdomain string) (r
 	ttl := record.TTL
 
 	switch rtype := record.Type; rtype {
-	case "CAA":
-		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, record.Rdata)
+	// case "CAA":
+	// 	rc, err = dc.NewRecordConfigParse(label, ttl, rtype, record.Rdata)
 	case "MX":
 		// See dnscontrol issue #2218
 		rc, err = dc.NewRecordConfig(label, ttl, rtype, record.Priority, dc.ToFqdnWithDot(record.Rdata))
-	case "NAPTR":
-		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, record.Rdata)
+	// case "NAPTR":
+	// 	rc, err = dc.NewRecordConfigParse(label, ttl, rtype, record.Rdata)
 	case "TXT":
 		rc, err = dc.NewRecordConfig(label, ttl, rtype, record.Rdata)
 	default:

--- a/providers/luadns/luadnsProvider.go
+++ b/providers/luadns/luadnsProvider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	api "github.com/luadns/luadns-go"
 	"golang.org/x/time/rate"
 
@@ -317,10 +318,10 @@ func recordsToNative(rc []*models.RecordConfig) []*api.RR {
 			Type: rec.Type,
 			TTL:  rec.TTL,
 		}
-		switch rtype := rec.Type; rtype {
-		case "TXT":
+		switch rtype := rec.TypeNum; rtype {
+		case dnsv2.TypeTXT:
 			r.Content = rec.GetTargetTXTJoined()
-		case "HTTPS":
+		case dnsv2.TypeHTTPS:
 			// The RDATA's String() quotes every SvcParam value (e.g. port="80",
 			// alpn="h2,h3"), which LuaDNS's strict SVCB parser rejects. Build the
 			// content with unquoted params (port=80, alpn=h2,h3) instead.

--- a/providers/mikrotik/convert.go
+++ b/providers/mikrotik/convert.go
@@ -91,37 +91,37 @@ func recordToNative(rc *models.RecordConfig) (*dnsStaticRecord, error) {
 		TTL:  formatMikrotikDuration(rc.TTL),
 	}
 
-	switch rc.Type {
-	case "A":
+	switch rc.TypeNum {
+	case dnsv2.TypeA:
 		nr.Type = "A"
 		nr.Address = rc.AsA().String()
 
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		nr.Type = "AAAA"
 		nr.Address = rc.AsAAAA().String()
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		nr.Type = "CNAME"
 		nr.CName = stripTrailingDot(rc.AsCNAME().Target)
 
-	case "MIKROTIK_FWD":
+	case privatetypes.TypeMIKROTIKFWD:
 		nr.Type = "FWD"
 		nr.ForwardTo = rc.AsMIKROTIKFWD().ForwardTo
 
-	case "MIKROTIK_NXDOMAIN":
+	case privatetypes.TypeMIKROTIKNXDOMAIN:
 		nr.Type = "NXDOMAIN"
 		// NXDOMAIN has no target field — only name matters.
 
-	case "MX":
+	case dnsv2.TypeMX:
 		nr.Type = "MX"
 		nr.MxExchange = stripTrailingDot(rc.AsMX().Mx)
 		nr.MxPreference = strconv.FormatUint(uint64(rc.AsMX().Preference), 10)
 
-	case "NS":
+	case dnsv2.TypeNS:
 		nr.Type = "NS"
 		nr.NS = stripTrailingDot(rc.AsNS().String())
 
-	case "SRV":
+	case dnsv2.TypeSRV:
 		nr.Type = "SRV"
 		srv := rc.AsSRV()
 		nr.SrvTarget = stripTrailingDot(srv.Target)
@@ -129,7 +129,7 @@ func recordToNative(rc *models.RecordConfig) (*dnsStaticRecord, error) {
 		nr.SrvPriority = strconv.FormatUint(uint64(srv.Priority), 10)
 		nr.SrvWeight = strconv.FormatUint(uint64(srv.Weight), 10)
 
-	case "TXT":
+	case dnsv2.TypeTXT:
 		nr.Type = "TXT"
 		nr.Text = rc.GetTargetTXTJoined()
 

--- a/providers/namecheap/namecheapProvider.go
+++ b/providers/namecheap/namecheapProvider.go
@@ -366,10 +366,10 @@ func (n *namecheapProvider) generateRecords(dc *models.DomainConfig) error {
 				TTL:  int(rc.TTL),
 			}
 
-			switch rtype := rc.Type; rtype {
-			case "CAA":
+			switch rtype := rc.TypeNum; rtype {
+			case dnsv2.TypeCAA:
 				rec.Address = rc.GetRDATA().String()
-			case "MX":
+			case dnsv2.TypeMX:
 				f := rc.AsMX()
 				rec.MXPref = int(f.Preference)
 				rec.Address = f.Mx

--- a/providers/netbird/convert.go
+++ b/providers/netbird/convert.go
@@ -3,6 +3,7 @@ package netbird
 import (
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -55,12 +56,12 @@ func recordConfigToNative(rc *models.RecordConfig, _ string) *CreateRecordReques
 	}
 
 	var target string
-	switch rc.Type {
-	case "A":
+	switch rc.TypeNum {
+	case dnsv2.TypeA:
 		target = rc.AsA().Addr.String()
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		target = rc.AsAAAA().Addr.String()
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		target = rc.AsCNAME().Target
 		// Remove trailing dot
 		if len(target) > 0 && target[len(target)-1] == '.' {

--- a/providers/netlify/netlifyProvider.go
+++ b/providers/netlify/netlifyProvider.go
@@ -256,23 +256,23 @@ func toReq(rc *models.RecordConfig) *dnsRecordCreate {
 		TTL:      int64(rc.TTL),
 	}
 
-	switch rc.Type {
-	case "CAA":
+	switch rc.TypeNum {
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		r.Tag = f.Tag
 		r.Flag = int64(f.Flag)
 		r.Value = f.Value
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		r.Priority = int64(f.Preference)
 		r.Value = f.Mx
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		r.Priority = int64(f.Priority)
 		r.Port = int64(f.Port)
 		r.Weight = int64(f.Weight)
 		r.Value = f.Target
-	case "TXT":
+	case dnsv2.TypeTXT:
 		r.Value = rc.GetTargetTXTJoined()
 	default:
 		r.Value = rc.GetRDATA().String()

--- a/providers/ns1/records.go
+++ b/providers/ns1/records.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
@@ -132,14 +133,14 @@ func buildRecord(recs models.Records, domain string, id string) *dns.Record {
 		Filters: []*filter.Filter{}, // Work through a bug in the NS1 API library that causes 400 Input validation failed (Value None for field '<obj>.filters' is not of type array)
 	}
 	for _, r := range recs {
-		switch r.Type {
-		case "MX":
+		switch r.TypeNum {
+		case dnsv2.TypeMX:
 			f := r.AsMX()
 			//rec.AddAnswer(&dns.Answer{Rdata: strings.Fields(fmt.Sprintf("%d %v", r.MxPreference, r.GetTargetField()))})
 			rec.AddAnswer(&dns.Answer{Rdata: []string{strconv.FormatInt(int64(f.Preference), 10), f.Mx}})
-		case "TXT":
+		case dnsv2.TypeTXT:
 			rec.AddAnswer(&dns.Answer{Rdata: []string{r.GetTargetTXTJoined()}})
-		case "CAA":
+		case dnsv2.TypeCAA:
 			f := r.AsCAA()
 			rec.AddAnswer(&dns.Answer{
 				Rdata: []string{
@@ -148,7 +149,7 @@ func buildRecord(recs models.Records, domain string, id string) *dns.Record {
 					f.Value,
 				},
 			})
-		case "SRV":
+		case dnsv2.TypeSRV:
 			f := r.AsSRV()
 			rec.AddAnswer(&dns.Answer{Rdata: []string{
 				strconv.FormatInt(int64(f.Priority), 10),
@@ -161,7 +162,7 @@ func buildRecord(recs models.Records, domain string, id string) *dns.Record {
 			//
 			// Here's the original for comparison:
 			// rec.AddAnswer(&dns.Answer{Rdata: strings.Fields(fmt.Sprintf("%d %d %d %v", r.SrvPriority, r.SrvWeight, r.SrvPort, r.GetTargetField()))})
-		case "NAPTR":
+		case dnsv2.TypeNAPTR:
 			f := r.AsNAPTR()
 			rec.AddAnswer(&dns.Answer{Rdata: []string{
 				strconv.Itoa(int(f.Order)),
@@ -171,7 +172,7 @@ func buildRecord(recs models.Records, domain string, id string) *dns.Record {
 				f.Regexp,
 				f.Replacement,
 			}})
-		case "DS":
+		case dnsv2.TypeDS:
 			f := r.AsDS()
 			rec.AddAnswer(&dns.Answer{Rdata: []string{
 				strconv.Itoa(int(f.KeyTag)),
@@ -179,21 +180,21 @@ func buildRecord(recs models.Records, domain string, id string) *dns.Record {
 				strconv.Itoa(int(f.DigestType)),
 				f.Digest,
 			}})
-		case "SVCB":
+		case dnsv2.TypeSVCB:
 			f := r.AsSVCB()
 			rec.AddAnswer(&dns.Answer{Rdata: []string{
 				strconv.Itoa(int(f.Priority)),
 				f.Target,
 				models.Svcbv2ValueToString(f.Value),
 			}})
-		case "HTTPS":
+		case dnsv2.TypeHTTPS:
 			f := r.AsHTTPS()
 			rec.AddAnswer(&dns.Answer{Rdata: []string{
 				strconv.Itoa(int(f.Priority)),
 				f.Target,
 				models.Svcbv2ValueToString(f.Value),
 			}})
-		case "TLSA":
+		case dnsv2.TypeTLSA:
 			f := r.AsTLSA()
 			rec.AddAnswer(&dns.Answer{Rdata: []string{
 				strconv.Itoa(int(f.Usage)),

--- a/providers/openwrt/convert.go
+++ b/providers/openwrt/convert.go
@@ -114,18 +114,18 @@ func toNative(rc *models.RecordConfig) (nativeRecord, string, error) {
 	var err error
 
 	// omits .type and .name
-	switch rc.Type {
-	case "A", "AAAA":
+	switch rc.TypeNum {
+	case dnsv2.TypeA, dnsv2.TypeAAAA:
 		recType = "domain"
 		r.Name = rc.NameFQDN
 		r.IP = rc.GetTargetIP().String()
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		recType = "cname"
 		r.Cname = rc.NameFQDN
 		r.Target = rc.AsCNAME().Target
 
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		recType = "srvhost"
 		r.Srv = rc.NameFQDN
@@ -134,7 +134,7 @@ func toNative(rc *models.RecordConfig) (nativeRecord, string, error) {
 		r.Port = strconv.Itoa(int(f.Port))
 		r.Target = f.Target
 
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		recType = "mxhost"
 		r.Domain = rc.NameFQDN

--- a/providers/packetframe/packetframeProvider.go
+++ b/providers/packetframe/packetframeProvider.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
@@ -193,8 +194,8 @@ func toReq(zoneID string, rc *models.RecordConfig) (*domainRecord, error) {
 		Zone:  zoneID,
 	}
 
-	switch rc.Type {
-	case "TXT":
+	switch rc.TypeNum {
+	case dnsv2.TypeTXT:
 		req.Value = rc.GetTargetTXTJoined()
 	default:
 		req.Value = rc.GetRDATA().String()

--- a/providers/porkbun/porkbunProvider.go
+++ b/providers/porkbun/porkbunProvider.go
@@ -452,8 +452,8 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 	}
 
 	switch rc.Type { // #rtype_variations
-	case "A", "AAAA", "NS", "ALIAS", "CNAME":
-		req["content"] = rc.GetRDATA().String()
+	// case "A", "AAAA", "NS", "ALIAS", "CNAME":
+	// 	req["content"] = rc.GetRDATA().String()
 	case "TXT":
 		req["content"] = rc.GetTargetTXTJoined()
 	case "MX":

--- a/providers/porkbun/porkbunProvider.go
+++ b/providers/porkbun/porkbunProvider.go
@@ -451,33 +451,33 @@ func toReq(rc *models.RecordConfig) (requestParams, error) {
 		req["name"] = ""
 	}
 
-	switch rc.Type { // #rtype_variations
+	switch rc.TypeNum { // #rtype_variations
 	// case "A", "AAAA", "NS", "ALIAS", "CNAME":
 	// 	req["content"] = rc.GetRDATA().String()
-	case "TXT":
+	case dnsv2.TypeTXT:
 		req["content"] = rc.GetTargetTXTJoined()
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		req["prio"] = strconv.Itoa(int(f.Preference))
 		req["content"] = f.Mx
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		req["prio"] = strconv.Itoa(int(f.Priority))
 		req["content"] = fmt.Sprintf("%d %d %s", f.Weight, f.Port, f.Target)
-	case "CAA":
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		req["content"] = fmt.Sprintf("%d %s \"%s\"", f.Flag, f.Tag, f.Value)
-	case "TLSA":
+	case dnsv2.TypeTLSA:
 		f := rc.AsTLSA()
 		req["content"] = fmt.Sprintf("%d %d %d %s",
 			f.Usage, f.Selector, f.MatchingType, f.Certificate)
-	case "HTTPS":
+	case dnsv2.TypeHTTPS:
 		fallthrough
-	case "SVCB":
+	case dnsv2.TypeSVCB:
 		f := rc.AsSVCB()
 		req["content"] = fmt.Sprintf("%d %s %s",
 			f.Priority, f.Target, models.Svcbv2ValueToString(f.Value))
-	case "SSHFP":
+	case dnsv2.TypeSSHFP:
 		req["content"] = rc.AsSSHFP().String()
 	default:
 		req["content"] = rc.GetRDATA().String()

--- a/providers/realtimeregister/realtimeregisterProvider.go
+++ b/providers/realtimeregister/realtimeregisterProvider.go
@@ -252,8 +252,8 @@ func toRecord(rc *models.RecordConfig) Record {
 		TTL:  int(rc.TTL),
 	}
 
-	switch rtype := rc.Type; rtype {
-	case "SRV":
+	switch rtype := rc.TypeNum; rtype {
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		record.Priority = parsePriority(int(f.Priority))
 		t := removeTrailingDot(f.Target)
@@ -261,15 +261,15 @@ func toRecord(rc *models.RecordConfig) Record {
 			t = "."
 		}
 		record.Content = fmt.Sprintf("%d %d %s", f.Weight, f.Port, t)
-	case "NAPTR", "SSHFP", "TLSA", "CAA":
+	case dnsv2.TypeNAPTR, dnsv2.TypeSSHFP, dnsv2.TypeTLSA, dnsv2.TypeCAA:
 		record.Content = rc.GetRDATA().String()
-	case "TXT":
+	case dnsv2.TypeTXT:
 		//record.Content = addEscapeChars(record.Content)
 		record.Content = rc.AsTXT().String()
-	case "DS":
+	case dnsv2.TypeDS:
 		f := rc.AsDS()
 		record.Content = fmt.Sprintf("%d %d %d %s", f.KeyTag, f.Algorithm, f.DigestType, strings.ToUpper(f.Digest))
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		// Workaround for 0 prio and 'omitempty' restrictions on json marshalling
 		if f.Preference == 0 {
@@ -284,7 +284,7 @@ func toRecord(rc *models.RecordConfig) Record {
 		}
 		record.Content = target
 
-	case "LOC":
+	case dnsv2.TypeLOC:
 		parts := strings.Fields(rc.GetRDATA().String())
 		degrees1, _ := strconv.ParseUint(parts[0], 10, 32)
 		minutes1, _ := strconv.ParseUint(parts[1], 10, 32)
@@ -298,10 +298,10 @@ func toRecord(rc *models.RecordConfig) Record {
 			degrees1, minutes1, parts[2], parts[3], degrees2, minutes2,
 			parts[6], parts[7], altitude, size, hp, vp,
 		)
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		record.Content = removeTrailingDot(rc.AsCNAME().Target)
 
-	case "A", "AAAA":
+	case dnsv2.TypeA, dnsv2.TypeAAAA:
 		record.Content = rc.GetRDATA().String()
 
 	default:

--- a/providers/sakuracloud/convert.go
+++ b/providers/sakuracloud/convert.go
@@ -3,6 +3,7 @@ package sakuracloud
 import (
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -43,10 +44,10 @@ func toNative(rc *models.RecordConfig) domainRecord {
 		rr.TTL = rc.TTL
 	}
 
-	switch rc.Type {
-	case "TXT":
+	switch rc.TypeNum {
+	case dnsv2.TypeTXT:
 		rr.RData = rc.GetTargetTXTJoined()
-	case "CAA":
+	case dnsv2.TypeCAA:
 		// SakuraCloud requires the CAA value to remain quoted, e.g.
 		// `0 issue "letsencrypt.org"`. The generic quote-stripping above
 		// produces `0 issue letsencrypt.org`, which the API rejects as

--- a/providers/softlayer/softlayerProvider.go
+++ b/providers/softlayer/softlayerProvider.go
@@ -290,8 +290,8 @@ func (s *softlayerProvider) updateRecordFunc(existing *datatypes.Dns_Domain_Reso
 		changes := false
 		var err error
 
-		switch desired.Type {
-		case "MX":
+		switch desired.TypeNum {
+		case dnsv2.TypeMX:
 			df := desired.AsMX()
 			preference := int(df.Preference)
 			service := services.GetDnsDomainResourceRecordMxTypeService(s.Session)
@@ -325,7 +325,7 @@ func (s *softlayerProvider) updateRecordFunc(existing *datatypes.Dns_Domain_Reso
 
 			_, err = service.Id(*existing.Id).EditObject(&updated)
 
-		case "SRV":
+		case dnsv2.TypeSRV:
 			df := desired.AsSRV()
 			priority, weight, port := int(df.Priority), int(df.Weight), int(df.Port)
 			service := services.GetDnsDomainResourceRecordSrvTypeService(s.Session)

--- a/providers/tencentdns/convert.go
+++ b/providers/tencentdns/convert.go
@@ -46,21 +46,21 @@ func nativeToRecord(r *dnspod.RecordListItem, dc *models.DomainConfig) (*models.
 		}
 		fmt.Printf("DEBUG TENCENT: MX apip=%v p=%v v=%q\n", *r.MX, p, val)
 		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeMX, p, val)
-	case "TXT":
-		// TODO(tlim): A few ways that might fix
-		//--- FAIL: TestDNSProviders/oomkill.com/27:complex_TXT:a_256-byte_TXT (2.47s)
-		//--- FAIL: TestDNSProviders/oomkill.com/28:TXT_backslashes:TXT_with_backslashs (4.47s)
-
-		// Try this first:
-		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, val)
-
-		// Try this if the other fails: (probably won't work)
-		//rc, err = dc.NewRecordConfig(label, ttl, rtype, val)
-
-		// Or this?
-		//rc, err = dc.NewRecordConfig(label, ttl, rtype, txtutil.EncodeQuoted(val))
-		// You'll need to add this to imports above:
-		// "github.com/DNSControl/dnscontrol/v5/pkg/txtutil"
+	// case "TXT":
+	// 	// TODO(tlim): A few ways that might fix
+	// 	//--- FAIL: TestDNSProviders/oomkill.com/27:complex_TXT:a_256-byte_TXT (2.47s)
+	// 	//--- FAIL: TestDNSProviders/oomkill.com/28:TXT_backslashes:TXT_with_backslashs (4.47s)
+	//
+	// 	// Try this first:
+	// 	rc, err = dc.NewRecordConfigParse(label, ttl, rtype, val)
+	//
+	// 	// Try this if the other fails: (probably won't work)
+	// 	//rc, err = dc.NewRecordConfig(label, ttl, rtype, val)
+	//
+	// 	// Or this?
+	// 	//rc, err = dc.NewRecordConfig(label, ttl, rtype, txtutil.EncodeQuoted(val))
+	// 	// You'll need to add this to imports above:
+	// 	// "github.com/DNSControl/dnscontrol/v5/pkg/txtutil"
 
 	// case "ALIAS":
 	// 	rc, err = dc.NewRecordConfig(label, ttl, rtype, val)

--- a/providers/unifi/api.go
+++ b/providers/unifi/api.go
@@ -394,8 +394,8 @@ func (c *unifiClient) useNewAPI() bool {
 	switch c.apiVersion {
 	case APIVersionNew:
 		return true
-	case APIVersionLegacy:
-		return false
+	// case APIVersionLegacy:
+	// 	return false
 	case APIVersionAuto:
 		c.detectAPIAvailability()
 		if c.newAPIAvailable != nil && *c.newAPIAvailable {

--- a/providers/unifi/types.go
+++ b/providers/unifi/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -139,45 +140,45 @@ func recordToLegacyMap(rc *models.RecordConfig) (map[string]any, error) {
 		"value":       "",
 	}
 
-	switch rc.Type {
-	case "A":
+	switch rc.TypeNum {
+	case dnsv2.TypeA:
 		m["value"] = rc.AsA().Addr.String()
 		// A records can have TTL
 		if rc.TTL > 0 {
 			m["ttl"] = int(rc.TTL)
 		}
 
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		m["value"] = rc.AsAAAA().Addr.String()
 		// AAAA records can have TTL
 		if rc.TTL > 0 {
 			m["ttl"] = int(rc.TTL)
 		}
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		m["value"] = strings.TrimSuffix(rc.AsCNAME().Target, ".")
 		// CNAME records can have TTL
 		if rc.TTL > 0 {
 			m["ttl"] = int(rc.TTL)
 		}
 
-	case "NS":
+	case dnsv2.TypeNS:
 		m["value"] = strings.TrimSuffix(rc.AsNS().Ns, ".")
 		// NS records can have TTL
 		if rc.TTL > 0 {
 			m["ttl"] = int(rc.TTL)
 		}
 
-	case "MX":
+	case dnsv2.TypeMX:
 		// MX records: only enabled, key, record_type, value, priority allowed
 		m["value"] = strings.TrimSuffix(rc.AsMX().Mx, ".")
 		m["priority"] = int(rc.AsMX().Preference)
 
-	case "TXT":
+	case dnsv2.TypeTXT:
 		// TXT records: only enabled, key, record_type, value allowed
 		m["value"] = rc.GetTargetTXTJoined()
 
-	case "SRV":
+	case dnsv2.TypeSRV:
 		// SRV records: enabled, key, record_type, value, priority, weight, port allowed
 		f := rc.AsSRV()
 		m["value"] = strings.TrimSuffix(f.Target, ".")
@@ -289,8 +290,8 @@ func recordToNew(rc *models.RecordConfig) (*dnsPolicyRecord, error) {
 
 	// The new API only accepts ttlSeconds for A/AAAA/CNAME; sending it for
 	// MX/TXT/SRV is rejected with "Unknown request body property '$.ttlSeconds'".
-	switch rc.Type {
-	case "A", "AAAA", "CNAME":
+	switch rc.TypeNum {
+	case dnsv2.TypeA, dnsv2.TypeAAAA, dnsv2.TypeCNAME:
 		if rc.TTL > 0 {
 			r.TTLSeconds = int(rc.TTL)
 		} else {
@@ -298,30 +299,30 @@ func recordToNew(rc *models.RecordConfig) (*dnsPolicyRecord, error) {
 		}
 	}
 
-	switch rc.Type {
-	case "A":
+	switch rc.TypeNum {
+	case dnsv2.TypeA:
 		r.Type = NewAPITypeA
 		r.IPv4Address = rc.AsA().Addr.String()
 
-	case "AAAA":
+	case dnsv2.TypeAAAA:
 		r.Type = NewAPITypeAAAA
 		r.IPv6Address = rc.AsAAAA().Addr.String()
 
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		r.Type = NewAPITypeCNAME
 		r.TargetDomain = strings.TrimSuffix(rc.AsCNAME().Target, ".")
 
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		r.Type = NewAPITypeMX
 		r.Priority = int(f.Preference)
 		r.MailServerDomain = strings.TrimSuffix(f.Mx, ".")
 
-	case "TXT":
+	case dnsv2.TypeTXT:
 		r.Type = NewAPITypeTXT
 		r.Text = rc.GetTargetTXTJoined()
 
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		r.Type = NewAPITypeSRV
 		// The new API wants the "_service._proto.name" label split apart, e.g.

--- a/providers/unifi/unifiProvider.go
+++ b/providers/unifi/unifiProvider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
@@ -155,8 +156,8 @@ func (p *unifiProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exist
 	// it and always reads them back as 300), so force those to 300 to avoid a
 	// perpetual TTL diff. Other types keep their TTL, defaulting 0 to 300.
 	for _, record := range dc.Records {
-		switch record.Type {
-		case "MX", "TXT", "SRV":
+		switch record.TypeNum {
+		case dnsv2.TypeMX, dnsv2.TypeTXT, dnsv2.TypeSRV:
 			record.TTL = 300
 		default:
 			if record.TTL == 0 {

--- a/providers/vercel/vercelProvider.go
+++ b/providers/vercel/vercelProvider.go
@@ -300,12 +300,12 @@ func toVercelCreateRequest(domain string, rc *models.RecordConfig) (createDNSRec
 	req.TTL = int64(rc.TTL)
 	req.Comment = ""
 
-	switch rc.Type {
-	case "MX":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		req.MXPriority = int64(f.Preference)
 		req.Value = new(f.Mx)
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		req.SRV = &vercelClient.SRV{
 			Priority: int64(f.Priority),
@@ -317,9 +317,9 @@ func toVercelCreateRequest(domain string, rc *models.RecordConfig) (createDNSRec
 		// otherwise the API throws an error:
 		// bad_request - Invalid request: should NOT have additional property `value`
 		req.Value = nil
-	case "TXT":
+	case dnsv2.TypeTXT:
 		req.Value = new(rc.GetTargetTXTJoined())
-	case "HTTPS":
+	case dnsv2.TypeHTTPS:
 		f := rc.AsHTTPS()
 		req.HTTPS = &httpsRecord{
 			Priority: int64(f.Priority),
@@ -330,7 +330,7 @@ func toVercelCreateRequest(domain string, rc *models.RecordConfig) (createDNSRec
 		// otherwise the API throws an error:
 		// bad_request - Invalid request: should NOT have additional property `value`.
 		req.Value = nil
-	case "CAA":
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		req.Value = new(fmt.Sprintf(`%v %s "%s"`, f.Flag, f.Tag, f.Value))
 	default:
@@ -353,12 +353,12 @@ func toVercelUpdateRequest(rc *models.RecordConfig) (updateDNSRecordRequest, err
 	req.TTL = new(int64(rc.TTL))
 	req.Comment = ""
 
-	switch rc.Type {
-	case "MX":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		req.MXPriority = new(int64(f.Preference))
 		req.Value = new(f.Mx)
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		req.SRV = &vercelClient.SRVUpdate{
 			Priority: new(int64(f.Priority)),
@@ -370,10 +370,10 @@ func toVercelUpdateRequest(rc *models.RecordConfig) (updateDNSRecordRequest, err
 		// otherwise the API throws an error:
 		// bad_request - Invalid request: should NOT have additional property `value`
 		req.Value = nil
-	case "TXT":
+	case dnsv2.TypeTXT:
 		txtValue := rc.GetTargetTXTJoined()
 		req.Value = &txtValue
-	case "HTTPS":
+	case dnsv2.TypeHTTPS:
 		f := rc.AsHTTPS()
 		req.HTTPS = &httpsRecord{
 			Priority: int64(f.Priority),
@@ -384,7 +384,7 @@ func toVercelUpdateRequest(rc *models.RecordConfig) (updateDNSRecordRequest, err
 		// otherwise the API throws an error:
 		// bad_request - Invalid request: should NOT have additional property `value`.
 		req.Value = nil
-	case "CAA":
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		value := fmt.Sprintf(`%v %s "%s"`, f.Flag, f.Tag, f.Value)
 		req.Value = &value

--- a/providers/vultr/vultrProvider.go
+++ b/providers/vultr/vultrProvider.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
@@ -326,12 +327,12 @@ func toVultrRecord(rc *models.RecordConfig, vultrID string) *govultr.DomainRecor
 		TTL:  int(rc.TTL),
 	}
 
-	switch rtype := rc.Type; rtype { // #rtype_variations
-	case "CNAME":
+	switch rtype := rc.TypeNum; rtype { // #rtype_variations
+	case dnsv2.TypeCNAME:
 		r.Data = strings.TrimSuffix(rc.AsCNAME().Target, ".")
-	case "NS":
+	case dnsv2.TypeNS:
 		r.Data = strings.TrimSuffix(rc.AsNS().Ns, ".")
-	case "MX":
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		r.Priority = int(f.Preference)
 		r.Data = strings.TrimSuffix(rc.AsMX().Mx, ".")
@@ -339,7 +340,7 @@ func toVultrRecord(rc *models.RecordConfig, vultrID string) *govultr.DomainRecor
 			// Vultr represents a null MX (RFC 7505) as a literal ".".
 			r.Data = "."
 		}
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		r.Priority = int(f.Priority)
 		target := strings.TrimSuffix(f.Target, ".")
@@ -347,13 +348,13 @@ func toVultrRecord(rc *models.RecordConfig, vultrID string) *govultr.DomainRecor
 			target = "."
 		}
 		r.Data = fmt.Sprintf("%v %v %s", f.Weight, f.Port, target)
-	case "CAA":
+	case dnsv2.TypeCAA:
 		f := rc.AsCAA()
 		r.Data = fmt.Sprintf(`%v %s "%s"`, f.Flag, f.Tag, f.Value)
-	case "SSHFP":
+	case dnsv2.TypeSSHFP:
 		f := rc.AsSSHFP()
 		r.Data = fmt.Sprintf("%d %d %s", f.Algorithm, f.Type, f.FingerPrint)
-	case "TXT":
+	case dnsv2.TypeTXT:
 		r.Data = `"` + rc.GetTargetTXTJoined() + `"` // see the toRecordConfig comment
 	default:
 		r.Data = rc.GetRDATA().String()

--- a/providers/websupport/auditrecords_test.go
+++ b/providers/websupport/auditrecords_test.go
@@ -9,8 +9,8 @@ import (
 func makeRC(rtype, label, target string) *models.RecordConfig {
 	dc := models.MustNewDomainConfig("example.com")
 	switch rtype {
-	case "TXT":
-		return dc.MustNewRecordConfig(label, 0, rtype, target)
+	// case "TXT":
+	// 	return dc.MustNewRecordConfig(label, 0, rtype, target)
 	case "MX":
 		return dc.MustNewRecordConfig(label, 0, rtype, 10, target)
 	case "SRV":

--- a/providers/websupport/convert.go
+++ b/providers/websupport/convert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -41,20 +42,20 @@ func toNative(rc *models.RecordConfig) (nativeRecord, error) {
 		TTL:  rc.TTL,
 	}
 
-	switch rc.Type {
-	case "MX":
+	switch rc.TypeNum {
+	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		r.Priority = intPtr(f.Preference)
 		r.Content = trimDot(f.Mx)
-	case "SRV":
+	case dnsv2.TypeSRV:
 		f := rc.AsSRV()
 		r.Priority = intPtr(f.Priority)
 		r.Weight = intPtr(f.Weight)
 		r.Port = intPtr(f.Port)
 		r.Content = trimDot(f.Target)
-	case "TXT":
+	case dnsv2.TypeTXT:
 		r.Content = rc.GetTargetTXTJoined()
-	case "CNAME":
+	case dnsv2.TypeCNAME:
 		f := rc.AsCNAME()
 		r.Content = trimDot(f.Target)
 	default:


### PR DESCRIPTION
## What changed

- convert straightforward `RecordConfig.Type` switches to `RecordConfig.TypeNum`
- use `dnsv2.Type...` and `privatetypes.Type...` constants for numeric cases
- comment out explicit cases whose behavior is identical to the switch default
- retain string switches where sentinel values, initialization timing, or alias subtypes make numeric switching unsafe

## Why

`RecordConfig.TypeNum` is the numeric equivalent of `RecordConfig.Type`, so switching on it avoids repeated string comparisons in common record conversion paths. Removing redundant active cases also lets the existing default behavior handle those values directly while preserving the former clauses as documentation.

## Impact

This is a behavior-preserving refactor intended to reduce switch overhead and simplify record-type handling.

## Validation

- `gofmt`
- `git diff --check`
- `go test ./...`
- AST scans for duplicate cases and default-only switches
