### PR TITLE
BUGFIX: integration tests audited the harness's own delegation NS records

### DIFF
--- a/integrationTest/helpers_integration_test.go
+++ b/integrationTest/helpers_integration_test.go
@@ -180,12 +180,22 @@ func makeChanges(t *testing.T, prv providers.DNSServiceProvider, dc *models.Doma
 			maps.Copy(dom.Metadata, domainMeta)
 		}
 
+		// testRecords holds only the records this test case contributes. dom
+		// additionally contains the zone's delegation NS records, which
+		// getDomainConfigWithNameservers() synthesized via
+		// nameservers.AddNSRecords(). Those must not be audited: in production
+		// AuditRecords() runs in pkg/normalize on the user's records, long
+		// before generateDelegationCorrections() synthesizes the apex NS
+		// records. Auditing them here makes a provider that rejects apex NS
+		// records (or NS records generally) skip every test in the suite.
+		testRecords := make(models.Records, 0, len(tst.Records))
 		for _, r := range tst.Records {
 			rc := models.RecordConfig(*r)
 
 			replaceIntegrationTargetTokens(&rc, origConfig["SubscriptionID"], origConfig["ResourceGroup"])
 
 			dom.Records = append(dom.Records, &rc)
+			testRecords = append(testRecords, &rc)
 		}
 		dom.Unmanaged = tst.Unmanaged
 		dom.UnmanagedUnsafe = tst.UnmanagedUnsafe
@@ -203,7 +213,9 @@ func makeChanges(t *testing.T, prv providers.DNSServiceProvider, dc *models.Doma
 		})
 		dom2, _ := dom.Copy()
 
-		if err := providers.AuditRecords(*providerFlag, dom.Records); err != nil {
+		// testRecords shares its pointers with dom.Records, so the records
+		// audited here are the same objects this test will push.
+		if err := providers.AuditRecords(*providerFlag, testRecords); err != nil {
 			t.Skipf("***SKIPPED(PROVIDER DOES NOT SUPPORT '%s' ::%q)", err, desc)
 			return
 		}


### PR DESCRIPTION
## The bug

`makeChanges()` passed `dom.Records` to `AuditRecords()`. `dom` is a copy of the `DomainConfig` built by `getDomainConfigWithNameservers()`, which calls `nameservers.AddNSRecords()` to synthesize one apex `NS` record per delegated nameserver. Those records are present in every single test case, so a provider whose auditor rejects apex `NS` records rejects *every* test case in the suite — including the record-less `Clean Slate` ones.

This was latent until #4707 made `rejectif.NsAtApex` actually match the apex label (it had compared against `""` instead of `"@"`, so it never fired). DOMAINNAMESHOP registers that rule, so its entire integration run silently became a no-op:

| | before #4707 | after #4707 |
|---|---|---|
| subtests executed | 230 (229 pass, 1 fail) | **0** |
| skipped by the audit | 0 | **230** |
| skipped by group filters | 72 | 72 |

Zero API calls were made against the provider, and the run still reported `ok`. WEBSUPPORT has the same problem via its `rejectNS` rule, which rejects `NS` records unconditionally.

## Why production is unaffected

That asymmetry is the point. `AuditRecords()` runs in `pkg/normalize/validate.go` on the user's records, whereas `AddNSRecords()` only runs later, in `generateDelegationCorrections()` (`commands/ppreviewPush.go`). In production the audit never sees synthesized apex NS records — only `NS()` records the user wrote themselves, which is exactly what these rules are meant to catch.

So this is a test-harness bug, not a provider bug, and `NsAtApex` itself is correct as fixed in #4707.

## The fix

Audit only the records the test case contributes, so the harness matches production ordering. Two details worth noting for review:

- The audited slice shares its pointers with `dom.Records`, so it holds the same record objects the test goes on to push.
- `Auditor.Audit()` only ever appends to a named return, so it yields `nil` for the empty slice a `Clean Slate` case produces. Those cases run rather than skipping on an empty error list.

## Verification

Full run against DOMAINNAMESHOP (bdns.no): **230 subtests run and pass, 0 failures.** The 72 group-level filter skips are unchanged.

The only tests this rule still skips are the two in `27:NS only APEX`:

```
***SKIPPED(PROVIDER DOES NOT SUPPORT '[NS records not supported at apex]' ::"27:NS only APEX")
***SKIPPED(PROVIDER DOES NOT SUPPORT '[NS records not supported at apex NS records not supported at apex]' ::"27:NS only APEX")
```

Those are the only test cases in the entire suite carrying an apex NS record of their own (`ns("@", ...)` appears exactly twice, at `integration_test.go:511-512`), and they are precisely the tests #4707 set out to make skip.

## Note for WEBSUPPORT (@mtmn)

This un-skips WEBSUPPORT's suite too, but its `26:NS` group will then genuinely fail rather than skip, since `rejectNS` rejects all NS records and WEBSUPPORT isn't in that group's `not()` list. Left alone here — needs a separate look from someone who can run against that provider.

Related to #4748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoVVephnrZDEmU4fzzWUzJ
