### PR TITLE
TRANSIP: TransIP does not support TXT with trailing whitespace

### DIFF
--- a/providers/transip/auditrecords.go
+++ b/providers/transip/auditrecords.go
@@ -17,6 +17,8 @@ func AuditRecords(records models.Records) []error {
 
 	a.Add("TXT", rejectif.TxtHasDoubleQuotes) // Last verified 2026-07-21
 
+	a.Add("TXT", rejectif.TxtHasTrailingSpace) // Last verified 2026-07-21
+
 	a.Add("TXT", rejectif.TxtIsEmpty) // Last verified 2026-08-28
 
 	return a.Audit(records)


### PR DESCRIPTION
```
=== RUN   TestDNSProviders/dnscontrol.nl/28:complex_TXT:TXT_trailing_ws
    helpers_integration_test.go:246:
        Zone update for dnscontrol.nl
        - DELETE foosp.dnscontrol.nl TXT "with spaces" ttl=300
        + CREATE foows1.dnscontrol.nl TXT "trailingws " ttl=300
    helpers_integration_test.go:251: whitespace at the end or start of the content of a record is not allowed: foows1 300 TXT trailingws
--- FAIL: TestDNSProviders (13.10s)
```