### PR TITLE
fix(mustbe): Fix 32-bit compatibility

### DIFF
--- a/documentation/advanced-features/integration-tests.md
+++ b/documentation/advanced-features/integration-tests.md
@@ -1,4 +1,9 @@
-### Integration Tests
+# Integration Tests
+
+- [Integration Tests](#integration-tests)
+  - [Configuration](#configuration)
+  - [Running a test](#running-a-test)
+  - [Bonus: How to test for 32-bit compatibility](#bonus-how-to-test-for-32-bit-compatibility)
 
 This is a simple framework for testing dns providers by making real requests.
 
@@ -74,3 +79,18 @@ should create a script that you can `source` to set these
 variables. Be careful not to check this script into Git since it
 contains credentials.
 {% endhint %}
+
+## Bonus: How to test for 32-bit compatibility
+
+Make sure it compiles:
+
+```bash
+GOOS=linux GOARCH=arm GOARM=7 go build
+```
+
+Use Docker to make sure all tests pass:
+
+```bash
+docker run --platform linux/arm -v "$(pwd):/src" -w /src golang:latest go test -v ./...
+docker run --platform linux/386 -v "$(pwd):/src" -w /src golang:latest go test -v ./...
+```

--- a/pkg/mustbe/numbers.go
+++ b/pkg/mustbe/numbers.go
@@ -114,12 +114,12 @@ func Uint32(arg any) uint32 {
 	case uint32:
 		return v
 	case uint:
-		if v > math.MaxUint32 {
+		if uint64(v) > uint64(math.MaxUint32) { // casts to assure 32-bit compatibility.
 			panic(fmt.Sprintf("value %v overflows uint32", arg))
 		}
 		return uint32(v)
 	case int:
-		if v < 0 || v > math.MaxUint32 {
+		if v < 0 || int64(v) > int64(math.MaxUint32) { // casts to assure 32-bit compatibility.
 			panic(fmt.Sprintf("value %v overflows uint32", arg))
 		}
 		return uint32(v)

--- a/pkg/mustbe/numbers_test.go
+++ b/pkg/mustbe/numbers_test.go
@@ -2,6 +2,32 @@ package mustbe
 
 import "testing"
 
+// Uint32
+
+func TestUint32FromUint(t *testing.T) {
+	if got := Uint32(uint(8888)); got != 8888 {
+		t.Fatalf("Uint32(uint(8888)) = %d, want 8888", got)
+	}
+}
+
+func TestUint32FromInt(t *testing.T) {
+	if got := Uint32(int(7777)); got != 7777 {
+		t.Fatalf("Uint32(int(7777)) = %d, want 7777", got)
+	}
+}
+
+func TestUint32RejectsNegative(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected function to panic")
+		}
+	}()
+
+	Uint32(int(-1))
+}
+
+// Int64
+
 func TestInt64FromFloat64(t *testing.T) {
 	if got := Int64(float64(12345)); got != 12345 {
 		t.Fatalf("Int64(12345) = %d, want 12345", got)


### PR DESCRIPTION
Fixes https://github.com/DNSControl/dnscontrol/issues/4816

* mustbe.Uint32() now compiles on 32-bit systems
* Added doc for how to test for 32-bit compatibility