### PR TITLE
DOCS: Update dnscontrol-action to a maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ DNSControl can be installed via packages for macOS, Linux and Windows, or from s
 
 ## Via GitHub Actions (GHA)
 
-See [dnscontrol-action](https://github.com/koenrh/dnscontrol-action) or [gacts/install-dnscontrol](https://github.com/gacts/install-dnscontrol).
+See [dnscontrol-action](https://github.com/metabrainz/dnscontrol-action) or [gacts/install-dnscontrol](https://github.com/gacts/install-dnscontrol).
 
 ## Deprecation warnings (updated 2025-11-21)
 


### PR DESCRIPTION
This updates the link in the readme from the abandoned one at https://github.com/koenrh/dnscontrol-action to one that is kept up-to-date at https://github.com/metabrainz/dnscontrol-action