### PR TITLE
REFACTOR: Switch on RDATA types where safe

### DIFF
--- a/providers/digitalocean/digitaloceanProvider.go
+++ b/providers/digitalocean/digitaloceanProvider.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	dnsv2 "codeberg.org/miekg/dns"
+	dnsrdatav2 "codeberg.org/miekg/dns/rdata"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
@@ -360,29 +361,26 @@ func toReq(rc *models.RecordConfig) *godo.DomainRecordEditRequest {
 		TTL:  int(rc.TTL),
 	}
 
-	switch rc.TypeNum {
-	case dnsv2.TypeCAA:
+	switch f := rc.GetRDATA().(type) {
+	case dnsrdatav2.CAA:
 		// DO API requires that a CAA target ends in dot.
 		// Interestingly enough, the value returned from API doesn't
 		// contain a trailing dot.
-		f := rc.AsCAA()
 		// r.Data = target + "."
 		r.Tag = f.Tag
 		r.Flags = int(f.Flag)
 		r.Data = f.Value + "."
-	case dnsv2.TypeMX:
-		f := rc.AsMX()
+	case dnsrdatav2.MX:
 		// DO uses the same field for MX and SRV priority
 		r.Priority = int(f.Preference)
 		r.Data = f.Mx
-	case dnsv2.TypeSRV:
-		f := rc.AsSRV()
+	case dnsrdatav2.SRV:
 		// DO uses the same field for MX and SRV priority
 		r.Priority = int(f.Priority)
 		r.Weight = int(f.Weight)
 		r.Port = int(f.Port)
 		r.Data = f.Target
-	case dnsv2.TypeTXT:
+	case dnsrdatav2.TXT:
 		// TXT records are the one place where DO combines many items into one field.
 		r.Data = rc.GetTargetTXTJoined()
 	default:

--- a/providers/domainnameshop/convert.go
+++ b/providers/domainnameshop/convert.go
@@ -3,7 +3,7 @@ package domainnameshop
 import (
 	"strconv"
 
-	dnsv2 "codeberg.org/miekg/dns"
+	dnsrdatav2 "codeberg.org/miekg/dns/rdata"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -56,9 +56,8 @@ func (api *domainNameShopProvider) fromRecordConfig(domainName string, rc *model
 		DomainID: domainID,
 	}
 
-	switch rc.TypeNum {
-	case dnsv2.TypeCAA:
-		f := rc.AsCAA()
+	switch f := rc.GetRDATA().(type) {
+	case dnsrdatav2.CAA:
 		// Actual CAA FLAG
 		switch f.Tag {
 		case "issue":
@@ -71,19 +70,17 @@ func (api *domainNameShopProvider) fromRecordConfig(domainName string, rc *model
 		dnsR.CAAFlag = uint64(int(f.Flag))
 		dnsR.ActualCAAFlag = strconv.Itoa(int(f.Flag))
 		dnsR.Data = f.Value
-	case dnsv2.TypeMX:
-		f := rc.AsMX()
+	case dnsrdatav2.MX:
 		dnsR.Priority = strconv.Itoa(int(f.Preference))
 		dnsR.Data = f.Mx
-	case dnsv2.TypeSRV:
-		f := rc.AsSRV()
+	case dnsrdatav2.SRV:
 		dnsR.Priority = strconv.Itoa(int(f.Priority))
 		dnsR.Weight = strconv.Itoa(int(f.Weight))
 		dnsR.Port = strconv.Itoa(int(f.Port))
 		dnsR.ActualWeight = f.Weight
 		dnsR.ActualPort = f.Port
 		dnsR.Data = f.Target
-	case dnsv2.TypeTXT:
+	case dnsrdatav2.TXT:
 		dnsR.Data = rc.GetTargetTXTJoined()
 	default:
 		dnsR.Data = rc.GetRDATA().String()

--- a/providers/hedns/hednsProvider.go
+++ b/providers/hedns/hednsProvider.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	dnsv2 "codeberg.org/miekg/dns"
+	dnsrdatav2 "codeberg.org/miekg/dns/rdata"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
@@ -759,13 +760,11 @@ func (c *hednsProvider) editZoneRecord(zoneID uint64, recordID uint64, rc *model
 	}
 
 	// Work out the content
-	switch rc.TypeNum {
-	case dnsv2.TypeMX:
-		f := rc.AsMX()
+	switch f := rc.GetRDATA().(type) {
+	case dnsrdatav2.MX:
 		values.Set("Priority", strconv.FormatUint(uint64(f.Preference), 10))
 		values.Set("Content", f.Mx)
-	case dnsv2.TypeSRV:
-		f := rc.AsSRV()
+	case dnsrdatav2.SRV:
 		values.Del("Content")
 		values.Set("Target", f.Target)
 		values.Set("Priority", strconv.FormatUint(uint64(f.Priority), 10))

--- a/providers/netlify/netlifyProvider.go
+++ b/providers/netlify/netlifyProvider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	dnsv2 "codeberg.org/miekg/dns"
+	dnsrdatav2 "codeberg.org/miekg/dns/rdata"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/nrc"
@@ -256,23 +257,20 @@ func toReq(rc *models.RecordConfig) *dnsRecordCreate {
 		TTL:      int64(rc.TTL),
 	}
 
-	switch rc.TypeNum {
-	case dnsv2.TypeCAA:
-		f := rc.AsCAA()
+	switch f := rc.GetRDATA().(type) {
+	case dnsrdatav2.CAA:
 		r.Tag = f.Tag
 		r.Flag = int64(f.Flag)
 		r.Value = f.Value
-	case dnsv2.TypeMX:
-		f := rc.AsMX()
+	case dnsrdatav2.MX:
 		r.Priority = int64(f.Preference)
 		r.Value = f.Mx
-	case dnsv2.TypeSRV:
-		f := rc.AsSRV()
+	case dnsrdatav2.SRV:
 		r.Priority = int64(f.Priority)
 		r.Port = int64(f.Port)
 		r.Weight = int64(f.Weight)
 		r.Value = f.Target
-	case dnsv2.TypeTXT:
+	case dnsrdatav2.TXT:
 		r.Value = rc.GetTargetTXTJoined()
 	default:
 		r.Value = rc.GetRDATA().String()

--- a/providers/tencentdns/convert.go
+++ b/providers/tencentdns/convert.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	dnsv2 "codeberg.org/miekg/dns"
+	dnsrdatav2 "codeberg.org/miekg/dns/rdata"
 	"github.com/DNSControl/dnscontrol/v5/models"
 	dnspod "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod/v20210323"
 )
@@ -125,13 +126,11 @@ func recordToCreateRequest(rc *models.RecordConfig) *dnspod.CreateRecordRequest 
 	}
 
 	var val string
-	switch rc.TypeNum {
-	case dnsv2.TypeMX:
-		f := rc.AsMX()
+	switch f := rc.GetRDATA().(type) {
+	case dnsrdatav2.MX:
 		val = f.Mx
 		req.MX = new(uint64(f.Preference))
-	case dnsv2.TypeTXT:
-		f := rc.AsTXT()
+	case dnsrdatav2.TXT:
 		val = f.String()
 
 	default:
@@ -165,9 +164,8 @@ func recordToModifyRequest(rc *models.RecordConfig, recordID uint64, previous *m
 	}
 
 	var val string
-	switch rc.TypeNum {
-	case dnsv2.TypeMX:
-		f := rc.AsMX()
+	switch f := rc.GetRDATA().(type) {
+	case dnsrdatav2.MX:
 		val = f.Mx
 		req.MX = new(uint64(f.Preference))
 
@@ -188,8 +186,7 @@ func recordToModifyRequest(rc *models.RecordConfig, recordID uint64, previous *m
 	// 		val = u
 	// 	}
 
-	case dnsv2.TypeTXT:
-		f := rc.AsTXT()
+	case dnsrdatav2.TXT:
 		val = f.String()
 	default:
 		val = rc.GetRDATA().String()

--- a/providers/websupport/convert.go
+++ b/providers/websupport/convert.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	dnsv2 "codeberg.org/miekg/dns"
+	dnsrdatav2 "codeberg.org/miekg/dns/rdata"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -42,21 +42,18 @@ func toNative(rc *models.RecordConfig) (nativeRecord, error) {
 		TTL:  rc.TTL,
 	}
 
-	switch rc.TypeNum {
-	case dnsv2.TypeMX:
-		f := rc.AsMX()
+	switch f := rc.GetRDATA().(type) {
+	case dnsrdatav2.MX:
 		r.Priority = intPtr(f.Preference)
 		r.Content = trimDot(f.Mx)
-	case dnsv2.TypeSRV:
-		f := rc.AsSRV()
+	case dnsrdatav2.SRV:
 		r.Priority = intPtr(f.Priority)
 		r.Weight = intPtr(f.Weight)
 		r.Port = intPtr(f.Port)
 		r.Content = trimDot(f.Target)
-	case dnsv2.TypeTXT:
+	case dnsrdatav2.TXT:
 		r.Content = rc.GetTargetTXTJoined()
-	case dnsv2.TypeCNAME:
-		f := rc.AsCNAME()
+	case dnsrdatav2.CNAME:
 		r.Content = trimDot(f.Target)
 	default:
 		r.Content = rc.GetRDATA().String()


### PR DESCRIPTION
## Summary

- convert seven `RecordConfig.TypeNum` switches to RDATA type switches
- use the type-switch value directly instead of repeating `As*()` assertions
- update DigitalOcean, DomainNameShop, HE DNS, Netlify, Tencent DNS, and WebSupport conversions

## Why

These switches immediately asserted the RDATA type selected by `TypeNum`. Switching on `GetRDATA()` directly avoids the duplicate lookup and assertion while making the concrete record data available in each case.

Only switches whose DNS types map one-to-one to concrete RDATA types are included. Cases involving shared concrete representations, such as HTTPS/SVCB, remain unchanged.

## Checks

- `go test ./providers/digitalocean ./providers/domainnameshop ./providers/hedns ./providers/netlify ./providers/tencentdns ./providers/websupport`
- `go test ./...`
- `git diff --check`
