### PR TITLE
OVH: Add the ability to disable ListZones() for testing / Fix TXT record handling

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
 	"github.com/DNSControl/dnscontrol/v5/pkg/rfc4183"
 	"github.com/DNSControl/dnscontrol/v5/pkg/zonerecs"
+	"github.com/DNSControl/dnscontrol/v5/providers/ovh"
 	"github.com/dustin/go-humanize"
 	"github.com/nozzle/throttler"
 	"github.com/urfave/cli/v3"
@@ -139,6 +140,18 @@ func (args *PPreviewArgs) flags() []cli.Flag {
 		Usage:  `Limit the IGNORE/NO_PURGE report to this many lines (Expermental. Will change in the future.)`,
 		Action: func(ctx context.Context, c *cli.Command, maxreport int) error {
 			printer.MaxReport = maxreport
+			return nil
+		},
+	})
+	flags = append(flags, &cli.BoolFlag{
+		Name:   "disable-list-zones",
+		Hidden: true,
+		Usage:  `Pretend ListZones() is unimplemented (OVH only)`,
+		Action: func(ctx context.Context, c *cli.Command, noListZones bool) error {
+			// This was added because the integration test API key donated to
+			// the project doesn't have ListZones privs. If other providers
+			// this, we should make it a general thing.
+			ovh.NoListZone = noListZones
 			return nil
 		},
 	})

--- a/integrationTest/helpers_integration_test.go
+++ b/integrationTest/helpers_integration_test.go
@@ -228,7 +228,7 @@ func makeChanges(t *testing.T, prv providers.DNSServiceProvider, dc *models.Doma
 
 		_, corrections, actualChangeCount, err := zonerecs.CorrectZoneRecords(prv, dom)
 		if err != nil {
-			t.Fatal(fmt.Errorf("runTests: %w", err))
+			t.Fatal(fmt.Errorf("runTests: CZR %w", err))
 		}
 		if tst.Changeless {
 			if actualChangeCount != 0 {

--- a/integrationTest/helpers_test.go
+++ b/integrationTest/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DNSControl/dnscontrol/v5/pkg/providergolden"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
 	"github.com/DNSControl/dnscontrol/v5/providers/cloudflare"
+	"github.com/DNSControl/dnscontrol/v5/providers/ovh"
 )
 
 func TestReplaceIntegrationTargetTokensAzureAlias(t *testing.T) {
@@ -45,6 +46,7 @@ var (
 	enableCFRedirectMode = flag.Bool("cfredirect", true, "enable CF SingleRedirect tests (default true)")
 	enableCFFlatten      = flag.Bool("cfflatten", false, "enable CF CNAME flattening tests (requires paid plan, default false)")
 	enableCFTags         = flag.Bool("cftags", false, "enable CF tag tests (requires paid plan, default false)")
+	disableListZones     = flag.Bool("disablelistzones", false, "disable ListZones() (OVH only)")
 )
 
 // recorder accumulates the conversion inputs of every provider call made by
@@ -142,6 +144,13 @@ func getProvider(t *testing.T) (providers.DNSServiceProvider, string, map[string
 			items = append(items, `"manage_single_redirects": true`)
 		}
 		metadata = []byte(`{ ` + strings.Join(items, `, `) + ` }`)
+	}
+
+	// The -disablelistzones flag is only for OVH at this time.  The API key we
+	// use for integration tests does not have the ability to issue the
+	// ListZones API call. Therefore, we added this hack.
+	if *disableListZones {
+		ovh.NoListZone = true
 	}
 
 	var createOptions []providers.CreateOption

--- a/providers/ovh/ovhProvider.go
+++ b/providers/ovh/ovhProvider.go
@@ -10,7 +10,6 @@ import (
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
-	"github.com/DNSControl/dnscontrol/v5/pkg/txtutil"
 	"github.com/ovh/go-ovh/ovh"
 )
 
@@ -87,11 +86,22 @@ func init() {
 	providers.RegisterMaintainer(providerName, providerMaintainer)
 }
 
+var NoListZone bool
+
+func listzonesEnabled() bool {
+	return !NoListZone
+}
+
 func (c *ovhProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
-	_, ok := c.zones[domain]
-	if !ok {
-		return nil, fmt.Errorf("'%s' not a zone in ovh account", domain)
+
+	// FIXME(tlim): This safety check is unneeded as the fetchNS() call will suffice.
+	if listzonesEnabled() {
+		_, ok := c.zones[domain]
+		if !ok {
+			return nil, fmt.Errorf("'%s' not a zone in ovh account", domain)
+		}
 	}
+	// If ListZones() is enabled, assume any zone exists. The safety check is rather silly anyway.
 
 	ns, err := c.fetchNS(domain)
 	if err != nil {
@@ -121,7 +131,8 @@ func (c *ovhProvider) ListZones() (zones []string, err error) {
 func (c *ovhProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records, error) {
 	domain := dc.Name
 
-	if !c.zones[domain] {
+	// FIXME(tlim): This safety check is unneeded as the fetchRecords() call will suffice.
+	if listzonesEnabled() && !c.zones[domain] {
 		return nil, errNoExist{domain}
 	}
 
@@ -229,7 +240,7 @@ func nativeToRecord(r *Record, dc *models.DomainConfig) (*models.RecordConfig, e
 
 	switch rtype {
 	case "TXT":
-		var tx string
+		//fmt.Printf("DEBUG: OVH %s=%s\n", r.FieldType, r.Target)
 		switch r.FieldType {
 		case "DKIM", "DMARC":
 			// Unlike regular TXT and SPF records, OVH stores and returns DKIM
@@ -237,14 +248,10 @@ func nativeToRecord(r *Record, dc *models.DomainConfig) (*models.RecordConfig, e
 			// through the RFC1035 zone-file TXT parser is wrong: an unescaped
 			// ';' is interpreted as the start of a comment, silently
 			// truncating values like "v=DMARC1; p=none; rua=...".
-			tx = r.Target
+			rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, r.Target)
 		default:
-			tx, err = txtutil.ParseQuoted(r.Target)
-			if err != nil {
-				return nil, err
-			}
+			rc, err = dc.NewRecordConfigParse(label, ttl, dnsv2.TypeTXT, r.Target)
 		}
-		rc, err = dc.NewRecordConfig(label, ttl, dnsv2.TypeTXT, tx)
 	default:
 		rc, err = dc.NewRecordConfigParse(label, ttl, rtype, r.Target)
 	}

--- a/providers/ovh/protocol.go
+++ b/providers/ovh/protocol.go
@@ -14,6 +14,13 @@ type Void struct{}
 
 // fetchDomainList gets list of zones for account.
 func (c *ovhProvider) fetchZones() error {
+	// If we're in "pretend ListZones() isn't implemented mode" we return an
+	// empty list.  Elsewhere, we disable functionality that would require
+	// having the entire list of zones.
+	if !listzonesEnabled() {
+		return nil
+	}
+
 	if c.zones != nil {
 		return nil
 	}


### PR DESCRIPTION
Fixes https://github.com/DNSControl/dnscontrol/issues/4761

The API key we use to test OVH does not have access to the "list all zones" API call. Therefore we need to be able to work without that call.

When used, ListZones() returns an empty list and the systems that rely (verifying that a zone exists) assume the zone is valid.

This mode is activated by the secret flag `preview --disable-list-zones` (works with `push` too) or when running integration tests, `-disablelistzones`.

Example usage:

```
# Testing:
go test -timeout 1h -failfast -v -args -verbose -profile OVH -disablelistzones
# preview/push:
dnscontrol preview --disable-list-zones
```

This issue was raised in https://github.com/DNSControl/dnscontrol/issues/4761

Now that OVH integration tests work, we discovered that TXT records don't parse correctly. Fixed.