### PR TITLE
FEATURE: updated DMARC_BUILDER for RFC 9989

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-puppeteer_skip_download=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+puppeteer_skip_download=true

--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -987,7 +987,6 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  *   DMARC_BUILDER({
  *     policy: "reject",
  *     subdomainPolicy: "quarantine",
- *     percent: 50,
  *     alignmentSPF: "r",
  *     alignmentDKIM: "strict",
  *     rua: [
@@ -998,7 +997,6 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  *       "mailto:mailauth-reports@example.com",
  *     ],
  *     failureOptions: "1",
- *     reportInterval: "1h",
  *   }),
  * );
  * ```
@@ -1022,7 +1020,7 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  * This yields the following records:
  *
  * ```text
- * @           IN  TXT "v=DMARC1; p=reject; sp=quarantine; adkim=s; aspf=r; pct=50; rua=mailto:mailauth-reports@example.com,https://dmarc.example.com/submit; ruf=mailto:mailauth-reports@example.com; fo=1; ri=3600"
+ * @           IN  TXT "v=DMARC1; p=reject; sp=quarantine; adkim=s; aspf=r; rua=mailto:mailauth-reports@example.com,https://dmarc.example.com/submit; ruf=mailto:mailauth-reports@example.com; fo=1"
  * insecure    IN  TXT "v=DMARC1; p=none; ruf=mailto:mailauth-reports@example.com; fo=d"
  * ```
  *
@@ -1037,9 +1035,9 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  * * `alignmentDKIM:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for DKIM (`adkim=`, default: `"r"`)
  * * `rua:` Array of aggregate report targets (optional)
  * * `ruf:` Array of failure report targets (optional)
- * * `failureOptions:` Object or string; Object containing booleans `SPF` and `DKIM`, string is passed raw (`fo=`, default: `"0"`)
  * * `publicSuffixDomain:` `"y"`, or `"n"` or `"u"` indicates whether the domain is a Public Suffix Domain (`psd=`, default: `"u"`)
  * * `testMode:` `"y"` or `"n"` DMARC policy test mode dictates whether p, sp, or np policy tags are applied (`t=`, default: `"n"`)
+ * * `failureOptions:` Object or string; Object containing booleans `SPF` and `DKIM`, string is passed raw (`fo=`, default: `"0"`)
  * * `ttl:` Input for `TTL` method (optional)
  *
  * ### Caveats
@@ -1049,7 +1047,7 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/dmarc_builder
  */
-declare function DMARC_BUILDER(opts: { label?: string; version?: string; policy: 'none' | 'quarantine' | 'reject'; subdomainPolicy?: 'none' | 'quarantine' | 'reject'; nonexistentSubdomainPolicy?: 'none' | 'quarantine' | 'reject'; alignmentSPF?: 'strict' | 's' | 'relaxed' | 'r'; alignmentDKIM?: 'strict' | 's' | 'relaxed' | 'r'; rua?: string[]; ruf?: string[]; failureOptions?: { SPF: boolean, DKIM: boolean } | string; publicSuffixDomain?: 'y' | 'n' | 'u'; testMode?: 'y' | 'n'; failureFormat?: string; ttl?: Duration }): DomainModifier;
+declare function DMARC_BUILDER(opts: { label?: string; version?: string; policy: 'none' | 'quarantine' | 'reject'; subdomainPolicy?: 'none' | 'quarantine' | 'reject'; nonexistentSubdomainPolicy?: 'none' | 'quarantine' | 'reject'; alignmentSPF?: 'strict' | 's' | 'relaxed' | 'r'; alignmentDKIM?: 'strict' | 's' | 'relaxed' | 'r'; rua?: string[]; ruf?: string[]; publicSuffixDomain: 'y' | 'n' | 'u'; testMode: 'y' | 'n'; failureOptions?: { SPF: boolean, DKIM: boolean } | string; ttl?: Duration }): DomainModifier;
 
 /**
  * `DNAME` adds a [Delegation name record](https://www.rfc-editor.org/rfc/rfc6672) to the domain.

--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -1032,14 +1032,14 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  * * `version:` The DMARC version to be used (default: `DMARC1`)
  * * `policy:` The DMARC policy (`p=`), must be one of `"none"`, `"quarantine"`, `"reject"`
  * * `subdomainPolicy:` The DMARC policy for subdomains (`sp=`), must be one of `"none"`, `"quarantine"`, `"reject"` (optional)
+ * * `nonexistentSubdomainPolicy:` The DMARC policy for nonexistent subdomains (`np=`), must be one of `"none"`, `"quarantine"`, `"reject"` (optional)
  * * `alignmentSPF:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for SPF (`aspf=`, default: `"r"`)
  * * `alignmentDKIM:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for DKIM (`adkim=`, default: `"r"`)
- * * `percent:` Number between `0` and `100`, percentage for which policies are applied (`pct=`, default: `100`)
  * * `rua:` Array of aggregate report targets (optional)
  * * `ruf:` Array of failure report targets (optional)
  * * `failureOptions:` Object or string; Object containing booleans `SPF` and `DKIM`, string is passed raw (`fo=`, default: `"0"`)
- * * `failureFormat:` Format in which failure reports are requested (`rf=`, default: `"afrf"`)
- * * `reportInterval:` Interval in which reports are requested (`ri=`)
+ * * `publicSuffixDomain:` `"y"`, or `"n"` or `"u"` indicates whether the domain is a Public Suffix Domain (`psd=`, default: `"u"`)
+ * * `testMode:` `"y"` or `"n"` DMARC policy test mode dictates whether p, sp, or np policy tags are applied (`t=`, default: `"n"`)
  * * `ttl:` Input for `TTL` method (optional)
  *
  * ### Caveats
@@ -1049,7 +1049,7 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/dmarc_builder
  */
-declare function DMARC_BUILDER(opts: { label?: string; version?: string; policy: 'none' | 'quarantine' | 'reject'; subdomainPolicy?: 'none' | 'quarantine' | 'reject'; alignmentSPF?: 'strict' | 's' | 'relaxed' | 'r'; alignmentDKIM?: 'strict' | 's' | 'relaxed' | 'r'; percent?: number; rua?: string[]; ruf?: string[]; failureOptions?: { SPF: boolean, DKIM: boolean } | string; failureFormat?: string; reportInterval?: Duration; ttl?: Duration }): DomainModifier;
+declare function DMARC_BUILDER(opts: { label?: string; version?: string; policy: 'none' | 'quarantine' | 'reject'; subdomainPolicy?: 'none' | 'quarantine' | 'reject'; nonexistentSubdomainPolicy?: 'none' | 'quarantine' | 'reject'; alignmentSPF?: 'strict' | 's' | 'relaxed' | 'r'; alignmentDKIM?: 'strict' | 's' | 'relaxed' | 'r'; rua?: string[]; ruf?: string[]; failureOptions?: { SPF: boolean, DKIM: boolean } | string; publicSuffixDomain?: 'y' | 'n' | 'u'; testMode?: 'y' | 'n'; failureFormat?: string; ttl?: Duration }): DomainModifier;
 
 /**
  * `DNAME` adds a [Delegation name record](https://www.rfc-editor.org/rfc/rfc6672) to the domain.

--- a/documentation/language-reference/domain-modifiers/DMARC_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/DMARC_BUILDER.md
@@ -5,14 +5,14 @@ parameters:
   - version
   - policy
   - subdomainPolicy
+  - nonexistentSubdomainPolicy
   - alignmentSPF
   - alignmentDKIM
-  - percent
   - rua
   - ruf
+  - publicSuffixDomain
+  - testMode
   - failureOptions
-  - failureFormat
-  - reportInterval
   - ttl
 parameters_object: true
 parameter_types:
@@ -20,14 +20,14 @@ parameter_types:
   version: string?
   policy: "'none' | 'quarantine' | 'reject'"
   subdomainPolicy: "'none' | 'quarantine' | 'reject'?"
+  nonexistentSubdomainPolicy: "'none' | 'quarantine' | 'reject'?"
   alignmentSPF: "'strict' | 's' | 'relaxed' | 'r'?"
   alignmentDKIM: "'strict' | 's' | 'relaxed' | 'r'?"
-  percent: number?
   rua: string[]?
   ruf: string[]?
+  publicSuffixDomain: "'y' | 'n' | 'u'"
+  testMode: "'y' | 'n'"
   failureOptions: "{ SPF: boolean, DKIM: boolean } | string?"
-  failureFormat: string?
-  reportInterval: Duration?
   ttl: Duration?
 ---
 
@@ -66,7 +66,6 @@ D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
   DMARC_BUILDER({
     policy: "reject",
     subdomainPolicy: "quarantine",
-    percent: 50,
     alignmentSPF: "r",
     alignmentDKIM: "strict",
     rua: [
@@ -77,7 +76,6 @@ D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
       "mailto:mailauth-reports@example.com",
     ],
     failureOptions: "1",
-    reportInterval: "1h",
   }),
 );
 ```
@@ -104,7 +102,7 @@ D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
 This yields the following records:
 
 ```text
-@           IN  TXT "v=DMARC1; p=reject; sp=quarantine; adkim=s; aspf=r; pct=50; rua=mailto:mailauth-reports@example.com,https://dmarc.example.com/submit; ruf=mailto:mailauth-reports@example.com; fo=1; ri=3600"
+@           IN  TXT "v=DMARC1; p=reject; sp=quarantine; adkim=s; aspf=r; rua=mailto:mailauth-reports@example.com,https://dmarc.example.com/submit; ruf=mailto:mailauth-reports@example.com; fo=1"
 insecure    IN  TXT "v=DMARC1; p=none; ruf=mailto:mailauth-reports@example.com; fo=d"
 ```
 
@@ -114,14 +112,14 @@ insecure    IN  TXT "v=DMARC1; p=none; ruf=mailto:mailauth-reports@example.com; 
 * `version:` The DMARC version to be used (default: `DMARC1`)
 * `policy:` The DMARC policy (`p=`), must be one of `"none"`, `"quarantine"`, `"reject"`
 * `subdomainPolicy:` The DMARC policy for subdomains (`sp=`), must be one of `"none"`, `"quarantine"`, `"reject"` (optional)
+* `nonexistentSubdomainPolicy:` The DMARC policy for nonexistent subdomains (`np=`), must be one of `"none"`, `"quarantine"`, `"reject"` (optional)
 * `alignmentSPF:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for SPF (`aspf=`, default: `"r"`)
 * `alignmentDKIM:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for DKIM (`adkim=`, default: `"r"`)
-* `percent:` Number between `0` and `100`, percentage for which policies are applied (`pct=`, default: `100`)
 * `rua:` Array of aggregate report targets (optional)
 * `ruf:` Array of failure report targets (optional)
+* `publicSuffixDomain:` `"y"`, or `"n"` or `"u"` indicates whether the domain is a Public Suffix Domain (`psd=`, default: `"u"`) 
+* `testMode:` `"y"` or `"n"` DMARC policy test mode dictates whether p, sp, or np policy tags are applied (`t=`, default: `"n"`) 
 * `failureOptions:` Object or string; Object containing booleans `SPF` and `DKIM`, string is passed raw (`fo=`, default: `"0"`)
-* `failureFormat:` Format in which failure reports are requested (`rf=`, default: `"afrf"`)
-* `reportInterval:` Interval in which reports are requested (`ri=`)
 * `ttl:` Input for `TTL` method (optional)
 
 ### Caveats

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -2260,6 +2260,8 @@ function DMARC_BUILDER(value) {
     // Percentage
     if (value.percent) {
         record.push('pct=' + value.percent);
+        console.log("WARNING: DMARC pct tag depracated.");
+        
     }
 
     // Aggregate reports
@@ -2294,18 +2296,23 @@ function DMARC_BUILDER(value) {
         }
     }
 
+    
+
     // Failure report format
     if (value.ruf && value.failureFormat) {
         record.push('rf=' + value.failureFormat);
+        console.log("WARNING: DMARC rf tag depracated.");
     }
 
     // Report interval
+    
     if (value.reportInterval) {
         if (_.isString(value.reportInterval)) {
             value.reportInterval = stringToDuration(value.reportInterval);
         }
 
         record.push('ri=' + value.reportInterval);
+        console.log("WARNING: DMARC ri tag depracated.");
     }
 
     if (value.ttl) {

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -2167,14 +2167,14 @@ function DKIM_BUILDER(value) {
 // version: The DMARC version, by default DMARC1 (optional)
 // policy: The DMARC policy (p=), must be one of 'none', 'quarantine', 'reject'
 // subdomainPolicy: The DMARC policy for subdomains (sp=), must be one of 'none', 'quarantine', 'reject' (optional)
+// nonexistentSubdomainPolicy: The DMARC policy for nonexistent subdomains (np=), must be one of 'none', 'quarantine', 'reject' (optional)
 // alignmentSPF: 'strict'/'s' or 'relaxed'/'r' alignment for SPF (aspf=, default: 'r')
 // alignmentDKIM: 'strict'/'s' or 'relaxed'/'r' alignment for DKIM (adkim=, default: 'r')
-// percent: Number between 0 and 100, percentage for which policies are applied (pct=, default: 100)
 // rua: Array of aggregate report targets (optional)
 // ruf: Array of failure report targets (optional)
+// publicSuffixDomain: 'y', 'n', or 'u' indicates whether the domain is a Public Suffix Domain (`psd=`, default='u') 
+// testMode: 'y' or 'n' DMARC policy test mode dictates whether p, sp, or np policy tags are applied (`t=`, default: 'n')
 // failureOptions: Object or string; Object containing booleans SPF and DKIM, string is passed raw (fo=, default: '0')
-// failureFormat: Format in which failure reports are requested (rf=, default: 'afrf')
-// reportInterval: Interval in which reports are requested (ri=)
 // ttl: Input for TTL method
 function DMARC_BUILDER(value) {
     if (!value) {
@@ -2317,7 +2317,6 @@ function DMARC_BUILDER(value) {
     }
 
     // Report interval
-    
     if (value.reportInterval) {
         if (_.isString(value.reportInterval)) {
             value.reportInterval = stringToDuration(value.reportInterval);
@@ -2328,14 +2327,13 @@ function DMARC_BUILDER(value) {
     }
 
     // Public Suffix Domain
-
     if (value.publicSuffixDomain) {
         if (
-            !value.subdomainPolicy === 'u' ||
-            !value.subdomainPolicy === 'y' ||
-            !value.subdomainPolicy === 'n'
+            !value.publicSuffixDomain === 'u' ||
+            !value.publicSuffixDomain === 'y' ||
+            !value.publicSuffixDomain === 'n'
         ) {
-            throw "Invalid public-suffix-domain tag");
+            throw 'Invalid public-suffix-domain tag';
         }
 
         record.push('psd=' + value.publicSuffixDomain)
@@ -2348,7 +2346,7 @@ function DMARC_BUILDER(value) {
             !value.testMode === 'y' ||
             !value.testMode === 'n'
         ) {
-            throw "Invalid test-mode tag"
+            throw 'Invalid test-mode tag'
         }
 
         record.push('t=' + value.testMode)

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -2172,7 +2172,7 @@ function DKIM_BUILDER(value) {
 // alignmentDKIM: 'strict'/'s' or 'relaxed'/'r' alignment for DKIM (adkim=, default: 'r')
 // rua: Array of aggregate report targets (optional)
 // ruf: Array of failure report targets (optional)
-// publicSuffixDomain: 'y', 'n', or 'u' indicates whether the domain is a Public Suffix Domain (`psd=`, default='u') 
+// publicSuffixDomain: 'y', 'n', or 'u' indicates whether the domain is a Public Suffix Domain (`psd=`, default='u')
 // testMode: 'y' or 'n' DMARC policy test mode dictates whether p, sp, or np policy tags are applied (`t=`, default: 'n')
 // failureOptions: Object or string; Object containing booleans SPF and DKIM, string is passed raw (fo=, default: '0')
 // ttl: Input for TTL method
@@ -2272,8 +2272,7 @@ function DMARC_BUILDER(value) {
     // Percentage
     if (value.percent) {
         record.push('pct=' + value.percent);
-        console.log("WARNING: DMARC pct tag depracated.");
-        
+        console.log('WARNING: DMARC pct tag depracated.');
     }
 
     // Aggregate reports
@@ -2285,7 +2284,7 @@ function DMARC_BUILDER(value) {
     if (value.ruf && value.ruf.length > 0) {
         record.push('ruf=' + value.ruf.join(','));
     }
-    
+
     // Failure reporting options
     if (value.ruf && value.failureOptions) {
         var fo = '0';
@@ -2308,12 +2307,10 @@ function DMARC_BUILDER(value) {
         }
     }
 
-    
-
     // Failure report format
     if (value.ruf && value.failureFormat) {
         record.push('rf=' + value.failureFormat);
-        console.log("WARNING: DMARC rf tag depracated.");
+        console.log('WARNING: DMARC rf tag depracated.');
     }
 
     // Report interval
@@ -2323,7 +2320,7 @@ function DMARC_BUILDER(value) {
         }
 
         record.push('ri=' + value.reportInterval);
-        console.log("WARNING: DMARC ri tag depracated.");
+        console.log('WARNING: DMARC ri tag depracated.');
     }
 
     // Public Suffix Domain
@@ -2336,20 +2333,17 @@ function DMARC_BUILDER(value) {
             throw 'Invalid public-suffix-domain tag';
         }
 
-        record.push('psd=' + value.publicSuffixDomain)
+        record.push('psd=' + value.publicSuffixDomain);
     }
 
     // Test mode
 
     if (value.testMode) {
-        if (
-            !value.testMode === 'y' ||
-            !value.testMode === 'n'
-        ) {
-            throw 'Invalid test-mode tag'
+        if (!value.testMode === 'y' || !value.testMode === 'n') {
+            throw 'Invalid test-mode tag';
         }
 
-        record.push('t=' + value.testMode)
+        record.push('t=' + value.testMode);
     }
 
     if (value.ttl) {

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -2221,6 +2221,18 @@ function DMARC_BUILDER(value) {
         record.push('sp=' + value.subdomainPolicy);
     }
 
+    // Nonexistent-Subdomain policy
+    if (
+        !value.nonexistentSubdomainPolicy === 'none' ||
+        !value.nonexistentSubdomainPolicy === 'quarantine' ||
+        !value.nonexistentSubdomainPolicy === 'reject'
+    ) {
+        throw 'Invalid DMARC nonexistent-subdomain policy';
+    }
+    if (value.subdomainPolicy) {
+        record.push('np=' + value.subdomainPolicy);
+    }
+
     // Alignment DKIM
     if (value.alignmentDKIM) {
         switch (value.alignmentDKIM) {
@@ -2273,7 +2285,7 @@ function DMARC_BUILDER(value) {
     if (value.ruf && value.ruf.length > 0) {
         record.push('ruf=' + value.ruf.join(','));
     }
-
+    
     // Failure reporting options
     if (value.ruf && value.failureOptions) {
         var fo = '0';
@@ -2313,6 +2325,33 @@ function DMARC_BUILDER(value) {
 
         record.push('ri=' + value.reportInterval);
         console.log("WARNING: DMARC ri tag depracated.");
+    }
+
+    // Public Suffix Domain
+
+    if (value.publicSuffixDomain) {
+        if (
+            !value.subdomainPolicy === 'u' ||
+            !value.subdomainPolicy === 'y' ||
+            !value.subdomainPolicy === 'n'
+        ) {
+            throw "Invalid public-suffix-domain tag");
+        }
+
+        record.push('psd=' + value.publicSuffixDomain)
+    }
+
+    // Test mode
+
+    if (value.testMode) {
+        if (
+            !value.testMode === 'y' ||
+            !value.testMode === 'n'
+        ) {
+            throw "Invalid test-mode tag"
+        }
+
+        record.push('t=' + value.testMode)
     }
 
     if (value.ttl) {


### PR DESCRIPTION
Fixes #4378

Updated DMARC_BUILDER to deprecate `ri`, `rf`, and `pct` tags. Added support for `np`, `t`, and `psd` tags. Updated documentation to represent the changes (removed information about `ri`, `rf`, and `pct` and added information about `np`, `t`, and `psd`). 

`ri`, `rf`, and `pct` logic left in place; they now log warning to the console. 

