### PR TITLE
BUILD: Upgrade to Go 1.27

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -95,7 +95,7 @@ jobs:
   warm-gomod-cache:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.26
+      image: golang:1.27
     needs:
       - integration-test-providers
     outputs:
@@ -144,7 +144,7 @@ jobs:
     if: ${{ inputs.full || (github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main') }}
     runs-on: ubuntu-latest
     container:
-      image: golang:1.26
+      image: golang:1.27
     needs:
       - integration-test-providers
       - warm-gomod-cache

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -211,10 +211,8 @@ func preloadProviders(cfg *models.DNSConfig) (*models.DNSConfig, error) {
 			return nil, fmt.Errorf("registrar named %s expected for %s, but never registered", d.RegistrarName, d.Name)
 		}
 		d.RegistrarInstance = &models.RegistrarInstance{
-			ProviderBase: models.ProviderBase{
-				Name:         reg.Name,
-				ProviderType: reg.Type,
-			},
+			Name:         reg.Name,
+			ProviderType: reg.Type,
 		}
 		for pName, n := range d.DNSProviderNames {
 			prov, ok := cfg.DNSProvidersByName[pName]
@@ -222,10 +220,8 @@ func preloadProviders(cfg *models.DNSConfig) (*models.DNSConfig, error) {
 				return nil, fmt.Errorf("DNS Provider named %s expected for %s, but never registered", pName, d.Name)
 			}
 			d.DNSProviderInstances = append(d.DNSProviderInstances, &models.DNSProviderInstance{
-				ProviderBase: models.ProviderBase{
-					Name:         pName,
-					ProviderType: prov.Type,
-				},
+				Name:                pName,
+				ProviderType:        prov.Type,
 				NumberOfNameservers: n,
 			})
 		}

--- a/commands/gz_test.go
+++ b/commands/gz_test.go
@@ -46,8 +46,8 @@ func testFormat(t *testing.T, domain, format string) {
 		OutputFile:   outfile.Name(),
 		CredName:     "bind",
 		ProviderName: "BIND",
-	}
-	gzargs.CredsFile = "test_data/bind-creds.json"
+
+		CredsFile: "test_data/bind-creds.json"}
 
 	// Read the zonefile and convert
 	err = GetZone(gzargs)

--- a/go.mod
+++ b/go.mod
@@ -2,70 +2,109 @@ module github.com/DNSControl/dnscontrol/v5
 
 go 1.27
 
-require golang.org/x/net v0.57.0
-
 require (
-	github.com/jtolds/gls v4.20.0+incompatible // indirect
-	github.com/smartystreets/assertions v1.2.0 // indirect
-)
-
-require (
-	cloud.google.com/go/auth v0.22.0 // indirect
-	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
-	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	codeberg.org/miekg/dns v0.6.90
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0
-	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7
 	github.com/G-Core/gcore-dns-sdk-go v0.3.3
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/TomOnTime/utfutil v1.0.0
 	github.com/akamai/AkamaiOPEN-edgegrid-golang/v12 v12.3.0
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107
-	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.43.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.35
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.34
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.65.6
+	github.com/aws/aws-sdk-go-v2/service/route53domains v1.38.4
+	github.com/aws/aws-sdk-go-v2/service/sts v1.45.4
+	github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6
+	github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v5 v5.0.19
+	github.com/cloudflare/cloudflare-go v0.117.0
+	github.com/digitalocean/godo v1.203.0
+	github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c
+	github.com/dnsimple/dnsimple-go/v8 v8.3.0
+	github.com/dustin/go-humanize v1.0.1
+	github.com/exoscale/egoscale/v3 v3.1.43
+	github.com/failsafe-go/failsafe-go v0.9.6
+	github.com/fatih/color v1.19.0
+	github.com/fbiville/markdown-table-formatter v0.3.0
+	github.com/go-gandi/go-gandi v0.7.0
+	github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe
+	github.com/google/go-cmp v0.7.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/gopherjs/jquery v0.0.0-20191017083323-73f4c7416038
+	github.com/hetznercloud/hcloud-go/v2 v2.47.0
+	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.210
+	github.com/kylelemons/godebug v1.1.0
+	github.com/luadns/luadns-go v0.3.0
+	github.com/mattn/go-isatty v0.0.24
+	github.com/mittwald/go-powerdns v0.6.7
+	github.com/namedotcom/go v0.0.0-20180403034216-08470befbe04
+	github.com/netnod/netnod-primary-dns-client v1.1.1
+	github.com/nicholas-fedor/shoutrrr v0.17.0
+	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
+	github.com/nrdcg/goinwx v0.12.0
+	github.com/oracle/oci-go-sdk/v65 v65.123.0
+	github.com/ovh/go-ovh v1.9.0
+	github.com/philhug/opensrs-go v0.0.0-20171126225031-9dfa7433020d
+	github.com/pkg/errors v0.9.1
+	github.com/pquerna/otp v1.5.0
+	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494
+	github.com/robertkrimen/otto v0.5.1
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.37
+	github.com/softlayer/softlayer-go v1.2.1
+	github.com/stretchr/testify v1.11.1
+	github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.1462+incompatible
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.154
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.131
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.3.66
+	github.com/transip/gotransip/v6 v6.27.3
+	github.com/urfave/cli/v3 v3.10.1
+	github.com/vercel/terraform-provider-vercel v1.14.1
+	github.com/vultr/govultr/v3 v3.32.0
+	github.com/willpower232/go-namecheap v0.0.0-20260720171816-b13495139f3c
+	github.com/xddxdd/ottoext v0.0.0-20221109171055-210517fa4419
+	golang.org/x/net v0.57.0
+	golang.org/x/oauth2 v0.36.0
+	golang.org/x/text v0.40.0
+	golang.org/x/time v0.15.0
+	golang.org/x/tools v0.48.0
+	google.golang.org/api v0.292.0
+	gopkg.in/ns1/ns1-go.v2 v2.18.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	cloud.google.com/go/auth v0.22.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
+	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.35 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.35 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.35 // indirect
-	github.com/aws/aws-sdk-go-v2/service/route53 v1.65.6
-	github.com/aws/aws-sdk-go-v2/service/route53domains v1.38.4
 	github.com/aws/aws-sdk-go-v2/service/signin v1.5.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.45.4
 	github.com/aws/smithy-go v1.27.6 // indirect
-	github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
-	github.com/centralnicgroup-opensource/rtldev-middleware-go-sdk/v5 v5.0.19
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudflare/cloudflare-go v0.117.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/digitalocean/godo v1.203.0
-	github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c
-	github.com/dnsimple/dnsimple-go/v8 v8.3.0
-	github.com/dustin/go-humanize v1.0.1
 	github.com/eclipse/paho.golang v0.23.0 // indirect
-	github.com/exoscale/egoscale/v3 v3.1.43
-	github.com/failsafe-go/failsafe-go v0.9.6
-	github.com/fatih/color v1.19.0
 	github.com/fatih/structs v1.1.0 // indirect
-	github.com/fbiville/markdown-table-formatter v0.3.0
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
-	github.com/go-gandi/go-gandi v0.7.0
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0 // indirect
@@ -73,68 +112,46 @@ require (
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.9.8 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
-	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.19 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
-	github.com/gopherjs/jquery v0.0.0-20191017083323-73f4c7416038
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
-	github.com/hetznercloud/hcloud-go/v2 v2.47.0
-	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.210
 	github.com/influxdata/tdigest v0.0.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b // indirect
-	github.com/kylelemons/godebug v1.1.0
 	github.com/leodido/go-urn v1.2.1 // indirect
-	github.com/luadns/luadns-go v0.3.0
 	github.com/mattn/go-colorable v0.1.15 // indirect
-	github.com/mattn/go-isatty v0.0.24
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mittwald/go-powerdns v0.6.7
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/namedotcom/go v0.0.0-20180403034216-08470befbe04
-	github.com/netnod/netnod-primary-dns-client v1.1.1
-	github.com/nicholas-fedor/shoutrrr v0.17.0
-	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
-	github.com/nrdcg/goinwx v0.12.0
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
-	github.com/oracle/oci-go-sdk/v65 v65.123.0
-	github.com/ovh/go-ovh v1.9.0
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/peterhellberg/link v1.2.0 // indirect
-	github.com/philhug/opensrs-go v0.0.0-20171126225031-9dfa7433020d
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.0 // indirect
-	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494
-	github.com/robertkrimen/otto v0.5.1
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.37
 	github.com/shopspring/decimal v1.4.0 // indirect
-	github.com/softlayer/softlayer-go v1.2.1
+	github.com/smartystreets/assertions v1.2.0 // indirect
 	github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e // indirect
 	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
@@ -142,19 +159,8 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	github.com/stretchr/testify v1.11.1
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.1462+incompatible
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.154
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.3.131
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/domain v1.3.66
 	github.com/tjfoc/gmsm v1.4.1 // indirect
-	github.com/transip/gotransip/v6 v6.27.3
-	github.com/urfave/cli/v3 v3.10.1
-	github.com/vercel/terraform-provider-vercel v1.14.1
-	github.com/vultr/govultr/v3 v3.32.0
-	github.com/willpower232/go-namecheap v0.0.0-20260720171816-b13495139f3c
-	github.com/xddxdd/ottoext v0.0.0-20221109171055-210517fa4419
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.mongodb.org/mongo-driver v1.17.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -167,23 +173,16 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
-	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/text v0.40.0
-	golang.org/x/time v0.15.0
-	golang.org/x/tools v0.48.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/api v0.292.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/grpc v1.83.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/ns1/ns1-go.v2 v2.18.0
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1
 	moul.io/http2curl v1.0.0 // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DNSControl/dnscontrol/v5
 
-go 1.26
+go 1.27
 
 require golang.org/x/net v0.57.0
 

--- a/pkg/privatetypes/t_adguardhome_a_passthrough.go
+++ b/pkg/privatetypes/t_adguardhome_a_passthrough.go
@@ -42,10 +42,8 @@ func (rr *ADGUARDHOMEAPASSTHROUGH) Data() dnsv2.RDATA {
 }
 func (rr *ADGUARDHOMEAPASSTHROUGH) Clone() dnsv2.RR {
 	return &ADGUARDHOMEAPASSTHROUGH{
-		Hdr: rr.Hdr,
-		ADGUARDHOMEAPASSTHROUGH: privatetypesrdata.ADGUARDHOMEAPASSTHROUGH{
-			Target: rr.Target,
-		}}
+		Hdr:    rr.Hdr,
+		Target: rr.Target}
 }
 func (rr *ADGUARDHOMEAPASSTHROUGH) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_adguardhome_a_passthrough_test.go
+++ b/pkg/privatetypes/t_adguardhome_a_passthrough_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestAdguardhomeAPassthrough(t *testing.T) {
 	y := &ADGUARDHOMEAPASSTHROUGH{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		ADGUARDHOMEAPASSTHROUGH: privatetypesrdata.ADGUARDHOMEAPASSTHROUGH{
-			Target: "",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Target: "",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_adguardhome_aaaa_passthrough.go
+++ b/pkg/privatetypes/t_adguardhome_aaaa_passthrough.go
@@ -42,10 +42,8 @@ func (rr *ADGUARDHOMEAAAAPASSTHROUGH) Data() dnsv2.RDATA {
 }
 func (rr *ADGUARDHOMEAAAAPASSTHROUGH) Clone() dnsv2.RR {
 	return &ADGUARDHOMEAAAAPASSTHROUGH{
-		Hdr: rr.Hdr,
-		ADGUARDHOMEAAAAPASSTHROUGH: privatetypesrdata.ADGUARDHOMEAAAAPASSTHROUGH{
-			Target: rr.Target,
-		}}
+		Hdr:    rr.Hdr,
+		Target: rr.Target}
 }
 func (rr *ADGUARDHOMEAAAAPASSTHROUGH) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_adguardhome_aaaa_passthrough_test.go
+++ b/pkg/privatetypes/t_adguardhome_aaaa_passthrough_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestAdguardhomeAaaaPassthrough(t *testing.T) {
 	y := &ADGUARDHOMEAAAAPASSTHROUGH{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		ADGUARDHOMEAAAAPASSTHROUGH: privatetypesrdata.ADGUARDHOMEAAAAPASSTHROUGH{
-			Target: "",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Target: "",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_akamaicdn.go
+++ b/pkg/privatetypes/t_akamaicdn.go
@@ -43,10 +43,8 @@ func (rr *AKAMAICDN) Data() dnsv2.RDATA {
 }
 func (rr *AKAMAICDN) Clone() dnsv2.RR {
 	return &AKAMAICDN{
-		Hdr: rr.Hdr,
-		AKAMAICDN: privatetypesrdata.AKAMAICDN{
-			Target: rr.Target,
-		}}
+		Hdr:    rr.Hdr,
+		Target: rr.Target}
 }
 func (rr *AKAMAICDN) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_akamaicdn_test.go
+++ b/pkg/privatetypes/t_akamaicdn_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestAkamaicdn(t *testing.T) {
 	y := &AKAMAICDN{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		AKAMAICDN: privatetypesrdata.AKAMAICDN{
-			Target: "example.com.",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Target: "example.com.",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_akamaitlc.go
+++ b/pkg/privatetypes/t_akamaitlc.go
@@ -44,11 +44,9 @@ func (rr *AKAMAITLC) Data() dnsv2.RDATA {
 }
 func (rr *AKAMAITLC) Clone() dnsv2.RR {
 	return &AKAMAITLC{
-		Hdr: rr.Hdr,
-		AKAMAITLC: privatetypesrdata.AKAMAITLC{
-			AnswerType: rr.AnswerType,
-			Target:     rr.Target,
-		}}
+		Hdr:        rr.Hdr,
+		AnswerType: rr.AnswerType,
+		Target:     rr.Target}
 }
 func (rr *AKAMAITLC) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_akamaitlc_test.go
+++ b/pkg/privatetypes/t_akamaitlc_test.go
@@ -6,16 +6,13 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestAkamaitlc(t *testing.T) {
 	y := &AKAMAITLC{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		AKAMAITLC: privatetypesrdata.AKAMAITLC{
-			AnswerType: "cname",
-			Target:     "example.com.",
-		},
+		Hdr:        dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		AnswerType: "cname",
+		Target:     "example.com.",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_alias.go
+++ b/pkg/privatetypes/t_alias.go
@@ -43,10 +43,8 @@ func (rr *ALIAS) Data() dnsv2.RDATA {
 }
 func (rr *ALIAS) Clone() dnsv2.RR {
 	return &ALIAS{
-		Hdr: rr.Hdr,
-		ALIAS: privatetypesrdata.ALIAS{
-			Target: rr.Target,
-		}}
+		Hdr:    rr.Hdr,
+		Target: rr.Target}
 }
 func (rr *ALIAS) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_alias_test.go
+++ b/pkg/privatetypes/t_alias_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestAlias(t *testing.T) {
 	y := &ALIAS{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		ALIAS: privatetypesrdata.ALIAS{
-			Target: "example.com.",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Target: "example.com.",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_azure_alias.go
+++ b/pkg/privatetypes/t_azure_alias.go
@@ -43,11 +43,9 @@ func (rr *AZUREALIAS) Data() dnsv2.RDATA {
 }
 func (rr *AZUREALIAS) Clone() dnsv2.RR {
 	return &AZUREALIAS{
-		Hdr: rr.Hdr,
-		AZUREALIAS: privatetypesrdata.AZUREALIAS{
-			AliasType: rr.AliasType,
-			Target:    rr.Target,
-		}}
+		Hdr:       rr.Hdr,
+		AliasType: rr.AliasType,
+		Target:    rr.Target}
 }
 func (rr *AZUREALIAS) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_azure_alias_test.go
+++ b/pkg/privatetypes/t_azure_alias_test.go
@@ -6,16 +6,13 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestAzureAlias(t *testing.T) {
 	y := &AZUREALIAS{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		AZUREALIAS: privatetypesrdata.AZUREALIAS{
-			AliasType: "A",
-			Target:    "example.com.",
-		},
+		Hdr:       dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		AliasType: "A",
+		Target:    "example.com.",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_bunny_dns_pz.go
+++ b/pkg/privatetypes/t_bunny_dns_pz.go
@@ -42,10 +42,8 @@ func (rr *BUNNYDNSPZ) Data() dnsv2.RDATA {
 }
 func (rr *BUNNYDNSPZ) Clone() dnsv2.RR {
 	return &BUNNYDNSPZ{
-		Hdr: rr.Hdr,
-		BUNNYDNSPZ: privatetypesrdata.BUNNYDNSPZ{
-			PullZoneID: rr.PullZoneID,
-		}}
+		Hdr:        rr.Hdr,
+		PullZoneID: rr.PullZoneID}
 }
 func (rr *BUNNYDNSPZ) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_bunny_dns_pz_test.go
+++ b/pkg/privatetypes/t_bunny_dns_pz_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestBunnyDnsPz(t *testing.T) {
 	y := &BUNNYDNSPZ{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		BUNNYDNSPZ: privatetypesrdata.BUNNYDNSPZ{
-			PullZoneID: 123,
-		},
+		Hdr:        dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		PullZoneID: 123,
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_bunny_dns_rdr.go
+++ b/pkg/privatetypes/t_bunny_dns_rdr.go
@@ -42,10 +42,8 @@ func (rr *BUNNYDNSRDR) Data() dnsv2.RDATA {
 }
 func (rr *BUNNYDNSRDR) Clone() dnsv2.RR {
 	return &BUNNYDNSRDR{
-		Hdr: rr.Hdr,
-		BUNNYDNSRDR: privatetypesrdata.BUNNYDNSRDR{
-			Target: rr.Target,
-		}}
+		Hdr:    rr.Hdr,
+		Target: rr.Target}
 }
 func (rr *BUNNYDNSRDR) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_bunny_dns_rdr_test.go
+++ b/pkg/privatetypes/t_bunny_dns_rdr_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestBunnyDnsRdr(t *testing.T) {
 	y := &BUNNYDNSRDR{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		BUNNYDNSRDR: privatetypesrdata.BUNNYDNSRDR{
-			Target: "https://example.com",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Target: "https://example.com",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_cf_worker_route.go
+++ b/pkg/privatetypes/t_cf_worker_route.go
@@ -43,11 +43,9 @@ func (rr *CFWORKERROUTE) Data() dnsv2.RDATA {
 }
 func (rr *CFWORKERROUTE) Clone() dnsv2.RR {
 	return &CFWORKERROUTE{
-		Hdr: rr.Hdr,
-		CFWORKERROUTE: privatetypesrdata.CFWORKERROUTE{
-			When: rr.When,
-			Then: rr.Then,
-		}}
+		Hdr:  rr.Hdr,
+		When: rr.When,
+		Then: rr.Then}
 }
 func (rr *CFWORKERROUTE) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_cf_worker_route_test.go
+++ b/pkg/privatetypes/t_cf_worker_route_test.go
@@ -6,16 +6,13 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestCfWorkerRoute(t *testing.T) {
 	y := &CFWORKERROUTE{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		CFWORKERROUTE: privatetypesrdata.CFWORKERROUTE{
-			When: "whenWhen",
-			Then: "ThenThen",
-		},
+		Hdr:  dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		When: "whenWhen",
+		Then: "ThenThen",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_cloudflareapi_single_redirect.go
+++ b/pkg/privatetypes/t_cloudflareapi_single_redirect.go
@@ -47,15 +47,13 @@ func (rr *CLOUDFLAREAPISINGLEREDIRECT) Data() dnsv2.RDATA {
 }
 func (rr *CLOUDFLAREAPISINGLEREDIRECT) Clone() dnsv2.RR {
 	return &CLOUDFLAREAPISINGLEREDIRECT{
-		Hdr: rr.Hdr,
-		CLOUDFLAREAPISINGLEREDIRECT: privatetypesrdata.CLOUDFLAREAPISINGLEREDIRECT{
-			SRName:              rr.SRName,
-			Code:                rr.Code,
-			SRWhen:              rr.SRWhen,
-			SRThen:              rr.SRThen,
-			RT_SRRRulesetID:     rr.RT_SRRRulesetID,
-			RT_SRRRulesetRuleID: rr.RT_SRRRulesetRuleID,
-		}}
+		Hdr:                 rr.Hdr,
+		SRName:              rr.SRName,
+		Code:                rr.Code,
+		SRWhen:              rr.SRWhen,
+		SRThen:              rr.SRThen,
+		RT_SRRRulesetID:     rr.RT_SRRRulesetID,
+		RT_SRRRulesetRuleID: rr.RT_SRRRulesetRuleID}
 }
 func (rr *CLOUDFLAREAPISINGLEREDIRECT) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_cloudflareapi_single_redirect_test.go
+++ b/pkg/privatetypes/t_cloudflareapi_single_redirect_test.go
@@ -6,18 +6,15 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestCloudflareapiSingleRedirect(t *testing.T) {
 	y := &CLOUDFLAREAPISINGLEREDIRECT{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		CLOUDFLAREAPISINGLEREDIRECT: privatetypesrdata.CLOUDFLAREAPISINGLEREDIRECT{
-			SRName: "first_rule",
-			Code:   301,
-			SRWhen: "when_string",
-			SRThen: "then_string",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		SRName: "first_rule",
+		Code:   301,
+		SRWhen: "when_string",
+		SRThen: "then_string",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_cloudns_wr.go
+++ b/pkg/privatetypes/t_cloudns_wr.go
@@ -42,10 +42,8 @@ func (rr *CLOUDNSWR) Data() dnsv2.RDATA {
 }
 func (rr *CLOUDNSWR) Clone() dnsv2.RR {
 	return &CLOUDNSWR{
-		Hdr: rr.Hdr,
-		CLOUDNSWR: privatetypesrdata.CLOUDNSWR{
-			Target: rr.Target,
-		}}
+		Hdr:    rr.Hdr,
+		Target: rr.Target}
 }
 func (rr *CLOUDNSWR) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_cloudns_wr_test.go
+++ b/pkg/privatetypes/t_cloudns_wr_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestCloudnsWr(t *testing.T) {
 	y := &CLOUDNSWR{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		CLOUDNSWR: privatetypesrdata.CLOUDNSWR{
-			Target: "example.com.",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Target: "example.com.",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_frame.go
+++ b/pkg/privatetypes/t_frame.go
@@ -42,10 +42,8 @@ func (rr *FRAME) Data() dnsv2.RDATA {
 }
 func (rr *FRAME) Clone() dnsv2.RR {
 	return &FRAME{
-		Hdr: rr.Hdr,
-		FRAME: privatetypesrdata.FRAME{
-			Target: rr.Target,
-		}}
+		Hdr:    rr.Hdr,
+		Target: rr.Target}
 }
 func (rr *FRAME) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_frame_test.go
+++ b/pkg/privatetypes/t_frame_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestFrame(t *testing.T) {
 	y := &FRAME{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		FRAME: privatetypesrdata.FRAME{
-			Target: "example.com.",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Target: "example.com.",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_import_transform.go
+++ b/pkg/privatetypes/t_import_transform.go
@@ -45,13 +45,11 @@ func (rr *IMPORTTRANSFORM) Data() dnsv2.RDATA {
 }
 func (rr *IMPORTTRANSFORM) Clone() dnsv2.RR {
 	return &IMPORTTRANSFORM{
-		Hdr: rr.Hdr,
-		IMPORTTRANSFORM: privatetypesrdata.IMPORTTRANSFORM{
-			TransformTable: rr.TransformTable,
-			TTL:            rr.TTL,
-			SuffixStrip:    rr.SuffixStrip,
-			TargetDomain:   rr.TargetDomain,
-		}}
+		Hdr:            rr.Hdr,
+		TransformTable: rr.TransformTable,
+		TTL:            rr.TTL,
+		SuffixStrip:    rr.SuffixStrip,
+		TargetDomain:   rr.TargetDomain}
 }
 func (rr *IMPORTTRANSFORM) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_import_transform_test.go
+++ b/pkg/privatetypes/t_import_transform_test.go
@@ -6,18 +6,15 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestImportTransform(t *testing.T) {
 	y := &IMPORTTRANSFORM{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		IMPORTTRANSFORM: privatetypesrdata.IMPORTTRANSFORM{
-			TransformTable: "1.1.1.0 ~ 1.1.1.100 ~ 4.4.4.100 ~",
-			TTL:            123,
-			SuffixStrip:    "com",
-			TargetDomain:   "example.com",
-		},
+		Hdr:            dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		TransformTable: "1.1.1.0 ~ 1.1.1.100 ~ 4.4.4.100 ~",
+		TTL:            123,
+		SuffixStrip:    "com",
+		TargetDomain:   "example.com",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_lua.go
+++ b/pkg/privatetypes/t_lua.go
@@ -43,11 +43,9 @@ func (rr *LUA) Data() dnsv2.RDATA {
 }
 func (rr *LUA) Clone() dnsv2.RR {
 	return &LUA{
-		Hdr: rr.Hdr,
-		LUA: privatetypesrdata.LUA{
-			LuaType:    rr.LuaType,
-			LuaPayload: rr.LuaPayload,
-		}}
+		Hdr:        rr.Hdr,
+		LuaType:    rr.LuaType,
+		LuaPayload: rr.LuaPayload}
 }
 func (rr *LUA) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_lua_test.go
+++ b/pkg/privatetypes/t_lua_test.go
@@ -6,16 +6,13 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestLua(t *testing.T) {
 	y := &LUA{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		LUA: privatetypesrdata.LUA{
-			LuaType:    "A",
-			LuaPayload: "return_127_0_0_1",
-		},
+		Hdr:        dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		LuaType:    "A",
+		LuaPayload: "return_127_0_0_1",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_mikrotik_forwarder.go
+++ b/pkg/privatetypes/t_mikrotik_forwarder.go
@@ -42,10 +42,8 @@ func (rr *MIKROTIKFORWARDER) Data() dnsv2.RDATA {
 }
 func (rr *MIKROTIKFORWARDER) Clone() dnsv2.RR {
 	return &MIKROTIKFORWARDER{
-		Hdr: rr.Hdr,
-		MIKROTIKFORWARDER: privatetypesrdata.MIKROTIKFORWARDER{
-			Target: rr.Target,
-		}}
+		Hdr:    rr.Hdr,
+		Target: rr.Target}
 }
 func (rr *MIKROTIKFORWARDER) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_mikrotik_forwarder_test.go
+++ b/pkg/privatetypes/t_mikrotik_forwarder_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestMikrotikForwarder(t *testing.T) {
 	y := &MIKROTIKFORWARDER{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		MIKROTIKFORWARDER: privatetypesrdata.MIKROTIKFORWARDER{
-			Target: "1.1.1.1,8.8.8.8",
-		},
+		Hdr:    dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Target: "1.1.1.1,8.8.8.8",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_mikrotik_fwd.go
+++ b/pkg/privatetypes/t_mikrotik_fwd.go
@@ -42,10 +42,8 @@ func (rr *MIKROTIKFWD) Data() dnsv2.RDATA {
 }
 func (rr *MIKROTIKFWD) Clone() dnsv2.RR {
 	return &MIKROTIKFWD{
-		Hdr: rr.Hdr,
-		MIKROTIKFWD: privatetypesrdata.MIKROTIKFWD{
-			ForwardTo: rr.ForwardTo,
-		}}
+		Hdr:       rr.Hdr,
+		ForwardTo: rr.ForwardTo}
 }
 func (rr *MIKROTIKFWD) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_mikrotik_fwd_test.go
+++ b/pkg/privatetypes/t_mikrotik_fwd_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestMikrotikFwd(t *testing.T) {
 	y := &MIKROTIKFWD{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		MIKROTIKFWD: privatetypesrdata.MIKROTIKFWD{
-			ForwardTo: "example.com.",
-		},
+		Hdr:       dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		ForwardTo: "example.com.",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_porkbun_urlfwd.go
+++ b/pkg/privatetypes/t_porkbun_urlfwd.go
@@ -42,10 +42,8 @@ func (rr *PORKBUNURLFWD) Data() dnsv2.RDATA {
 }
 func (rr *PORKBUNURLFWD) Clone() dnsv2.RR {
 	return &PORKBUNURLFWD{
-		Hdr: rr.Hdr,
-		PORKBUNURLFWD: privatetypesrdata.PORKBUNURLFWD{
-			Location: rr.Location,
-		}}
+		Hdr:      rr.Hdr,
+		Location: rr.Location}
 }
 func (rr *PORKBUNURLFWD) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_porkbun_urlfwd_test.go
+++ b/pkg/privatetypes/t_porkbun_urlfwd_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestPorkbunUrlfwd_Plain(t *testing.T) {
 	y := &PORKBUNURLFWD{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		PORKBUNURLFWD: privatetypesrdata.PORKBUNURLFWD{
-			Location: "http://example.com",
-		},
+		Hdr:      dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Location: "http://example.com",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_r53_alias.go
+++ b/pkg/privatetypes/t_r53_alias.go
@@ -46,13 +46,11 @@ func (rr *R53ALIAS) Data() dnsv2.RDATA {
 }
 func (rr *R53ALIAS) Clone() dnsv2.RR {
 	return &R53ALIAS{
-		Hdr: rr.Hdr,
-		R53ALIAS: privatetypesrdata.R53ALIAS{
-			AliasType:        rr.AliasType,
-			Target:           rr.Target,
-			EvalTargetHealth: rr.EvalTargetHealth,
-			ZoneID:           rr.ZoneID,
-		}}
+		Hdr:              rr.Hdr,
+		AliasType:        rr.AliasType,
+		Target:           rr.Target,
+		EvalTargetHealth: rr.EvalTargetHealth,
+		ZoneID:           rr.ZoneID}
 }
 func (rr *R53ALIAS) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_r53_alias_test.go
+++ b/pkg/privatetypes/t_r53_alias_test.go
@@ -6,18 +6,15 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestR53Alias_NormalUser(t *testing.T) {
 	y := &R53ALIAS{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		R53ALIAS: privatetypesrdata.R53ALIAS{
-			AliasType:        "1",
-			Target:           "alice.",
-			EvalTargetHealth: "true",
-			ZoneID:           "1234",
-		},
+		Hdr:              dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		AliasType:        "1",
+		Target:           "alice.",
+		EvalTargetHealth: "true",
+		ZoneID:           "1234",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_url.go
+++ b/pkg/privatetypes/t_url.go
@@ -42,10 +42,8 @@ func (rr *URL) Data() dnsv2.RDATA {
 }
 func (rr *URL) Clone() dnsv2.RR {
 	return &URL{
-		Hdr: rr.Hdr,
-		URL: privatetypesrdata.URL{
-			Location: rr.Location,
-		}}
+		Hdr:      rr.Hdr,
+		Location: rr.Location}
 }
 func (rr *URL) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_url301.go
+++ b/pkg/privatetypes/t_url301.go
@@ -42,10 +42,8 @@ func (rr *URL301) Data() dnsv2.RDATA {
 }
 func (rr *URL301) Clone() dnsv2.RR {
 	return &URL301{
-		Hdr: rr.Hdr,
-		URL301: privatetypesrdata.URL301{
-			Location: rr.Location,
-		}}
+		Hdr:      rr.Hdr,
+		Location: rr.Location}
 }
 func (rr *URL301) String() string {
 	return (rr.Header().Name + "\t" +

--- a/pkg/privatetypes/t_url301_test.go
+++ b/pkg/privatetypes/t_url301_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestUrl301(t *testing.T) {
 	y := &URL301{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		URL301: privatetypesrdata.URL301{
-			Location: "https://example.com/",
-		},
+		Hdr:      dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Location: "https://example.com/",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/t_url_test.go
+++ b/pkg/privatetypes/t_url_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	dnsv2 "codeberg.org/miekg/dns"
-	privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"
 )
 
 func TestUrl(t *testing.T) {
 	y := &URL{
-		Hdr: dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
-		URL: privatetypesrdata.URL{
-			Location: "https://example.com/",
-		},
+		Hdr:      dnsv2.Header{Name: "example.org.", Class: dnsv2.ClassINET},
+		Location: "https://example.com/",
 	}
 	rry, err := dnsv2.New(y.String())
 	if err != nil {

--- a/pkg/privatetypes/types_generate.go
+++ b/pkg/privatetypes/types_generate.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -39,8 +40,8 @@ type FieldDef struct {
 
 // TestDataDef represents test data for a type
 type TestDataDef struct {
-	Name   string                 `yaml:"name"`
-	Values map[string]interface{} `yaml:"values"`
+	Name   string         `yaml:"name"`
+	Values map[string]any `yaml:"values"`
 }
 
 // Config represents the YAML file structure
@@ -166,7 +167,7 @@ func fieldStringExpr(receiver string, f FieldDef) string {
 }
 
 // formatLiteral renders a test-data value as a Go literal appropriate for the field type.
-func formatLiteral(typeName string, v interface{}) string {
+func formatLiteral(typeName string, v any) string {
 	ti := info(typeName)
 	s := fmt.Sprintf("%v", v)
 	switch {
@@ -330,7 +331,7 @@ func generateTypeFile(t *TypeDef) error {
 		fmt.Fprintf(&buf, "\treturn nil\n")
 	} else {
 		fmt.Fprintf(&buf, "\treturn privatetypesrdata.%s{", typeName)
-		fields := append(append(append([]FieldDef{}, t.Fields...), t.OptionalFields...), t.RuntimeFields...)
+		fields := slices.Concat(t.Fields, t.OptionalFields, t.RuntimeFields)
 		for i, f := range fields {
 			if i > 0 {
 				buf.WriteString(", ")
@@ -349,12 +350,14 @@ func generateTypeFile(t *TypeDef) error {
 	} else {
 		fmt.Fprintf(&buf, "\treturn &%s{\n", typeName)
 		buf.WriteString("\t\tHdr: rr.Hdr,\n")
-		fmt.Fprintf(&buf, "\t\t%s: privatetypesrdata.%s{\n", typeName, typeName)
-		fields := append(append(append([]FieldDef{}, t.Fields...), t.OptionalFields...), t.RuntimeFields...)
-		for _, f := range fields {
-			fmt.Fprintf(&buf, "\t\t\t%s: rr.%s,\n", f.Name, f.Name)
+		fields := slices.Concat(t.Fields, t.OptionalFields, t.RuntimeFields)
+		for i, f := range fields {
+			if i == len(fields)-1 {
+				fmt.Fprintf(&buf, "\t\t%s: rr.%s}\n", f.Name, f.Name)
+			} else {
+				fmt.Fprintf(&buf, "\t\t%s: rr.%s,\n", f.Name, f.Name)
+			}
 		}
-		buf.WriteString("\t\t}}\n")
 	}
 	buf.WriteString("}\n")
 
@@ -430,9 +433,6 @@ func generateTestFile(t *TypeDef) error {
 		std = append(std, `"net/netip"`)
 	}
 	third := []string{`dnsv2 "codeberg.org/miekg/dns"`}
-	if len(t.Fields) > 0 {
-		third = append(third, `privatetypesrdata "github.com/DNSControl/dnscontrol/v5/pkg/privatetypes/rdata"`)
-	}
 	writeImports(&buf, std, third)
 
 	if len(t.Fields) == 0 {
@@ -451,11 +451,9 @@ func generateTestFile(t *TypeDef) error {
 			fmt.Fprintf(&buf, "func Test%s(t *testing.T) {\n", testFuncName)
 			fmt.Fprintf(&buf, "\ty := &%s{\n", typeName)
 			buf.WriteString("\t\tHdr: dnsv2.Header{Name: \"example.org.\", Class: dnsv2.ClassINET},\n")
-			fmt.Fprintf(&buf, "\t\t%s: privatetypesrdata.%s{\n", typeName, typeName)
-			for _, f := range append(t.Fields, t.OptionalFields...) {
-				fmt.Fprintf(&buf, "\t\t\t%s: %s,\n", f.Name, zeroLiteral(f.Type))
+			for _, f := range slices.Concat(t.Fields, t.OptionalFields) {
+				fmt.Fprintf(&buf, "\t\t%s: %s,\n", f.Name, zeroLiteral(f.Type))
 			}
-			buf.WriteString("\t\t},\n")
 			buf.WriteString("\t}\n")
 			buf.WriteString("\trry, err := dnsv2.New(y.String())\n")
 			buf.WriteString("\tif err != nil {\n")
@@ -475,19 +473,17 @@ func generateTestFile(t *TypeDef) error {
 				fmt.Fprintf(&buf, "func Test%s(t *testing.T) {\n", testName)
 				fmt.Fprintf(&buf, "\ty := &%s{\n", typeName)
 				buf.WriteString("\t\tHdr: dnsv2.Header{Name: \"example.org.\", Class: dnsv2.ClassINET},\n")
-				fmt.Fprintf(&buf, "\t\t%s: privatetypesrdata.%s{\n", typeName, typeName)
 
-				for _, f := range append(t.Fields, t.OptionalFields...) {
+				for _, f := range slices.Concat(t.Fields, t.OptionalFields) {
 					var lit string
 					if v, ok := td.Values[f.Name]; ok {
 						lit = formatLiteral(f.Type, v)
 					} else {
 						lit = zeroLiteral(f.Type)
 					}
-					fmt.Fprintf(&buf, "\t\t\t%s: %s,\n", f.Name, lit)
+					fmt.Fprintf(&buf, "\t\t%s: %s,\n", f.Name, lit)
 				}
 
-				buf.WriteString("\t\t},\n")
 				buf.WriteString("\t}\n")
 				buf.WriteString("\trry, err := dnsv2.New(y.String())\n")
 				buf.WriteString("\tif err != nil {\n")
@@ -651,7 +647,7 @@ func generateRdataFile(t *TypeDef) error {
 	// "origin" is unused when there are no TargetHost fields.
 	if len(t.Fields) > 0 || len(t.OptionalFields) > 0 {
 		needsOrigin := false
-		for _, f := range append(t.Fields, t.OptionalFields...) {
+		for _, f := range slices.Concat(t.Fields, t.OptionalFields) {
 			if info(f.Type).NeedsOrigin {
 				needsOrigin = true
 				break
@@ -660,8 +656,8 @@ func generateRdataFile(t *TypeDef) error {
 		if !needsOrigin {
 			// Rewrite the receiver to use _ instead of origin to avoid unused-var warnings.
 			out := bytes.Replace(buf.Bytes(),
-				[]byte(fmt.Sprintf("func Make%s(origin string, isEnabled, args ...any)", typeName)),
-				[]byte(fmt.Sprintf("func Make%s(_ string, isEnabled, args ...any)", typeName)),
+				fmt.Appendf(nil, "func Make%s(origin string, isEnabled, args ...any)", typeName),
+				fmt.Appendf(nil, "func Make%s(_ string, isEnabled, args ...any)", typeName),
 				1)
 			buf.Reset()
 			buf.Write(out)

--- a/providers/desec/desecProvider.go
+++ b/providers/desec/desecProvider.go
@@ -188,10 +188,10 @@ func (c *desecProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, exist
 
 		case diff2.DELETE:
 			// An empty array of records deletes this rrset.
-			rc := resourceRecord{}
-			rc.Type = change.Key.Type
-			rc.Records = make([]string, 0)
-			rc.TTL = 3600
+			rc := resourceRecord{
+				Type:    change.Key.Type,
+				Records: make([]string, 0),
+				TTL:     3600}
 			shortname := dc.ToShort(change.Key.NameFQDN)
 			if shortname == "@" {
 				shortname = ""

--- a/providers/exoscale/exoscaleProvider.go
+++ b/providers/exoscale/exoscaleProvider.go
@@ -256,9 +256,8 @@ func (provider *exoscaleProvider) createRecordFunc(
 			Type:     egoscale.CreateDNSDomainRecordRequestType(recordConfig.Type),
 			Content:  target,
 			Priority: prio,
-		}
 
-		record.Ttl = int64(recordConfig.TTL)
+			Ttl: int64(recordConfig.TTL)}
 
 		ctx := context.Background()
 		op, err := provider.client.CreateDNSDomainRecord(ctx, domainID, record)

--- a/providers/gcore/convertMetadata.go
+++ b/providers/gcore/convertMetadata.go
@@ -335,8 +335,8 @@ func parseRecordFilter(filterString string) ([]dnssdk.RecordFilter, error) {
 			return nil, fmt.Errorf("filter %s has invalid format, correct format is \"type,strict[,limit]\"", s)
 		}
 
-		record := dnssdk.RecordFilter{}
-		record.Type = fields[0]
+		record := dnssdk.RecordFilter{
+			Type: fields[0]}
 
 		record.Strict, err = strconv.ParseBool(fields[1])
 		if err != nil {

--- a/providers/hetznerv2/hetznerv2Provider.go
+++ b/providers/hetznerv2/hetznerv2Provider.go
@@ -225,8 +225,8 @@ func (h *hetznerv2Provider) GetZoneRecords(dc *models.DomainConfig) (models.Reco
 	if err != nil {
 		return nil, err
 	}
-	opts := hcloud.ZoneRRSetListOpts{}
-	opts.PerPage = 100
+	opts := hcloud.ZoneRRSetListOpts{
+		PerPage: 100}
 	records, err := h.client.Zone.AllRRSetsWithOpts(context.Background(), z, opts)
 	if err != nil {
 		return nil, err

--- a/providers/loopia/convert.go
+++ b/providers/loopia/convert.go
@@ -37,10 +37,10 @@ func nativeToRecord(zr zoneRecord, dc *models.DomainConfig, subdomain string) (r
 
 func recordToNative(rc *models.RecordConfig, id ...uint32) paramStruct {
 	// rc is the record from dnscontrol to loopia
-	zrec := zRec{}
-	zrec.Type = rc.Type
-	zrec.TTL = rc.TTL
-	zrec.Rdata = rc.GetRDATA().String()
+	zrec := zRec{
+		Type:  rc.Type,
+		TTL:   rc.TTL,
+		Rdata: rc.GetRDATA().String()}
 
 	if rc.Original != nil {
 		zrec.RecordID = rc.Original.(*zRec).RecordID

--- a/providers/loopia/convert_test.go
+++ b/providers/loopia/convert_test.go
@@ -25,12 +25,12 @@ func TestNativeToRecord_1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	zrec := zRec{}
-	zrec.Type = "A"
-	zrec.TTL = 300
-	zrec.Rdata = "1.2.3.4"
-	zrec.Priority = 0
-	zrec.RecordID = 0
+	zrec := zRec{
+		Type:     "A",
+		TTL:      300,
+		Rdata:    "1.2.3.4",
+		Priority: 0,
+		RecordID: 0}
 
 	rc, err := nativeToRecord(zrec.SetZR(), dc, "www")
 

--- a/providers/vercel/convert_test.go
+++ b/providers/vercel/convert_test.go
@@ -5,7 +5,6 @@ import (
 
 	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
-	vercelClient "github.com/vercel/terraform-provider-vercel/client"
 )
 
 func TestVercelRecordToRCUsesV3RecordConfig(t *testing.T) {
@@ -15,10 +14,10 @@ func TestVercelRecordToRCUsesV3RecordConfig(t *testing.T) {
 		in   DNSRecord
 		want *models.RecordConfig
 	}{
-		{"A", DNSRecord{DNSRecord: vercelClient.DNSRecord{Name: "www", RecordType: "A", Value: "192.0.2.1", TTL: 300}, Type: "A"}, dc.MustNewRecordConfig("www", 300, dnsv2.TypeA, "192.0.2.1")},
-		{"TXT", DNSRecord{DNSRecord: vercelClient.DNSRecord{Name: "www", RecordType: "TXT", Value: "hello world", TTL: 300}, Type: "TXT"}, dc.MustNewRecordConfig("www", 300, dnsv2.TypeTXT, "hello world")},
-		{"MX", DNSRecord{DNSRecord: vercelClient.DNSRecord{Name: "www", RecordType: "MX", Value: "mail.example.net", TTL: 300}, Type: "MX", MXPriority: 10}, dc.MustNewRecordConfig("www", 300, dnsv2.TypeMX, uint16(10), "mail.example.net.")},
-		{"SRV", DNSRecord{DNSRecord: vercelClient.DNSRecord{Name: "www", RecordType: "SRV", Value: "2 443 service.example.net.", TTL: 300, Priority: 1}, Type: "SRV"}, dc.MustNewRecordConfig("www", 300, dnsv2.TypeSRV, uint16(1), uint16(2), uint16(443), "service.example.net.")},
+		{"A", DNSRecord{Name: "www", RecordType: "A", Value: "192.0.2.1", TTL: 300, Type: "A"}, dc.MustNewRecordConfig("www", 300, dnsv2.TypeA, "192.0.2.1")},
+		{"TXT", DNSRecord{Name: "www", RecordType: "TXT", Value: "hello world", TTL: 300, Type: "TXT"}, dc.MustNewRecordConfig("www", 300, dnsv2.TypeTXT, "hello world")},
+		{"MX", DNSRecord{Name: "www", RecordType: "MX", Value: "mail.example.net", TTL: 300, Type: "MX", MXPriority: 10}, dc.MustNewRecordConfig("www", 300, dnsv2.TypeMX, uint16(10), "mail.example.net.")},
+		{"SRV", DNSRecord{Name: "www", RecordType: "SRV", Value: "2 443 service.example.net.", TTL: 300, Priority: 1, Type: "SRV"}, dc.MustNewRecordConfig("www", 300, dnsv2.TypeSRV, uint16(1), uint16(2), uint16(443), "service.example.net.")},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
* Bump the `go` directive in `go.mod` from `1.26` to `1.27`.
* Update types_generate.go to generate Go 1.27 constructs
* Update non-generated files to Go 1.27 constructs
