### PR TITLE
BUGFIX: Fix dnssort issue not resolving all records in certain edge cases

### DIFF
--- a/pkg/dnssort/graphsort.go
+++ b/pkg/dnssort/graphsort.go
@@ -22,8 +22,8 @@ func SortUsingGraph[T dnsgraph.Graphable](records []T) SortResult[T] {
 	sortState := createDirectedSortState(records)
 
 	for sortState.hasWork() {
+		sortState.hasResolvedLastRound = false
 		for _, node := range sortState.graph.All {
-			sortState.hasResolvedLastRound = false
 
 			if hasUnmetDependencies(node) {
 				continue

--- a/pkg/dnssort/graphsort_test.go
+++ b/pkg/dnssort/graphsort_test.go
@@ -37,6 +37,22 @@ func Test_graphsort(t *testing.T) {
 		),
 	)
 
+	t.Run("Multi-round dependency chain resolves when tail is last",
+		executeGraphSort(
+			[]testutils.StubRecord{
+				{NameFQDN: "d.example.com", Dependencies: []dnsgraph.Dependency{{Type: dnsgraph.ForwardDependency, NameFQDN: "e.example.com"}}},
+				{NameFQDN: "e.example.com", Dependencies: []dnsgraph.Dependency{}},
+				{NameFQDN: "l.example.com", Dependencies: []dnsgraph.Dependency{{Type: dnsgraph.ForwardDependency, NameFQDN: "d.example.com"}}},
+			},
+			[]string{
+				"e.example.com",
+				"d.example.com",
+				"l.example.com",
+			},
+			[]string{},
+		),
+	)
+
 	t.Run("Use wildcards",
 		executeGraphSort(
 			[]testutils.StubRecord{


### PR DESCRIPTION
## What

Fixes #4780, a bug found by an LLM  inspecting the code. The `hasResolvedLastRound` must indeed be moved one up. I let an LLM generate a testcase for it and loo and behold: it failed to sort the most basic of record set without a good reason. Moving the `hasResolvedLastRound` to the "round" loop and it sorted it no problem. 

TLDR: good bot.

## Release changelog section

BUGFIX: Fix dnssort issue not resolving all records in certain edgecases