### PR TITLE
DNSCALE: fix regression in PR#4664

### DIFF
--- a/providers/dnscale/dnscaleProvider.go
+++ b/providers/dnscale/dnscaleProvider.go
@@ -543,8 +543,7 @@ func fromRecordConfig(rc *models.RecordConfig) Record {
 	case dnsv2.TypeCNAME, dnsv2.TypeNS, dnsv2.
 		// Remove trailing dot for DNScale API
 		TypePTR, privatetypes.TypeALIAS:
-
-		content = strings.TrimSuffix(content, ".")
+		content = strings.TrimSuffix(rc.GetRDATA().String(), ".")
 	case dnsv2.TypeMX:
 		f := rc.AsMX()
 		priority = int(f.Preference)


### PR DESCRIPTION
https://github.com/DNSControl/dnscontrol/pull/4664 (commit: d5268bbdfea5d2bc07533fc5a671c3fedc56518e) introduced a regression preventing successful integration tests harness run against release_candidate_v5.

This PR addresses the regression.

```
--- FAIL: TestDNSProviders (370.74s)
    --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com (370.40s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/04:CNAME:Create_a_CNAME (0.55s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/05:CNAME-short:Create_a_CNAME (0.83s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/17:TypeChangeHard:Create_a_CNAME (0.49s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/22:CNAME:Record_pointing_to_@ (0.97s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/26:NS:NS_for_subdomain (0.44s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/33:IDNA:Internationalized_CNAME_Target (0.43s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/34:IDNAs_in_CNAME_targets:IDN_CNAME_AND_Target (0.46s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/43:PTR:Create_PTR_record (0.47s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/55:ALIAS_on_apex:ALIAS_at_root (0.41s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/56:ALIAS_to_nonfqdn:ALIAS_at_root (0.87s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/57:ALIAS_on_subdomain:ALIAS_at_subdomain (0.41s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/91:IGNORE_main:Create_some_records (2.29s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/92:IGNORE_apex:Create_some_records (2.24s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/94:IGNORE_wilds:Create_some_records (2.17s)
        --- FAIL: TestDNSProviders/dnscontrol-test-zone-001.com/96:IGNORE_TARGET_b2285:Create_some_records (0.52s)
FAIL
FAIL    github.com/DNSControl/dnscontrol/v5/integrationTest     372.969s
```

