### PR TITLE
CHORE: Use errors.New instead of fmt.Errorf when there is no format verb

### DIFF
--- a/models/b_loc.go
+++ b/models/b_loc.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 
 	dnsv2 "codeberg.org/miekg/dns"
@@ -17,7 +18,7 @@ func BuilderLOC(dc *DomainConfig, ttl uint32, args []any, subdomain string) (Rec
 	// args includes the label at args[0], so the parameter counts are +1:
 	// 8 = label + 7 preprocessed LOC fields; 13 = label + 12 DMS parameters.
 	if len(args) != 8 && len(args) != 13 {
-		return nil, fmt.Errorf("LOC should have 7 or 12 parameters")
+		return nil, errors.New("LOC should have 7 or 12 parameters")
 	}
 
 	label, err := dc.LabelFromDnsconfigjs(

--- a/models/record_label.go
+++ b/models/record_label.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -180,7 +181,7 @@ func (dc *DomainConfig) labelFromDnsconfigjsHelper(nameRaw string) (string, erro
 	name := nameRaw
 
 	if name == "" {
-		return "", fmt.Errorf(`label "" is invalid. Use "@" when a label is at the root (apex) of the zone`)
+		return "", errors.New(`label "" is invalid. Use "@" when a label is at the root (apex) of the zone`)
 	}
 	if name == "@" {
 		return name, nil

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -208,7 +208,7 @@ func decodeHexOrBase64(s string) ([]byte, error) {
 		// we will assume that the input is hex.
 		return hexData, nil
 	} else {
-		return nil, fmt.Errorf("unreachable")
+		return nil, errors.New("unreachable")
 	}
 }
 

--- a/providers/alidns/aliDnsProvider.go
+++ b/providers/alidns/aliDnsProvider.go
@@ -2,6 +2,7 @@ package alidns
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -81,12 +82,12 @@ type domainVersionInfo struct {
 func newAliDNSDsp(config map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
 	accessKeyID := config["access_key_id"]
 	if accessKeyID == "" {
-		return nil, fmt.Errorf("creds.json: access_key_id must not be empty")
+		return nil, errors.New("creds.json: access_key_id must not be empty")
 	}
 
 	accessKeySecret := config["access_key_secret"]
 	if accessKeySecret == "" {
-		return nil, fmt.Errorf("creds.json: access_key_secret must not be empty")
+		return nil, errors.New("creds.json: access_key_secret must not be empty")
 	}
 
 	// Region ID defaults to "cn-hangzhou". The region value does not affect

--- a/providers/alidns/api.go
+++ b/providers/alidns/api.go
@@ -1,6 +1,7 @@
 package alidns
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DNSControl/dnscontrol/v5/models"
@@ -80,7 +81,7 @@ func (a *aliDNSDsp) deleteRecordset(records models.Records) error {
 		req := alidns.CreateDeleteDomainRecordRequest()
 		original, ok := r.Original.(*alidns.Record)
 		if !ok {
-			return fmt.Errorf("deleteRecordset: record original is not of type *alidns.Record")
+			return errors.New("deleteRecordset: record original is not of type *alidns.Record")
 		}
 		req.RecordId = original.RecordId
 

--- a/providers/bunnydns/convert.go
+++ b/providers/bunnydns/convert.go
@@ -1,6 +1,7 @@
 package bunnydns
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -50,7 +51,7 @@ func fromRecordConfig(rc *models.RecordConfig) (*record, error) {
 		// while the Value field should be empty.
 		rdata, ok := rc.GetRDATA().(privatetypesrdata.BUNNYDNSPZ)
 		if !ok {
-			return nil, fmt.Errorf("invalid RDATA for BUNNY_DNS_PZ")
+			return nil, errors.New("invalid RDATA for BUNNY_DNS_PZ")
 		}
 		r.PullZoneID = rdata.PullZoneID
 		r.Value = ""
@@ -110,7 +111,7 @@ func toRecordConfig(dc *models.DomainConfig, r *record) (*models.RecordConfig, e
 	case "BUNNY_DNS_PZ":
 		// When reading Pull Zone records, the API provides the PullZoneId in the LinkName field as string.
 		if r.LinkName == "" {
-			return nil, fmt.Errorf("missing Pull Zone ID (LinkName) for BUNNY_DNS_PZ")
+			return nil, errors.New("missing Pull Zone ID (LinkName) for BUNNY_DNS_PZ")
 		}
 		rc, err = dc.NewRecordConfig(label, r.TTL, privatetypes.TypeBUNNYDNSPZ, r.LinkName)
 	case "BUNNY_DNS_RDR":

--- a/providers/dynu/dynuProvider.go
+++ b/providers/dynu/dynuProvider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -60,7 +61,7 @@ func init() {
 func New(m map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
 	apiKey := m["api_key"]
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing Dynu API key")
+		return nil, errors.New("missing Dynu API key")
 	}
 	return &dynuProvider{
 		apiKey:    apiKey,

--- a/providers/exoscale/auditrecords.go
+++ b/providers/exoscale/auditrecords.go
@@ -1,7 +1,7 @@
 package exoscale
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/rejectif"
@@ -17,7 +17,7 @@ func AuditRecords(records models.Records) []error {
 	auditor.Add("MX", rejectif.MxNull) // Last verified 2022-07-11
 
 	auditor.Add("PTR", func(rc *models.RecordConfig) error {
-		return fmt.Errorf("PTR records are not supported by the Exoscale provider")
+		return errors.New("PTR records are not supported by the Exoscale provider")
 	})
 
 	auditor.Add("SRV", rejectif.SrvHasNullTarget) // Last verified 2020-12-28

--- a/providers/gcloud/dnssec.go
+++ b/providers/gcloud/dnssec.go
@@ -2,6 +2,7 @@ package gcloud
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -13,7 +14,7 @@ import (
 func (g *gcloudProvider) getDnssecCorrections(dc *models.DomainConfig) ([]*models.Correction, error) {
 	// Don't allow combining AUTODNSSEC_{ON,OFF} with metadata DnssecConfig
 	if dc.AutoDNSSEC != "" && dc.Metadata["DnssecConfig"] != "" {
-		return nil, fmt.Errorf("cannot use AUTODNSSEC and DnssecConfig-metadata at the same time")
+		return nil, errors.New("cannot use AUTODNSSEC and DnssecConfig-metadata at the same time")
 	}
 	if dc.Metadata["DnssecConfig"] != "" {
 		return g.getDnssecCorrectionsFromMetadata(dc)

--- a/providers/mikrotik/api.go
+++ b/providers/mikrotik/api.go
@@ -3,6 +3,7 @@ package mikrotik
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -153,7 +154,7 @@ func (p *mikrotikProvider) doRequest(method, path string, payload any) ([]byte, 
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("mikrotik: authentication failed (401)")
+		return nil, errors.New("mikrotik: authentication failed (401)")
 	}
 
 	if resp.StatusCode >= 400 {

--- a/providers/mikrotik/mikrotikProvider.go
+++ b/providers/mikrotik/mikrotikProvider.go
@@ -2,6 +2,7 @@ package mikrotik
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -101,13 +102,13 @@ func newMikrotikProvider(cfg map[string]string, _ json.RawMessage) (providers.DN
 	password := cfg["password"]
 
 	if host == "" {
-		return nil, fmt.Errorf("mikrotik: 'host' is required")
+		return nil, errors.New("mikrotik: 'host' is required")
 	}
 	if username == "" {
-		return nil, fmt.Errorf("mikrotik: 'username' is required")
+		return nil, errors.New("mikrotik: 'username' is required")
 	}
 	if password == "" {
-		return nil, fmt.Errorf("mikrotik: 'password' is required")
+		return nil, errors.New("mikrotik: 'password' is required")
 	}
 
 	host = strings.TrimRight(host, "/")
@@ -294,7 +295,7 @@ func (p *mikrotikProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 				F: func() error {
 					oldOriginal, ok := oldRec.Original.(*dnsStaticRecord)
 					if !ok {
-						return fmt.Errorf("mikrotik: missing original record data for update")
+						return errors.New("mikrotik: missing original record data for update")
 					}
 					native, err := recordToNative(newRec)
 					if err != nil {
@@ -312,7 +313,7 @@ func (p *mikrotikProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 				F: func() error {
 					oldOriginal, ok := oldRec.Original.(*dnsStaticRecord)
 					if !ok {
-						return fmt.Errorf("mikrotik: missing original record data for delete")
+						return errors.New("mikrotik: missing original record data for delete")
 					}
 					return p.deleteRecord(oldOriginal.ID)
 				},
@@ -405,7 +406,7 @@ func (p *mikrotikProvider) getForwarderCorrections(dc *models.DomainConfig, exis
 				F: func() error {
 					oldFwd, ok := oldRec.Original.(*dnsForwarder)
 					if !ok {
-						return fmt.Errorf("mikrotik: missing original forwarder data for update")
+						return errors.New("mikrotik: missing original forwarder data for update")
 					}
 					f := recordToForwarder(newRec)
 					return p.updateForwarder(oldFwd.ID, f)
@@ -420,7 +421,7 @@ func (p *mikrotikProvider) getForwarderCorrections(dc *models.DomainConfig, exis
 				F: func() error {
 					oldFwd, ok := oldRec.Original.(*dnsForwarder)
 					if !ok {
-						return fmt.Errorf("mikrotik: missing original forwarder data for delete")
+						return errors.New("mikrotik: missing original forwarder data for delete")
 					}
 					return p.deleteForwarder(oldFwd.ID)
 				},

--- a/providers/ns1/naptr.go
+++ b/providers/ns1/naptr.go
@@ -1,6 +1,7 @@
 package ns1
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -51,7 +52,7 @@ func naptrAssureQuotedFields(contents string) (string, error) {
 func naptrAddQuotes(flag string) (string, error) {
 	switch len(flag) {
 	case 0:
-		return "", fmt.Errorf("empty flag")
+		return "", errors.New("empty flag")
 	case 1:
 		if flag[0] == '"' {
 			return "", fmt.Errorf("invalid flag: %q", flag)
@@ -59,13 +60,13 @@ func naptrAddQuotes(flag string) (string, error) {
 		return `"` + flag + `"`, nil
 	case 2:
 		if flag == `""` {
-			return "", fmt.Errorf("empty flag")
+			return "", errors.New("empty flag")
 		}
 		if flag[0] == '"' {
-			return "", fmt.Errorf("unclosed quote")
+			return "", errors.New("unclosed quote")
 		}
 		if flag[1] == '"' {
-			return "", fmt.Errorf("unopened quote")
+			return "", errors.New("unopened quote")
 		}
 		return `"` + flag + `"`, nil
 	}
@@ -75,10 +76,10 @@ func naptrAddQuotes(flag string) (string, error) {
 		return flag, nil
 	}
 	if flag[0] == '"' {
-		return "", fmt.Errorf("unclosed quote")
+		return "", errors.New("unclosed quote")
 	}
 	if flag[last] == '"' {
-		return "", fmt.Errorf("unopened quote")
+		return "", errors.New("unopened quote")
 	}
 	return `"` + flag + `"`, nil
 }

--- a/providers/openwrt/auditrecords.go
+++ b/providers/openwrt/auditrecords.go
@@ -1,6 +1,7 @@
 package openwrt
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DNSControl/dnscontrol/v5/models"
@@ -28,23 +29,23 @@ func AuditRecords(records models.Records) []error {
 	a.Add("SRV", rejectif.SrvHasNullTarget)
 
 	// Start with auditor errors
-	var errors []error
-	errors = append(errors, a.Audit(records)...)
+	var errs []error
+	errs = append(errs, a.Audit(records)...)
 
 	// Check for unsupported record types
 	for _, rc := range records {
 		if _, ok := supportedRTypes[rc.Type]; !ok {
-			errors = append(errors, fmt.Errorf("record type %q is not supported by OpenWrt", rc.Type))
+			errs = append(errs, fmt.Errorf("record type %q is not supported by OpenWrt", rc.Type))
 		}
 
 		// OpenWrt doesn't support wildcard CNAMEs
 		if rc.Type == "CNAME" && rc.GetLabel() == "*" {
-			errors = append(errors, fmt.Errorf("OpenWrt does not support wildcard CNAME records"))
+			errs = append(errs, errors.New("OpenWrt does not support wildcard CNAME records"))
 		}
 	}
 
-	if len(errors) == 0 {
+	if len(errs) == 0 {
 		return nil
 	}
-	return errors
+	return errs
 }

--- a/providers/scaleway/records.go
+++ b/providers/scaleway/records.go
@@ -1,6 +1,7 @@
 package scaleway
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DNSControl/dnscontrol/v5/models"
@@ -74,7 +75,7 @@ func (s *scalewayProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 		case diff2.CHANGE:
 			oldRec, ok := inst.Old[0].Original.(*domain.Record)
 			if !ok {
-				return nil, 0, fmt.Errorf("SCALEWAY: missing original record for change")
+				return nil, 0, errors.New("SCALEWAY: missing original record for change")
 			}
 			rec := fromRecordConfig(inst.New[0])
 			id := oldRec.ID
@@ -92,7 +93,7 @@ func (s *scalewayProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, ex
 		case diff2.DELETE:
 			oldRec, ok := inst.Old[0].Original.(*domain.Record)
 			if !ok {
-				return nil, 0, fmt.Errorf("SCALEWAY: missing original record for delete")
+				return nil, 0, errors.New("SCALEWAY: missing original record for delete")
 			}
 			id := oldRec.ID
 			msg := inst.Msgs[0]

--- a/providers/tencentdns/tencentdnsProvider.go
+++ b/providers/tencentdns/tencentdnsProvider.go
@@ -2,6 +2,7 @@ package tencentdns
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -96,7 +97,7 @@ func newTencentDNS(config map[string]string) (*tencentdnsProvider, error) {
 	secretID := config["secret_id"]
 	secretKey := config["secret_key"]
 	if secretID == "" || secretKey == "" {
-		return nil, fmt.Errorf("missing tencent cloud credentials (secret_id, secret_key)")
+		return nil, errors.New("missing tencent cloud credentials (secret_id, secret_key)")
 	}
 
 	region := config["region"]

--- a/providers/unifi/api.go
+++ b/providers/unifi/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -440,7 +441,7 @@ func (c *unifiClient) getRecords() ([]any, bool, error) {
 			}
 		}
 
-		return nil, false, fmt.Errorf("no API available")
+		return nil, false, errors.New("no API available")
 	}
 
 	if c.useNewAPI() {

--- a/providers/unifi/auditrecords.go
+++ b/providers/unifi/auditrecords.go
@@ -1,6 +1,7 @@
 package unifi
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DNSControl/dnscontrol/v5/models"
@@ -36,23 +37,23 @@ func AuditRecords(records models.Records) []error {
 	a.Add("SRV", rejectif.SrvHasNullTarget)
 
 	// Start with auditor errors
-	var errors []error
-	errors = append(errors, a.Audit(records)...)
+	var errs []error
+	errs = append(errs, a.Audit(records)...)
 
 	// Check for unsupported record types
 	for _, r := range records {
 		if _, ok := supportedRTypes[r.Type]; !ok {
-			errors = append(errors, fmt.Errorf("record type %q is not supported by UniFi", r.Type))
+			errs = append(errs, fmt.Errorf("record type %q is not supported by UniFi", r.Type))
 		}
 
 		// UniFi doesn't support wildcard CNAMEs well
 		if r.Type == "CNAME" && r.GetLabel() == "*" {
-			errors = append(errors, fmt.Errorf("UniFi does not support wildcard CNAME records"))
+			errs = append(errs, errors.New("UniFi does not support wildcard CNAME records"))
 		}
 	}
 
-	if len(errors) == 0 {
+	if len(errs) == 0 {
 		return nil
 	}
-	return errors
+	return errs
 }

--- a/providers/websupport/auditrecords.go
+++ b/providers/websupport/auditrecords.go
@@ -1,7 +1,7 @@
 package websupport
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/rejectif"
@@ -30,5 +30,5 @@ func AuditRecords(records models.Records) []error {
 }
 
 func rejectNS(rc *models.RecordConfig) error {
-	return fmt.Errorf("WEBSUPPORT does not support managing NS records via its API")
+	return errors.New("WEBSUPPORT does not support managing NS records via its API")
 }

--- a/providers/websupport/records.go
+++ b/providers/websupport/records.go
@@ -1,6 +1,7 @@
 package websupport
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DNSControl/dnscontrol/v5/models"
@@ -90,7 +91,7 @@ func (c *websupportProvider) mkChangeCorrection(svcID int64, oldRec, newRec *mod
 		F: func() error {
 			id := oldRec.Original.(nativeRecord).ID
 			if id == 0 {
-				return fmt.Errorf("WEBSUPPORT: cannot update record without an id")
+				return errors.New("WEBSUPPORT: cannot update record without an id")
 			}
 			input := models.Records{newRec}
 			before := providers.BeginToNative(c.observer, "toNative", input)
@@ -110,7 +111,7 @@ func (c *websupportProvider) mkDeleteCorrection(svcID int64, oldRec *models.Reco
 		F: func() error {
 			id := oldRec.Original.(nativeRecord).ID
 			if id == 0 {
-				return fmt.Errorf("WEBSUPPORT: cannot delete record without an id")
+				return errors.New("WEBSUPPORT: cannot delete record without an id")
 			}
 			return c.deleteRecord(svcID, id)
 		},


### PR DESCRIPTION
`fmt.Errorf` with no format directive is equivalent to `errors.New` but does a needless `Sprintf` pass (staticcheck **S1028**). **No behavior change.**

### Changes
- Rewrite the 36 verb-less `fmt.Errorf("...")` call sites to `errors.New("...")` across 19 files, adjusting imports (`errors` in / `fmt` out) as needed.
- Two auditors declared a local `var errors []error` that shadowed the `errors` package; renamed to `errs` so the package call resolves (`providers/openwrt/auditrecords.go`, `providers/unifi/auditrecords.go`).

### Verification
`gofmt -l` clean · `go vet ./...` clean · `go build ./...` clean · `golangci-lint run` (v2.13.1) → 0 issues.
