### PR TITLE
DYNU: Fix NAPTR replacement field, and RP trailing dot

### DIFF
--- a/providers/dynu/dynuProvider.go
+++ b/providers/dynu/dynuProvider.go
@@ -428,7 +428,7 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		req.Services = f.Service
 		req.RegExp = f.Regexp
 		// Preserve "." as-is (null replacement); strip trailing dot from real FQDNs.
-		naptrTarget := f.Service
+		naptrTarget := f.Replacement
 		if naptrTarget != "." {
 			naptrTarget = strings.TrimSuffix(naptrTarget, ".")
 		}

--- a/providers/dynu/dynuProvider.go
+++ b/providers/dynu/dynuProvider.go
@@ -437,9 +437,18 @@ func toReq(rc *models.RecordConfig) *dynuRecord {
 		// Target is the base64-encoded public key (zone-file format == API format).
 		req.PublicKey = rc.AsOPENPGPKEY().PublicKey
 	case dnsv2.TypeRP:
+		// Preserve "." as-is (null name); strip trailing dot from real FQDNs.
 		rd := rc.AsRP()
-		req.MailBox = rd.Mbox
-		req.TxtDomainName = rd.Txt
+		mbox := rd.Mbox
+		if mbox != "." {
+			mbox = strings.TrimSuffix(mbox, ".")
+		}
+		txt := rd.Txt
+		if txt != "." {
+			txt = strings.TrimSuffix(txt, ".")
+		}
+		req.MailBox = mbox
+		req.TxtDomainName = txt
 	case dnsv2.TypeSMIMEA:
 		f := rc.AsSMIMEA()
 		usage := int(f.Usage)

--- a/providers/dynu/dynuProvider_test.go
+++ b/providers/dynu/dynuProvider_test.go
@@ -98,3 +98,40 @@ func TestToReqNAPTR(t *testing.T) {
 		})
 	}
 }
+
+// TestToReqRP verifies that toReq strips the trailing dot from the RP mailbox
+// and TXT domain name. The Dynu API validates both as hostnames and rejects a
+// trailing dot with "Invalid content.". DNSControl fully qualifies relative
+// names, so both fields always arrive here with a trailing dot.
+func TestToReqRP(t *testing.T) {
+	dc, err := models.NewDomainConfig("example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name              string
+		mbox, txt         string
+		wantMbox, wantTxt string
+	}{
+		{"absolute names", "user.example.com.", "bar.com.", "user.example.com", "bar.com"},
+		{"relative names get qualified", "user", "server", "user.example.com", "server.example.com"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rc, err := dc.NewRecordConfig("foo", 300, dnsv2.TypeRP, tc.mbox, tc.txt)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req := toReq(rc)
+			if req.MailBox != tc.wantMbox {
+				t.Errorf("MailBox = %q, want %q", req.MailBox, tc.wantMbox)
+			}
+			if req.TxtDomainName != tc.wantTxt {
+				t.Errorf("TxtDomainName = %q, want %q", req.TxtDomainName, tc.wantTxt)
+			}
+		})
+	}
+}

--- a/providers/dynu/dynuProvider_test.go
+++ b/providers/dynu/dynuProvider_test.go
@@ -3,6 +3,7 @@ package dynu
 import (
 	"testing"
 
+	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
 )
 
@@ -16,6 +17,8 @@ func TestToRc(t *testing.T) {
 	zero := 0
 	weight := 2
 	port := 5060
+	order := 100
+	preference := 10
 	tests := []struct {
 		name       string
 		record     dynuRecord
@@ -26,6 +29,8 @@ func TestToRc(t *testing.T) {
 		{"null MX", dynuRecord{NodeName: "@", RecordType: "MX", Host: "example.com", Priority: &zero, TTL: 300}, "0 ."},
 		{"TXT", dynuRecord{NodeName: "@", RecordType: "TXT", TextData: "raw text", TTL: 300}, `"raw text"`},
 		{"SRV", dynuRecord{NodeName: "_sip._tcp", RecordType: "SRV", Host: "sip.example.net", Priority: &priority, Weight: &weight, Port: &port, TTL: 300}, "10 2 5060 sip.example.net."},
+		{"NAPTR", dynuRecord{NodeName: "@", RecordType: "NAPTR", Order: &order, Preference: &preference, NaptrFlags: "U", Services: "E2U+sip", RegExp: `!^.*$!sip:info@example.com!`, Replacement: "sip.example.net", TTL: 300}, `100 10 "U" "E2U+sip" "!^.*$!sip:info@example.com!" sip.example.net.`},
+		{"NAPTR null replacement", dynuRecord{NodeName: "@", RecordType: "NAPTR", Order: &order, Preference: &preference, NaptrFlags: "S", Services: "SIP+D2U", Replacement: "", TTL: 300}, `100 10 "S" "SIP+D2U" "" .`},
 	}
 
 	for _, tc := range tests {
@@ -40,6 +45,55 @@ func TestToRc(t *testing.T) {
 			}
 			if rc.Original != &record {
 				t.Error("original provider record was not retained")
+			}
+		})
+	}
+}
+
+// TestToReqNAPTR verifies that toReq puts each NAPTR field in the matching Dynu
+// API field. In particular, replacement must come from the record's replacement
+// and not from its service.
+func TestToReqNAPTR(t *testing.T) {
+	dc, err := models.NewDomainConfig("example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name            string
+		replacement     string
+		wantReplacement string
+	}{
+		{"fqdn replacement", "sip.example.net.", "sip.example.net"},
+		{"null replacement", ".", "."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rc, err := dc.NewRecordConfig("@", 300, dnsv2.TypeNAPTR,
+				100, 10, "U", "E2U+sip", `!^.*$!sip:info@example.com!`, tc.replacement) // ignore:legacyfield
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req := toReq(rc)
+			if req.Replacement != tc.wantReplacement {
+				t.Errorf("Replacement = %q, want %q", req.Replacement, tc.wantReplacement)
+			}
+			if req.Services != "E2U+sip" {
+				t.Errorf("Services = %q, want %q", req.Services, "E2U+sip")
+			}
+			if req.NaptrFlags != "U" {
+				t.Errorf("NaptrFlags = %q, want %q", req.NaptrFlags, "U")
+			}
+			if req.RegExp != `!^.*$!sip:info@example.com!` {
+				t.Errorf("RegExp = %q, want %q", req.RegExp, `!^.*$!sip:info@example.com!`)
+			}
+			if intOrZero(req.Order) != 100 {
+				t.Errorf("Order = %d, want 100", intOrZero(req.Order))
+			}
+			if intOrZero(req.Preference) != 10 {
+				t.Errorf("Preference = %d, want 10", intOrZero(req.Preference))
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #4781.

## 1. NAPTR — the reported bug

The LLM was right. `toReq()` built the Dynu API `replacement` field from the record's `Service` rather than its `Replacement`:

```go
naptrTarget := f.Service
```

`rdata.NAPTR` has both a `Service` and a `Replacement` field, so this compiled cleanly and sent the service string as the replacement on every create and update. The read path in `toRc()` was already correct, which is probably why it reads as fine at a glance — only writes were affected.

It isn't a silent-corruption bug. Dynu validates `replacement` as a hostname, so a service value like `E2U+sip` is rejected outright and NAPTR records could not be pushed at all. Reverting just this line and running the NAPTR group against a live account:

```
=== RUN   TestDNSProviders/claudecode.com/42:NAPTR:NAPTR_record
    provider Dynu API error 505: Invalid host.
--- FAIL: TestDNSProviders/claudecode.com/42:NAPTR:NAPTR_record (0.11s)
```

It fails on the first NAPTR case. With the fix, all 10 pass.

## 2. RP — a second bug found while verifying

Running the full suite to check the NAPTR output surfaced an unrelated failure in both RP groups, `505: Invalid content.`. `toReq()` passed the RP mailbox and TXT domain name through unchanged, where every other name-valued field in that switch strips the trailing dot first. Dynu validates both as hostnames and rejects the trailing dot.

Confirmed directly against the API:

```
mailBox=user.example.com.  ->  505 Invalid content.
mailBox=user.example.com   ->  200 OK
```

DNSControl fully qualifies relative names before they reach the provider, so both fields always arrive with a trailing dot — `rp("foo", "user", "server")` arrives as `user.example.com.` and `server.example.com.`. That makes it unconditional rather than an edge case. The read path already runs both through `ensureTrailingDot()`, so the round trip is symmetric once the write path strips it.

I've kept this as a separate commit so it can be dropped independently if you'd rather keep the PR scoped to the reported issue.

## Testing

Verified against a live Dynu account and zone.

| Check | Result |
| --- | --- |
| `gofmt -l providers/dynu/` | clean |
| `go build ./...` | pass |
| `go vet ./providers/dynu/...` | pass |
| `go test ./providers/dynu/...` | pass |
| `go test ./integrationTest/ -provider DYNU` | **305 passed, 0 failed, 112 skipped** |

The suite is fully green with both fixes. Before them it failed on NAPTR and RP.

New regression tests, each of which fails without its corresponding fix:

- `TestToReqNAPTR` — write path, FQDN and null replacement, and asserts the other five NAPTR fields land in the right place
- `TestToReqRP` — write path, absolute and relative names
- Two NAPTR cases added to the existing `TestToRc` table — read path, including the null replacement round trip where Dynu represents `.` as an empty string

No documentation change: `documentation/provider/dynu.md` already lists NAPTR and RP as supported, which is now actually true.
