### PR TITLE
fix(pr_status): Fix for code scanning alert no. 50: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/pr_check_git_status.yml
+++ b/.github/workflows/pr_check_git_status.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - "tlim_testpr"
   pull_request:
-  workflow_dispatch:
 
 concurrency:
   # Cancel superseded runs when new commits are pushed to the same PR/branch.


### PR DESCRIPTION
Potential fix for [https://github.com/DNSControl/dnscontrol/security/code-scanning/50](https://github.com/DNSControl/dnscontrol/security/code-scanning/50)

Best fix: prevent this workflow from running in a default-branch `workflow_dispatch` context when it checks out and executes PR head code. The minimal, functionality-preserving fix is to remove `workflow_dispatch` from this workflow’s triggers, leaving `push` and `pull_request`.

Concretely, edit `.github/workflows/pr_check_git_status.yml` and delete the `workflow_dispatch:` trigger line under `on:`. No other code changes are required. This keeps existing PR/push behavior intact while removing the risky execution context that enables default-branch cache poisoning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
