### PR TITLE
DOCS: Verify parameters match across code, docs, and dnscontrol.d.ts

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -250,7 +250,7 @@ declare function AAAA(name: string, address: string, ...modifiers: RecordModifie
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/service-provider-specific//adguardhome_aaaa_passthrough
  */
-declare function ADGUARDHOME_AAAA_PASSTHROUGH(source: string, destination: string): DomainModifier;
+declare function ADGUARDHOME_AAAA_PASSTHROUGH(source: string, destination: string, ...modifiers: RecordModifier[]): DomainModifier;
 
 /**
  * `ADGUARDHOME_A_PASSTHROUGH` represents the literal 'A'. AdGuardHome uses this to passthrough
@@ -269,7 +269,7 @@ declare function ADGUARDHOME_AAAA_PASSTHROUGH(source: string, destination: strin
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/service-provider-specific//adguardhome_a_passthrough
  */
-declare function ADGUARDHOME_A_PASSTHROUGH(source: string, destination: string): DomainModifier;
+declare function ADGUARDHOME_A_PASSTHROUGH(source: string, destination: string, ...modifiers: RecordModifier[]): DomainModifier;
 
 /**
  * AKAMAICDN is a proprietary record type that is used to configure [Zone Apex Mapping](https://www.akamai.com/blog/security/edge-dns--zone-apex-mapping---dnssec).
@@ -671,7 +671,7 @@ declare function CF_TEMP_REDIRECT(source: string, destination: string, ...modifi
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/service-provider-specific/cloudflare-dns/cf_worker_route
  */
-declare function CF_WORKER_ROUTE(pattern: string, script: string): DomainModifier;
+declare function CF_WORKER_ROUTE(pattern: string, script: string, ...modifiers: RecordModifier[]): DomainModifier;
 
 /**
  * Documentation needed.
@@ -1033,11 +1033,14 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  * * `nonexistentSubdomainPolicy:` The DMARC policy for nonexistent subdomains (`np=`), must be one of `"none"`, `"quarantine"`, `"reject"` (optional)
  * * `alignmentSPF:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for SPF (`aspf=`, default: `"r"`)
  * * `alignmentDKIM:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for DKIM (`adkim=`, default: `"r"`)
+ * * `percent:` Integer percentage (0-100) of messages to which the DMARC policy is applied (`pct=`, optional)
  * * `rua:` Array of aggregate report targets (optional)
  * * `ruf:` Array of failure report targets (optional)
  * * `publicSuffixDomain:` `"y"`, or `"n"` or `"u"` indicates whether the domain is a Public Suffix Domain (`psd=`, default: `"u"`)
  * * `testMode:` `"y"` or `"n"` DMARC policy test mode dictates whether p, sp, or np policy tags are applied (`t=`, default: `"n"`)
  * * `failureOptions:` Object or string; Object containing booleans `SPF` and `DKIM`, string is passed raw (`fo=`, default: `"0"`)
+ * * `failureFormat:` Format of the message's failure reports (`rf=`); only emitted when `ruf` is also set (optional)
+ * * `reportInterval:` Requested interval between aggregate reports, as a `Duration` or number of seconds (`ri=`, optional)
  * * `ttl:` Input for `TTL` method (optional)
  *
  * ### Caveats
@@ -1047,7 +1050,7 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/dmarc_builder
  */
-declare function DMARC_BUILDER(opts: { label?: string; version?: string; policy: 'none' | 'quarantine' | 'reject'; subdomainPolicy?: 'none' | 'quarantine' | 'reject'; nonexistentSubdomainPolicy?: 'none' | 'quarantine' | 'reject'; alignmentSPF?: 'strict' | 's' | 'relaxed' | 'r'; alignmentDKIM?: 'strict' | 's' | 'relaxed' | 'r'; rua?: string[]; ruf?: string[]; publicSuffixDomain: 'y' | 'n' | 'u'; testMode: 'y' | 'n'; failureOptions?: { SPF: boolean, DKIM: boolean } | string; ttl?: Duration }): DomainModifier;
+declare function DMARC_BUILDER(opts: { label?: string; version?: string; policy: 'none' | 'quarantine' | 'reject'; subdomainPolicy?: 'none' | 'quarantine' | 'reject'; nonexistentSubdomainPolicy?: 'none' | 'quarantine' | 'reject'; alignmentSPF?: 'strict' | 's' | 'relaxed' | 'r'; alignmentDKIM?: 'strict' | 's' | 'relaxed' | 'r'; percent?: number; rua?: string[]; ruf?: string[]; publicSuffixDomain: 'y' | 'n' | 'u'; testMode: 'y' | 'n'; failureOptions?: { SPF: boolean, DKIM: boolean } | string; failureFormat?: string; reportInterval?: Duration | number; ttl?: Duration }): DomainModifier;
 
 /**
  * `DNAME` adds a [Delegation name record](https://www.rfc-editor.org/rfc/rfc6672) to the domain.
@@ -2496,7 +2499,7 @@ declare function MX(name: string, priority: number, target: string, ...modifiers
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/nameserver
  */
-declare function NAMESERVER(name: string, ...modifiers: RecordModifier[]): DomainModifier;
+declare function NAMESERVER(name: string): DomainModifier;
 
 /**
  * NAMESERVER_TTL sets the TTL on the domain apex NS RRs defined by [`NAMESERVER`](NAMESERVER.md).
@@ -2719,7 +2722,7 @@ declare function NAMESERVER_TTL(ttl: Duration): DomainModifier;
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/naptr
  */
-declare function NAPTR(subdomain: string, order: number, preference: number, terminalflag: string, service: string, regexp: string, target: string): DomainModifier;
+declare function NAPTR(subdomain: string, order: number, preference: number, terminalflag: string, service: string, regexp: string, target: string, ...modifiers: RecordModifier[]): DomainModifier;
 
 /**
  * `NO_PURGE` indicates that existing records should not be deleted from a domain. Records will be added and updated, but not removed.

--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -1908,9 +1908,11 @@ declare function IP(ip: string): number;
  * deg1: uint32
  * min1: uint32
  * sec1: float32
+ * ns: string
  * deg2: uint32
  * min2: uint32
  * sec2: float32
+ * ew: string
  * altitude: float32
  * size: float32
  * horizontal_precision: float32
@@ -1983,7 +1985,7 @@ declare function IP(ip: string): number;
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/loc
  */
-declare function LOC(deg1: number, min1: number, sec1: number, deg2: number, min2: number, sec2: number, altitude: number, size: number, horizontal_precision: number, vertical_precision: number): DomainModifier;
+declare function LOC(name: string, deg1: number, min1: number, sec1: number, ns: "N" | "S" | "n" | "s", deg2: number, min2: number, sec2: number, ew: "E" | "W" | "e" | "w", altitude: number, size: number, horizontal_precision: number, vertical_precision: number, ...modifiers: RecordModifier[]): DomainModifier;
 
 /**
  * `LOC_BUILDER_DD({})` actually takes an object with the following properties:

--- a/documentation/language-reference/domain-modifiers/ADGUARDHOME_AAAA_PASSTHROUGH.md
+++ b/documentation/language-reference/domain-modifiers/ADGUARDHOME_AAAA_PASSTHROUGH.md
@@ -3,10 +3,12 @@ name: ADGUARDHOME_AAAA_PASSTHROUGH
 parameters:
   - source
   - destination
+  - modifiers...
 provider: ADGUARDHOME
 parameter_types:
   source: string
   destination: string
+  "modifiers...": RecordModifier[]
 ---
 
 `ADGUARDHOME_AAAA_PASSTHROUGH` represents the literal 'A'. AdGuardHome uses this to passthrough

--- a/documentation/language-reference/domain-modifiers/ADGUARDHOME_A_PASSTHROUGH.md
+++ b/documentation/language-reference/domain-modifiers/ADGUARDHOME_A_PASSTHROUGH.md
@@ -3,10 +3,12 @@ name: ADGUARDHOME_A_PASSTHROUGH
 parameters:
   - source
   - destination
+  - modifiers...
 provider: ADGUARDHOME
 parameter_types:
   source: string
   destination: string
+  "modifiers...": RecordModifier[]
 ---
 
 `ADGUARDHOME_A_PASSTHROUGH` represents the literal 'A'. AdGuardHome uses this to passthrough

--- a/documentation/language-reference/domain-modifiers/CF_WORKER_ROUTE.md
+++ b/documentation/language-reference/domain-modifiers/CF_WORKER_ROUTE.md
@@ -3,9 +3,11 @@ name: CF_WORKER_ROUTE
 parameters:
   - pattern
   - script
+  - modifiers...
 parameter_types:
   pattern: string
   script: string
+  "modifiers...": RecordModifier[]
 provider: CLOUDFLAREAPI
 ---
 

--- a/documentation/language-reference/domain-modifiers/DMARC_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/DMARC_BUILDER.md
@@ -8,11 +8,14 @@ parameters:
   - nonexistentSubdomainPolicy
   - alignmentSPF
   - alignmentDKIM
+  - percent
   - rua
   - ruf
   - publicSuffixDomain
   - testMode
   - failureOptions
+  - failureFormat
+  - reportInterval
   - ttl
 parameters_object: true
 parameter_types:
@@ -23,11 +26,14 @@ parameter_types:
   nonexistentSubdomainPolicy: "'none' | 'quarantine' | 'reject'?"
   alignmentSPF: "'strict' | 's' | 'relaxed' | 'r'?"
   alignmentDKIM: "'strict' | 's' | 'relaxed' | 'r'?"
+  percent: number?
   rua: string[]?
   ruf: string[]?
   publicSuffixDomain: "'y' | 'n' | 'u'"
   testMode: "'y' | 'n'"
   failureOptions: "{ SPF: boolean, DKIM: boolean } | string?"
+  failureFormat: string?
+  reportInterval: "Duration | number?"
   ttl: Duration?
 ---
 
@@ -115,11 +121,14 @@ insecure    IN  TXT "v=DMARC1; p=none; ruf=mailto:mailauth-reports@example.com; 
 * `nonexistentSubdomainPolicy:` The DMARC policy for nonexistent subdomains (`np=`), must be one of `"none"`, `"quarantine"`, `"reject"` (optional)
 * `alignmentSPF:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for SPF (`aspf=`, default: `"r"`)
 * `alignmentDKIM:` `"strict"`/`"s"` or `"relaxed"`/`"r"` alignment for DKIM (`adkim=`, default: `"r"`)
+* `percent:` Integer percentage (0-100) of messages to which the DMARC policy is applied (`pct=`, optional)
 * `rua:` Array of aggregate report targets (optional)
 * `ruf:` Array of failure report targets (optional)
 * `publicSuffixDomain:` `"y"`, or `"n"` or `"u"` indicates whether the domain is a Public Suffix Domain (`psd=`, default: `"u"`) 
 * `testMode:` `"y"` or `"n"` DMARC policy test mode dictates whether p, sp, or np policy tags are applied (`t=`, default: `"n"`) 
 * `failureOptions:` Object or string; Object containing booleans `SPF` and `DKIM`, string is passed raw (`fo=`, default: `"0"`)
+* `failureFormat:` Format of the message's failure reports (`rf=`); only emitted when `ruf` is also set (optional)
+* `reportInterval:` Requested interval between aggregate reports, as a `Duration` or number of seconds (`ri=`, optional)
 * `ttl:` Input for `TTL` method (optional)
 
 ### Caveats

--- a/documentation/language-reference/domain-modifiers/LOC.md
+++ b/documentation/language-reference/domain-modifiers/LOC.md
@@ -1,29 +1,35 @@
 ---
 name: LOC
 parameters:
+  - name
   - deg1
   - min1
   - sec1
+  - ns
   - deg2
   - min2
   - sec2
+  - ew
   - altitude
   - size
   - horizontal_precision
   - vertical_precision
+  - modifiers...
 parameter_types:
   name: string
-  target: string
   deg1: number
   min1: number
   sec1: number
+  ns: '"N" | "S" | "n" | "s"'
   deg2: number
   min2: number
   sec2: number
+  ew: '"E" | "W" | "e" | "w"'
   altitude: number
   size: number
   horizontal_precision: number
   vertical_precision: number
+  "modifiers...": RecordModifier[]
 ---
 
 `LOC` add a [Location record](https://www.rfc-editor.org/rfc/rfc1876) to the domain.
@@ -36,9 +42,11 @@ target: string
 deg1: uint32
 min1: uint32
 sec1: float32
+ns: string
 deg2: uint32
 min2: uint32
 sec2: float32
+ew: string
 altitude: float32
 size: float32
 horizontal_precision: float32

--- a/documentation/language-reference/domain-modifiers/NAMESERVER.md
+++ b/documentation/language-reference/domain-modifiers/NAMESERVER.md
@@ -2,10 +2,8 @@
 name: NAMESERVER
 parameters:
   - name
-  - modifiers...
 parameter_types:
   name: string
-  "modifiers...": RecordModifier[]
 ---
 
 `NAMESERVER()` instructs DNSControl to inform the domain's registrar where to find this zone. For some registrars this will also add NS records to the zone itself.

--- a/documentation/language-reference/domain-modifiers/NAMESERVER_TTL.md
+++ b/documentation/language-reference/domain-modifiers/NAMESERVER_TTL.md
@@ -4,8 +4,6 @@ parameters:
   - ttl
 parameter_types:
   ttl: Duration
-  target: string
-  modifiers...: RecordModifier[]
 ---
 
 NAMESERVER_TTL sets the TTL on the domain apex NS RRs defined by [`NAMESERVER`](NAMESERVER.md).

--- a/documentation/language-reference/domain-modifiers/NAPTR.md
+++ b/documentation/language-reference/domain-modifiers/NAPTR.md
@@ -8,6 +8,7 @@ parameters:
   - service
   - regexp
   - target
+  - modifiers...
 parameter_types:
   subdomain: string
   order: number
@@ -16,6 +17,7 @@ parameter_types:
   service: string
   regexp: string
   target: string
+  "modifiers...": RecordModifier[]
 ---
 
 ## Introduction


### PR DESCRIPTION
Fixes #4804, and extends the fix into a full audit of the domain-modifier docs.

`commands/types/dnscontrol.d.ts` is generated by `build/generate` from each doc's front-matter (`parameters` + `parameter_types`). The LOC bug in #4804 turned out to be one instance of a broader class, so I cross-checked **every** doc in `documentation/language-reference/domain-modifiers/` against the real signatures (`models.Make*` arg counts, `pkg/js/helpers.js`, and `pkg/privatetypes/types_generate.yaml`).

### LOC (#4804)
Added the four missing params — `name`, `ns`, `ew`, `...modifiers`:
```ts
declare function LOC(name: string, deg1: number, min1: number, sec1: number, ns: "N" | "S" | "n" | "s", deg2: number, min2: number, sec2: number, ew: "E" | "W" | "e" | "w", altitude: number, size: number, horizontal_precision: number, vertical_precision: number, ...modifiers: RecordModifier[]): DomainModifier;
```

### Additional mismatches found & fixed
**Missing trailing `...modifiers`** (all are `rawrecordBuilder` records that accept trailing `RecordModifier`s, same as LOC):
- `NAPTR`
- `ADGUARDHOME_A_PASSTHROUGH`
- `ADGUARDHOME_AAAA_PASSTHROUGH`
- `CF_WORKER_ROUTE`

**Wrong/stray params:**
- `NAMESERVER` — removed a bogus `...modifiers`; the JS function throws if given more than one argument (`helpers.js:766`).
- `NAMESERVER_TTL` — removed stray `target`/`modifiers...` entries from `parameter_types` (not real parameters).

**Missing object properties:**
- `DMARC_BUILDER` — added `percent` (`pct=`), `failureFormat` (`rf=`), and `reportInterval` (`ri=`), which the builder reads (`helpers.js:1711/1749/1755`) but the docs omitted.

