### PR TITLE
WEBSUPPORT: fix MX/SRV empty priority and v5 preparation

### DIFF
--- a/documentation/provider/websupport.md
+++ b/documentation/provider/websupport.md
@@ -80,6 +80,17 @@ secret itself is never transmitted.
   * `ALIAS`/`ANAME` — WebSupport only allows `ANAME` at the apex and rejects it
     when other apex records exist, so it cannot be supported generically.
   * `LOC`, `NAPTR`, `PTR`, `SSHFP`, `TLSA`, `DS`.
+* **`TXT` records may not end in a space.** The API silently strips trailing
+  whitespace, so such records are rejected rather than churning forever.
+* **Null MX ([RFC 7505](https://www.rfc-editor.org/rfc/rfc7505.html)) is not
+  supported.** A null MX has an empty target and the API rejects a record with
+  empty `content`, so `MX("@", 0, ".")` is rejected with a clear error.
+* **MX and SRV reads cost one extra API request each.** WebSupport's record
+  listing endpoints return `null` for `priority`, `port` and `weight` on every
+  record, even though the values are stored correctly and served in DNS. The
+  provider re-reads each `MX` and `SRV` record through the v1 single-record
+  endpoint, which still reports them. This is a workaround for a bug on
+  WebSupport's side and stops by itself once they fix the listing.
 * The provider automatically resolves each domain to its numeric WebSupport
   service id (used internally by the v2 API); you only need to supply
   `api_key` and `secret`.

--- a/providers/websupport/api.go
+++ b/providers/websupport/api.go
@@ -32,7 +32,6 @@ type nativeRecord struct {
 	Priority *int   `json:"priority,omitempty"`
 	Port     *int   `json:"port,omitempty"`
 	Weight   *int   `json:"weight,omitempty"`
-	Note     string `json:"note,omitempty"`
 }
 
 // recordPage is one page of GET /v2/service/{service}/dns/record.
@@ -53,6 +52,14 @@ type v1Service struct {
 
 type v1ServiceList struct {
 	Items []v1Service `json:"items"`
+}
+
+// v1Record holds the only fields the record listings fail to return. v1 spells
+// priority "prio".
+type v1Record struct {
+	Prio   *int `json:"prio"`
+	Port   *int `json:"port"`
+	Weight *int `json:"weight"`
 }
 
 type apiError struct {
@@ -181,6 +188,33 @@ func (c *websupportProvider) getAllRecords(serviceID int64) ([]nativeRecord, err
 		page++
 	}
 	return all, nil
+}
+
+// repairMXSRV fills in the priority, port and weight of MX and SRV records,
+// which the record listings report as null on every record even though the
+// values are stored correctly. The v1 single-record endpoint still reports
+// them, so re-read those few records one at a time. Last verified 2026-08-09.
+func (c *websupportProvider) repairMXSRV(zone string, recs []nativeRecord) error {
+	for i := range recs {
+		r := &recs[i]
+		if r.Type != "MX" && r.Type != "SRV" {
+			continue
+		}
+		if r.Priority != nil {
+			continue // WebSupport fixed the listing; nothing to repair.
+		}
+
+		var v1 v1Record
+		endpoint := "/v1/user/self/zone/" + zone + "/record/" + strconv.FormatInt(r.ID, 10)
+		if err := c.do("Date", http.MethodGet, endpoint, nil, &v1); err != nil {
+			if isNotFound(err) {
+				continue // Deleted between the listing and this request.
+			}
+			return fmt.Errorf("WEBSUPPORT: re-reading record %d: %w", r.ID, err)
+		}
+		r.Priority, r.Port, r.Weight = v1.Prio, v1.Port, v1.Weight
+	}
+	return nil
 }
 
 func (c *websupportProvider) createRecord(serviceID int64, r nativeRecord) error {

--- a/providers/websupport/auditrecords.go
+++ b/providers/websupport/auditrecords.go
@@ -13,9 +13,12 @@ import (
 func AuditRecords(records []*models.RecordConfig) []error {
 	a := rejectif.Auditor{}
 
-	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2026-06-17
+	a.Add("MX", rejectif.MxNull) // Last verified 2026-08-09: the API rejects the empty content with a 422
 
 	a.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2026-06-17
+
+	a.Add("TXT", rejectif.TxtIsEmpty)          // Last verified 2026-06-17
+	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2026-08-09: the API strips trailing spaces
 
 	// The WebSupport v2 DNS record API silently ignores attempts to create NS
 	// records (it returns success but the record never appears), which would

--- a/providers/websupport/auditrecords_test.go
+++ b/providers/websupport/auditrecords_test.go
@@ -54,8 +54,18 @@ func TestAuditRecords(t *testing.T) {
 			wantCount: 1,
 		},
 		{
+			name:      "TXT with a trailing space is rejected",
+			records:   models.Records{makeRC("TXT", "@", "trailing ")},
+			wantCount: 1,
+		},
+		{
 			name:      "SRV with null target is rejected",
 			records:   models.Records{makeRC("SRV", "_sip._tcp", ".")},
+			wantCount: 1,
+		},
+		{
+			name:      "null MX is rejected",
+			records:   models.Records{makeRC("MX", "@", ".")},
 			wantCount: 1,
 		},
 	}

--- a/providers/websupport/auditrecords_test.go
+++ b/providers/websupport/auditrecords_test.go
@@ -9,8 +9,6 @@ import (
 func makeRC(rtype, label, target string) *models.RecordConfig {
 	dc := models.MustNewDomainConfig("example.com")
 	switch rtype {
-	// case "TXT":
-	// 	return dc.MustNewRecordConfig(label, 0, rtype, target)
 	case "MX":
 		return dc.MustNewRecordConfig(label, 0, rtype, 10, target)
 	case "SRV":

--- a/providers/websupport/convert.go
+++ b/providers/websupport/convert.go
@@ -57,8 +57,6 @@ func toNative(rc *models.RecordConfig) (nativeRecord, error) {
 		r.Content = trimDot(f.Target)
 	default:
 		r.Content = rc.GetRDATA().String()
-		// TODO(tlim): This was the original:
-		//r.Content = rc.Get TargetField()
 	}
 
 	return r, nil

--- a/providers/websupport/records.go
+++ b/providers/websupport/records.go
@@ -19,6 +19,9 @@ func (c *websupportProvider) GetZoneRecords(dc *models.DomainConfig) (models.Rec
 	if err != nil {
 		return nil, err
 	}
+	if err := c.repairMXSRV(dc.Name, nativeRecs); err != nil {
+		return nil, err
+	}
 
 	recs := make(models.Records, 0, len(nativeRecs))
 	for _, n := range nativeRecs {


### PR DESCRIPTION
Hi @TomOnTime, this is a follow-up to https://github.com/DNSControl/dnscontrol/pull/4584 (apologies for the delay!) that contains the fix for MX/SRV records. It's not ideal as there were some iffy changes upstream but does its job. 

I also reran integration tests and attached them to this PR. I will try to sort out a testing domain in the near future so that I am not blocking your changes.

[20260809_153902.log](https://github.com/user-attachments/files/30873928/20260809_153902.log)
