### PR TITLE
CLOUDNS: BUGFIX: CAA records get unneeded updates (fixes #4819)

### DIFF
--- a/models/makers.go
+++ b/models/makers.go
@@ -82,17 +82,10 @@ func MakeAAAA(origin string, _ map[string]string, isEnabled nrc.Flags, args ...a
 	return dnsrdatav2.AAAA{Addr: ip}, nil
 }
 
-func MakeCAA(origin string, metadata map[string]string, isEnabled nrc.Flags, args ...any) (dnsv2.RDATA, error) {
+func MakeCAA(origin string, _ map[string]string, isEnabled nrc.Flags, args ...any) (dnsv2.RDATA, error) {
 	mustbe.ValidArgs(args)
-	if len(args) != 2 && len(args) != 3 {
-		return nil, fmt.Errorf("MakeCAA expects 2 or 3 arguments, got %d: %+v", len(args), args)
-	}
-	if len(args) == 2 {
-		var flag any = uint8(0)
-		if cf, ok := metadata["caaflag"]; ok {
-			flag = cf
-		}
-		return dnsrdatav2.CAA{Flag: mustbe.Uint8(flag), Tag: mustbe.RawString(args[0]), Value: mustbe.RawString(args[1])}, nil
+	if len(args) != 3 {
+		return nil, fmt.Errorf("MakeCAA expects 3 arguments, got %d: %+v", len(args), args)
 	}
 
 	tag := mustbe.RawString(args[1])
@@ -102,7 +95,6 @@ func MakeCAA(origin string, metadata map[string]string, isEnabled nrc.Flags, arg
 	}
 
 	return dnsrdatav2.CAA{Flag: mustbe.Uint8(args[0]), Tag: tag, Value: mustbe.RawString(args[2])}, nil
-
 }
 func MakeCNAME(origin string, _ map[string]string, isEnabled nrc.Flags, args ...any) (dnsv2.RDATA, error) {
 	mustbe.ValidArgs(args)

--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -306,18 +306,24 @@ function DefaultTTL(v) {
 function makeCAAFlag(value) {
     return function (record) {
         record.caaflag |= value;
-        if (!_.isObject(record.meta)) {
-            record.meta = {};
-        }
-        // Store as a string: meta values cross to Go as strings (see
-        // mergeMetas), otherwise a numeric value would be mangled (e.g. into
-        // "%!s(float64=128)").
-        record.meta['caaflag'] = record.caaflag.toString();
     };
 }
 
 // CAA_CRITICAL: Critical CAA flag
 var CAA_CRITICAL = makeCAAFlag(1 << 7);
+
+// caaOptions injects the CAA flag as the first rdata argument so that MakeCAA
+// (Go) always receives (flag, tag, value). processedArgs is [label, tag, value];
+// the flag is accumulated on record.caaflag by the CAA_CRITICAL modifier and
+// defaults to 0.
+function caaOptions(record, processedArgs) {
+    return [
+        processedArgs[0],
+        record.caaflag || 0,
+        processedArgs[1],
+        processedArgs[2],
+    ];
+}
 
 // DnsProvider("providerName", 0)
 // nsCount of 0 means don't use or register any nameservers.
@@ -2089,9 +2095,9 @@ function rawrecordBuilder(type, noLabel, optionalsFn) {
                 );
             }
 
-            // Modifier functions (e.g. CAA_CRITICAL) may have written to
-            // record.meta. Capture that so it propagates to Go as a meta;
-            // otherwise it would be silently dropped.
+            // Modifier functions may have written to record.meta. Capture that
+            // so it propagates to Go as a meta; otherwise it would be silently
+            // dropped.
             if (_.isObject(record.meta) && !_.isEmpty(record.meta)) {
                 processedMetas.push(record.meta);
             }
@@ -2128,7 +2134,7 @@ var ALIAS = rawrecordBuilder('ALIAS');
 var AZURE_ALIAS = rawrecordBuilder('AZURE_ALIAS');
 var BUNNY_DNS_PZ = rawrecordBuilder('BUNNY_DNS_PZ');
 var BUNNY_DNS_RDR = rawrecordBuilder('BUNNY_DNS_RDR');
-var CAA = rawrecordBuilder('CAA');
+var CAA = rawrecordBuilder('CAA', false, caaOptions);
 var CF_REDIRECT = rawrecordBuilder('CF_REDIRECT', true);
 var CF_SINGLE_REDIRECT = rawrecordBuilder(
     'CLOUDFLAREAPI_SINGLE_REDIRECT',

--- a/pkg/js/parse_tests/014-caa.json
+++ b/pkg/js/parse_tests/014-caa.json
@@ -8,9 +8,6 @@
         {
           "comparablev3": "128 iodef \"https://example.com\"",
           "filepos": "[line:12:5]",
-          "meta": {
-            "caaflag": "128"
-          },
           "name": "@",
           "name_unicode": "@",
           "rdata": {
@@ -25,9 +22,6 @@
         {
           "comparablev3": "128 iodef \"mailto:test@example.com\"",
           "filepos": "[line:8:5]",
-          "meta": {
-            "caaflag": "128"
-          },
           "name": "@",
           "name_unicode": "@",
           "rdata": {


### PR DESCRIPTION
Fixes #4819.

### Problem
CLOUDNS keeps "modifying" an unchanged CAA record on every `push` (reported against v5.0.0):

```
± MODIFY ... CAA (128 issue "amazonaws.com" ttl=3600) -> (128 issue "amazonaws.com" ttl=3600) ...
```

### Root cause
The CAA **flag** was communicated two ways:
1. The record's RDATA `Flag` field, and
2. a redundant `Metadata["caaflag"]` entry, written by the `CAA_CRITICAL` modifier.

Records built from `dnsconfig.js` carried the extra metadata; records read back from the provider API did not. Providers that compare metadata (CLOUDNS) therefore saw a phantom difference and re-applied the record every time.

### Fix — one source of truth (RDATA only)
- **`models/makers.go`**: `MakeCAA` now requires exactly **3 arguments** (`flag, tag, value`), removing the 2-arg special case that pulled the flag from `metadata["caaflag"]`.
- **`pkg/js/helpers.js`**: `makeCAAFlag` no longer writes `record.meta['caaflag']` — it only accumulates `record.caaflag`. A new `caaOptions()` `optionalsFn` injects that flag as the first rdata argument so `MakeCAA` always receives 3 args. **`CAA_CRITICAL` usage is unchanged for users.**
- Regenerated the `014-caa` parse-test golden: the redundant `caaflag` metadata is gone; the RDATA `Flag` (128 for critical records) is unchanged.

### Verification
- `models`, `pkg/js`, and `providers/cloudns` test suites pass; `go build ./...`, `go vet`, and `gofmt` clean.
- End-to-end check of the exact issue config (`CAA_BUILDER` with `issue_critical`/`issuewild_critical`) now yields CAA records with **empty metadata** and correct `Flag=128`, so the phantom CLOUDNS diff is gone.
