### PR TITLE
ROUTE53: Fix R53_ALIAS and R53_EVALUATE_TARGET_HEALTH bugs

### DIFF
--- a/models/makers.go
+++ b/models/makers.go
@@ -310,25 +310,6 @@ func MakeRP(origin string, _ map[string]string, isEnabled nrc.Flags, args ...any
 	return dnsrdatav2.RP{Mbox: mbox, Txt: txt}, nil
 }
 
-func MakeR53ALIAS(origin string, _ map[string]string, isEnabled nrc.Flags, args ...any) (dnsv2.RDATA, error) {
-	mustbe.ValidArgs(args)
-	if len(args) != 5 {
-		return nil, fmt.Errorf("MakeR53ALIAS expects exactly 5 arguments, got %d: %+v", len(args), args)
-	}
-	target, err := mustbe.TargetHost(origin, isEnabled, args[1])
-	if err != nil {
-		return nil, err
-	}
-	return privatetypesrdata.R53ALIAS{
-		AliasType: mustbe.RawString(args[0]),
-		Target:    target,
-		// NB(tlim): These are commented out because the integration tests fail with them. Needs investigation.
-		// ZoneID:           mustbe.RawString(args[2]),
-		// EvalTargetHealth: mustbe.RawString(args[3]),
-		// FIXME(tlim): EvalTargetHealth is a boolean in our internal model but the R53ALIAS type expects a string. Maybe unify them in the future?
-	}, nil
-}
-
 func MakeSMIMEA(origin string, _ map[string]string, isEnabled nrc.Flags, args ...any) (dnsv2.RDATA, error) {
 	mustbe.ValidArgs(args)
 	if len(args) != 4 {

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -407,7 +407,13 @@ function R53_EVALUATE_TARGET_HEALTH(enabled) {
 
 function r53AliasOptions(record, processedArgs, processedMetas) {
     // The args are [label, aliasType, target, evaluate_target_health, zone_id].
-    var replacement = [ processedArgs[0], processedArgs[1], processedArgs[2], '', '', ];
+    var replacement = [
+        processedArgs[0],
+        processedArgs[1],
+        processedArgs[2],
+        '',
+        '',
+    ];
 
     if (_.isObject(record.r53_alias)) {
         replacement[3] = record.r53_alias['evaluate_target_health'] || 'false';

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -406,7 +406,8 @@ function R53_EVALUATE_TARGET_HEALTH(enabled) {
 }
 
 function r53AliasOptions(record, processedArgs, processedMetas) {
-    var replacement = [processedArgs[0], processedArgs[1], '', ''];
+    // The args are [label, aliasType, target, evaluate_target_health, zone_id].
+    var replacement = [ processedArgs[0], processedArgs[1], processedArgs[2], '', '', ];
 
     if (_.isObject(record.r53_alias)) {
         replacement[3] = record.r53_alias['evaluate_target_health'] = 'false';

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -410,7 +410,7 @@ function r53AliasOptions(record, processedArgs, processedMetas) {
     var replacement = [ processedArgs[0], processedArgs[1], processedArgs[2], '', '', ];
 
     if (_.isObject(record.r53_alias)) {
-        replacement[3] = record.r53_alias['evaluate_target_health'] = 'false';
+        replacement[3] = record.r53_alias['evaluate_target_health'] || 'false';
         replacement[4] = record.r53_alias['zone_id'] || '';
     }
 

--- a/pkg/js/parse_tests/019-r53-alias.js
+++ b/pkg/js/parse_tests/019-r53-alias.js
@@ -3,6 +3,7 @@ D("foo.com", "none",
     R53_ALIAS("atest", "A", "foo.com."),
     R53_ALIAS("atest", "A", "foo.com.", R53_ZONE("Z2FTEDLFRTF")),
     R53_ALIAS("aevaltargethealthtest", "A", "foo.com.", R53_EVALUATE_TARGET_HEALTH(true)),
+    R53_ALIAS("aevaltargethealthtest2", "A", "foo.com.", R53_EVALUATE_TARGET_HEALTH(false)),
     R53_ALIAS("aaaatest", "AAAA", "foo.com."),
     R53_ALIAS("aaaatest", "AAAA", "foo.com.", R53_ZONE("ERERTFGFGF")),
     R53_ALIAS("cnametest", "CNAME", "foo.com."),
@@ -17,5 +18,8 @@ D("foo.com", "none",
     R53_ALIAS("tlsatest", "TLSA", "foo.com."),
     R53_ALIAS("sshfptest", "SSHFP", "foo.com."),
     R53_ALIAS("svcbtest", "SVCB", "foo.com."),
-    R53_ALIAS("httpstest", "HTTPS", "foo.com.")
+    R53_ALIAS("httpstest", "HTTPS", "foo.com."),
+    // Non-apex (out-of-zone) targets. GitHub issue https://github.com/DNSControl/dnscontrol/issues/4796
+    R53_ALIAS("cftest", "A", "d111111abcdef8.cloudfront.net."),
+    R53_ALIAS("cfzonetest", "A", "d222222abcdef8.cloudfront.net.", R53_ZONE("Z2FDTNDATAQYW2"))
 );

--- a/pkg/js/parse_tests/019-r53-alias.json
+++ b/pkg/js/parse_tests/019-r53-alias.json
@@ -7,7 +7,7 @@
       "records": [
         {
           "comparablev3": "AAAA foo.com. \"\" \"\"",
-          "filepos": "[line:6:5]",
+          "filepos": "[line:7:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -25,7 +25,7 @@
         },
         {
           "comparablev3": "AAAA foo.com. false ERERTFGFGF",
-          "filepos": "[line:7:5]",
+          "filepos": "[line:8:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -49,6 +49,24 @@
           },
           "name": "aevaltargethealthtest",
           "name_unicode": "aevaltargethealthtest",
+          "rdata": {
+            "AliasType": "A",
+            "EvalTargetHealth": "true",
+            "Target": "foo.com.",
+            "ZoneID": ""
+          },
+          "ttl": 300,
+          "type": "R53_ALIAS",
+          "typenum": 65298
+        },
+        {
+          "comparablev3": "A foo.com. false \"\"",
+          "filepos": "[line:6:5]",
+          "meta": {
+            "orig_custom_type": "R53_ALIAS"
+          },
+          "name": "aevaltargethealthtest2",
+          "name_unicode": "aevaltargethealthtest2",
           "rdata": {
             "AliasType": "A",
             "EvalTargetHealth": "false",
@@ -97,7 +115,7 @@
         },
         {
           "comparablev3": "CAA foo.com. \"\" \"\"",
-          "filepos": "[line:13:5]",
+          "filepos": "[line:14:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -114,8 +132,44 @@
           "typenum": 65298
         },
         {
+          "comparablev3": "A d111111abcdef8.cloudfront.net. \"\" \"\"",
+          "filepos": "[line:23:5]",
+          "meta": {
+            "orig_custom_type": "R53_ALIAS"
+          },
+          "name": "cftest",
+          "name_unicode": "cftest",
+          "rdata": {
+            "AliasType": "A",
+            "EvalTargetHealth": "",
+            "Target": "d111111abcdef8.cloudfront.net.",
+            "ZoneID": ""
+          },
+          "ttl": 300,
+          "type": "R53_ALIAS",
+          "typenum": 65298
+        },
+        {
+          "comparablev3": "A d222222abcdef8.cloudfront.net. false Z2FDTNDATAQYW2",
+          "filepos": "[line:24:5]",
+          "meta": {
+            "orig_custom_type": "R53_ALIAS"
+          },
+          "name": "cfzonetest",
+          "name_unicode": "cfzonetest",
+          "rdata": {
+            "AliasType": "A",
+            "EvalTargetHealth": "false",
+            "Target": "d222222abcdef8.cloudfront.net.",
+            "ZoneID": "Z2FDTNDATAQYW2"
+          },
+          "ttl": 300,
+          "type": "R53_ALIAS",
+          "typenum": 65298
+        },
+        {
           "comparablev3": "CNAME foo.com. \"\" \"\"",
-          "filepos": "[line:8:5]",
+          "filepos": "[line:9:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -133,7 +187,7 @@
         },
         {
           "comparablev3": "DS foo.com. \"\" \"\"",
-          "filepos": "[line:16:5]",
+          "filepos": "[line:17:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -151,7 +205,7 @@
         },
         {
           "comparablev3": "HTTPS foo.com. \"\" \"\"",
-          "filepos": "[line:20:5]",
+          "filepos": "[line:21:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -187,7 +241,7 @@
         },
         {
           "comparablev3": "NAPTR foo.com. \"\" \"\"",
-          "filepos": "[line:14:5]",
+          "filepos": "[line:15:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -205,7 +259,7 @@
         },
         {
           "comparablev3": "PTR foo.com. \"\" \"\"",
-          "filepos": "[line:9:5]",
+          "filepos": "[line:10:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -223,7 +277,7 @@
         },
         {
           "comparablev3": "SOA foo.com. \"\" \"\"",
-          "filepos": "[line:15:5]",
+          "filepos": "[line:16:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -241,7 +295,7 @@
         },
         {
           "comparablev3": "SPF foo.com. \"\" \"\"",
-          "filepos": "[line:12:5]",
+          "filepos": "[line:13:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -259,7 +313,7 @@
         },
         {
           "comparablev3": "SRV foo.com. \"\" \"\"",
-          "filepos": "[line:11:5]",
+          "filepos": "[line:12:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -277,7 +331,7 @@
         },
         {
           "comparablev3": "SSHFP foo.com. \"\" \"\"",
-          "filepos": "[line:18:5]",
+          "filepos": "[line:19:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -295,7 +349,7 @@
         },
         {
           "comparablev3": "SVCB foo.com. \"\" \"\"",
-          "filepos": "[line:19:5]",
+          "filepos": "[line:20:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -313,7 +367,7 @@
         },
         {
           "comparablev3": "TLSA foo.com. \"\" \"\"",
-          "filepos": "[line:17:5]",
+          "filepos": "[line:18:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },
@@ -331,7 +385,7 @@
         },
         {
           "comparablev3": "TXT foo.com. \"\" \"\"",
-          "filepos": "[line:10:5]",
+          "filepos": "[line:11:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"
           },

--- a/pkg/js/parse_tests/019-r53-alias.json
+++ b/pkg/js/parse_tests/019-r53-alias.json
@@ -42,7 +42,7 @@
           "typenum": 65298
         },
         {
-          "comparablev3": "A foo.com. false \"\"",
+          "comparablev3": "A foo.com. true \"\"",
           "filepos": "[line:5:5]",
           "meta": {
             "orig_custom_type": "R53_ALIAS"


### PR DESCRIPTION
Fixes https://github.com/DNSControl/dnscontrol/issues/4796

* Bug 1: `R53_ALIAS`: Always sets the target to the apex domain.
* Bug 2: `R53_EVALUATE_TARGET_HEALTH`: Always sets to "false".

Changes:

* MakeR53ALIAS was defined in two places (luckily the extra one was unused)
* The JS r53AliasOptions function ignored the 3rd argument, which held the non-apex string.
* evaluate_target_health was set to "false" no matter what.
* Added test cases to 019-r53-alias.js to cover both bugs.