### PR TITLE
BUGFIX: DMARC_BUILDER handling of nonexistentSubdomain policy

### DIFF
--- a/pkg/js/helpers.js
+++ b/pkg/js/helpers.js
@@ -1674,8 +1674,8 @@ function DMARC_BUILDER(value) {
     ) {
         throw 'Invalid DMARC nonexistent-subdomain policy';
     }
-    if (value.subdomainPolicy) {
-        record.push('np=' + value.subdomainPolicy);
+    if (value.nonexistentSubdomainPolicy) {
+        record.push('np=' + value.nonexistentSubdomainPolicy);
     }
 
     // Alignment DKIM


### PR DESCRIPTION
Previously the builder used the presence and value of `subdomainPolicy` (sp=) to set nonexistent subdomain policy (np=). This resulted in setting np= incorrectly if the builder arguments included `subdomainPolicy`
