### PR TITLE
REFACTOR: Simplify boolean returns, hoist regexps, tidy error paths

### DIFF
--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -653,10 +653,12 @@ func skipProvider(name string, providers []*models.DNSProviderInstance) bool {
 	})
 }
 
+// ansiEscapeRe matches terminal ANSI styling escape sequences.
+var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
 func parseCorrectionMsg(s string) []string {
-	// Regex to remove the terminal styled formatting
-	ansiRe := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
-	s = ansiRe.ReplaceAllString(s, "")
+	// Remove the terminal styled formatting.
+	s = ansiEscapeRe.ReplaceAllString(s, "")
 	// Create a slice(array) of correction/actions/changes from Msg
 	corrections := strings.Split(s, "\n")
 	// Clean up the slice, precaution remove any empty entries.

--- a/models/stutter.go
+++ b/models/stutter.go
@@ -16,6 +16,7 @@ func doesStutter(name, origin string) bool {
 	if name == "@" {
 		return false
 	}
+	// Return true if name is the origin (should be "@") or ends in the origin.
 	return name == origin || strings.HasSuffix(name, "."+origin)
 }
 

--- a/models/stutter.go
+++ b/models/stutter.go
@@ -16,10 +16,7 @@ func doesStutter(name, origin string) bool {
 	if name == "@" {
 		return false
 	}
-	if name == origin || strings.HasSuffix(name, "."+origin) {
-		return true
-	}
-	return false
+	return name == origin || strings.HasSuffix(name, "."+origin)
 }
 
 func stutterError(rc *RecordConfig, domain string) error {

--- a/pkg/mustbe/hosts.go
+++ b/pkg/mustbe/hosts.go
@@ -127,12 +127,8 @@ func violatesSingleDotPolicy(s string) bool {
 	if strings.HasSuffix(s, ".") {
 		return false
 	}
-	// contains even a single dot, fails.
-	if strings.Contains(s, ".") {
-		return true
-	}
-	// Otherwise, passes.
-	return false
+	// Any interior dot (with no trailing dot to make it an FQDN) fails.
+	return strings.Contains(s, ".")
 }
 
 func MakeErrorSingleDotViolation(s string) error {

--- a/providers/autodns/api.go
+++ b/providers/autodns/api.go
@@ -120,7 +120,7 @@ func (api *autoDNSProvider) request(method string, requestPath string, data any)
 		time.Sleep(sleepDuration)
 	}
 
-	return nil, errors.New("Failed to fetch" + requestURL.Path + " after 4 retries")
+	return nil, fmt.Errorf("failed to fetch %s after 4 retries", requestURL.Path)
 }
 
 func (api *autoDNSProvider) findZoneSystemNameServer(domain string) (*models.Nameserver, error) {

--- a/providers/desec/protocol.go
+++ b/providers/desec/protocol.go
@@ -160,6 +160,9 @@ func appendDomainIndexFromResponse(domainIndex map[string]uint32, bodyString []b
 }
 
 // Parses the Link Header into a map (https://github.com/desec-io/desec-tools/blob/main/fetch_zone.py#L13)
+// linkRelRe extracts the rel="..." parameter from an HTTP Link header.
+var linkRelRe = regexp.MustCompile(`rel="(.*)"`)
+
 func convertLinks(links string) map[string]string {
 	mapping := make(map[string]string)
 	printer.Debugf("Header: %s\n", links)
@@ -169,8 +172,7 @@ func convertLinks(links string) map[string]string {
 			printer.Printf("unexpected link header %s", link)
 			continue
 		}
-		r := regexp.MustCompile(`rel="(.*)"`)
-		matches := r.FindStringSubmatch(tmpurl[1])
+		matches := linkRelRe.FindStringSubmatch(tmpurl[1])
 		if len(matches) != 2 {
 			printer.Printf("unexpected label %s", tmpurl[1])
 			continue

--- a/providers/gcloud/gcloudProvider.go
+++ b/providers/gcloud/gcloudProvider.go
@@ -398,13 +398,8 @@ func wouldOverfill(batch *gdns.Change, adds, dels *gdns.ResourceRecordSet) bool 
 		delCount = len(dels.Rrdatas)
 	}
 
-	if (len(batch.Additions) + addCount) > batchMax { // Would additions push us over the limit?
-		return true
-	}
-	if (len(batch.Deletions) + delCount) > batchMax { // Would deletions push us over the limit?
-		return true
-	}
-	return false
+	// Would additions or deletions push us over the limit?
+	return len(batch.Additions)+addCount > batchMax || len(batch.Deletions)+delCount > batchMax
 }
 
 func (g *gcloudProvider) mkCorrection(corrections []*models.Correction, accumulatedMsgs []string, batch *gdns.Change, origin string) []*models.Correction {

--- a/providers/openwrt/api.go
+++ b/providers/openwrt/api.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -82,10 +81,9 @@ retry:
 	}
 
 	if response.Result == "" {
-		return "", fmt.Errorf("authentication token is empty")
-	} else {
-		return response.Result, response.Error
+		return "", errors.New("authentication token is empty")
 	}
+	return response.Result, response.Error
 }
 
 func (c *openwrtProvider) uciApply() ([]any, error) {

--- a/providers/route53/route53Provider.go
+++ b/providers/route53/route53Provider.go
@@ -48,10 +48,9 @@ func newRoute53Reg(conf map[string]string) (providers.Registrar, error) {
 	// AWS European Sovereign Cloud (aws.eu) does not support registering domains, at least not yet.
 	// Let us assume only the global AWS is capable of registering domains currently.
 	if conf["Region"] != "" && conf["Region"] != "us-east-1" {
-		return nil, errors.New("Error! Domain register endpoint is only supported on the global AWS region us-east-1")
-	} else {
-		return newRoute53(conf, nil)
+		return nil, errors.New("domain register endpoint is only supported on the global AWS region us-east-1")
 	}
+	return newRoute53(conf, nil)
 }
 
 func newRoute53Dsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
@@ -79,7 +78,7 @@ func newRoute53(m map[string]string, _ json.RawMessage) (*route53Provider, error
 
 	profile := m["Profile"]
 	if profile != "" && (keyID != "" || secretKey != "") {
-		return nil, fmt.Errorf("route53: cannot set both Profile and KeyId/SecretKey")
+		return nil, errors.New("route53: cannot set both Profile and KeyId/SecretKey")
 	}
 	if profile != "" {
 		optFns = append(optFns, config.WithSharedConfigProfile(profile))
@@ -920,11 +919,11 @@ func (b *changeBatcher) Next() bool {
 			// "When the value of the Action element is UPSERT, each ResourceRecord element is counted twice."
 			rrsetSize *= 2
 		}
-		if newReqSize := reqSize + rrsetSize; newReqSize > b.maxSize {
+		newReqSize := reqSize + rrsetSize
+		if newReqSize > b.maxSize {
 			break
-		} else {
-			reqSize = newReqSize
 		}
+		reqSize = newReqSize
 
 		// Check that we won't exceed 32000 Value characters in the request.
 		var rrsetChars int
@@ -935,11 +934,11 @@ func (b *changeBatcher) Next() bool {
 			// "When the value of the Action element is UPSERT, each character in a Value element is counted twice."
 			rrsetChars *= 2
 		}
-		if newReqChars := reqChars + rrsetChars; newReqChars > b.maxChars {
+		newReqChars := reqChars + rrsetChars
+		if newReqChars > b.maxChars {
 			break
-		} else {
-			reqChars = newReqChars
 		}
+		reqChars = newReqChars
 
 		end++
 	}

--- a/providers/softlayer/softlayerProvider.go
+++ b/providers/softlayer/softlayerProvider.go
@@ -208,6 +208,9 @@ func (s *softlayerProvider) getExistingRecords(dc *models.DomainConfig, resource
 	return actual, nil
 }
 
+// srvLabelRe parses an SRV label of the form _service._protocol.
+var srvLabelRe = regexp.MustCompile(`^_(?P<Service>\w+)\.\_(?P<Protocol>\w+)$`)
+
 func (s *softlayerProvider) createRecordFunc(desired *models.RecordConfig, domain *datatypes.Dns_Domain) func() error {
 
 	ttl := verifyMinTTL(int(desired.TTL))
@@ -217,8 +220,6 @@ func (s *softlayerProvider) createRecordFunc(desired *models.RecordConfig, domai
 	newType := desired.Type
 
 	var err error
-
-	srvRegexp := regexp.MustCompile(`^_(?P<Service>\w+)\.\_(?P<Protocol>\w+)$`)
 
 	return func() error {
 		newRecord := datatypes.Dns_Domain_ResourceRecord{
@@ -244,7 +245,7 @@ func (s *softlayerProvider) createRecordFunc(desired *models.RecordConfig, domai
 		case "SRV":
 			service := services.GetDnsDomainResourceRecordSrvTypeService(s.Session)
 
-			result := srvRegexp.FindStringSubmatch(host)
+			result := srvLabelRe.FindStringSubmatch(host)
 			if len(result) != 3 {
 				return fmt.Errorf("SRV Record must match format \"_service._protocol\" not %s", host)
 			}


### PR DESCRIPTION
Small, mechanical cleanups from a repo-wide Go style pass. **No behavior change.**

### Changes
- **Boolean returns** — collapse `if cond { return true }; return false` into `return cond` (`models/stutter.go`, `pkg/mustbe/hosts.go`, `providers/gcloud/gcloudProvider.go`).
- **Regexp hoisting** — move constant `regexp.MustCompile(...)` calls out of frequently-called functions into package-level vars so they compile once (`commands/ppreviewPush.go`, `providers/desec/protocol.go`, `providers/softlayer/softlayerProvider.go`).
- **Error paths** — drop a redundant `else` after a terminating branch, lowercase/depunctuate a few error strings, and fix a missing space in an autodns error message (`providers/autodns/api.go`, `providers/route53/route53Provider.go`, `providers/openwrt/api.go`).

### Verification
`gofmt -l` clean · `go vet ./...` clean · `go build ./...` clean · `golangci-lint run` (v2.13.1) → 0 issues.

