### PR TITLE
BIND: BUGFIX: SOA not incrementing on the existing zone (fixes #4840)

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -286,7 +286,7 @@ func verifyDNSProviderCredsReal(sample InitCredsEntry) ([]string, error) {
 	maps.Copy(creds, sample.Fields)
 	provider, err := providers.CreateDNSProvider(sample.TypeName, creds, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed verifyDNSProviderCredsReal(%s): %w", sample.Name, err)
 	}
 	lister, ok := provider.(providers.ZoneLister)
 	if !ok {

--- a/commands/ppreviewPush.go
+++ b/commands/ppreviewPush.go
@@ -895,7 +895,7 @@ func PInitializeProviders(cfg *models.DNSConfig, providerConfigs map[string]map[
 			rCfg := cfg.RegistrarsByName[d.RegistrarName]
 			r, err := providers.CreateRegistrar(rCfg.Type, providerConfigs[d.RegistrarName])
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to initialize registrar %q: %w", rCfg.Name, err)
 			}
 			registrars[d.RegistrarName] = r
 		}
@@ -906,7 +906,7 @@ func PInitializeProviders(cfg *models.DNSConfig, providerConfigs map[string]map[
 				dCfg := cfg.DNSProvidersByName[pInst.Name]
 				prov, err := providers.CreateDNSProvider(dCfg.Type, providerConfigs[dCfg.Name], dCfg.Metadata)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to initialize DNS provider %q: %w", dCfg.Name, err)
 				}
 				dnsProviders[pInst.Name] = prov
 			}

--- a/commands/previewPush.go
+++ b/commands/previewPush.go
@@ -64,7 +64,7 @@ func InitializeProviders(cfg *models.DNSConfig, providerConfigs map[string]map[s
 				dCfg := cfg.DNSProvidersByName[pInst.Name]
 				prov, err := providers.CreateDNSProvider(dCfg.Type, providerConfigs[dCfg.Name], dCfg.Metadata)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to initialize %q: %w", dCfg.Name, err)
 				}
 				dnsProviders[pInst.Name] = prov
 			}

--- a/providers/bind/bindProvider.go
+++ b/providers/bind/bindProvider.go
@@ -77,6 +77,9 @@ func initBind(config map[string]string, providermeta json.RawMessage) (providers
 	if api.filenameformat == "" {
 		api.filenameformat = "%c.zone"
 	}
+	if err := validateDirName(api.directory, api.filenameformat); err != nil {
+		return nil, err
+	}
 	if len(providermeta) != 0 {
 		err := json.Unmarshal(providermeta, api)
 		if err != nil {
@@ -198,7 +201,6 @@ func (c *bindProvider) ListZones() ([]string, error) {
 // GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
 func (c *bindProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records, error) {
 	domain := dc.Name
-	// meta := dc.Metadata
 
 	var zonefile string
 
@@ -243,11 +245,11 @@ func findSoaRecord(recs models.Records) *models.RecordConfig {
 	return nil
 }
 
-func updateSerialNumber(desired, existing models.Records, forcedSerial uint32) {
+func updateSerialNumber(desired, existing models.Records, forcedSerial uint32) uint32 {
 
 	recToUpdate := findSoaRecord(desired)
 	if recToUpdate == nil {
-		return
+		return 0
 	}
 
 	f := recToUpdate.AsSOA()
@@ -270,6 +272,7 @@ func updateSerialNumber(desired, existing models.Records, forcedSerial uint32) {
 	}
 
 	recToUpdate.SetRDATA(f)
+	return recToUpdate.AsSOA().Serial
 }
 
 // ParseZoneContents parses a string as a BIND zone and returns the records.
@@ -346,13 +349,13 @@ func (c *bindProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, foundR
 
 	// We know there are changes. Update the SOA record's serial number,
 	// basing it on the serial already published in the existing zone.
-	updateSerialNumber(result.DesiredPlus, foundRecords, uint32(bindserial.ForcedValue&0xFFFF))
+	serial := updateSerialNumber(result.DesiredPlus, foundRecords, uint32(bindserial.ForcedValue&0xFFFF))
 
 	corrections = append(corrections,
 		&models.Correction{
 			Msg: msg,
 			F: func() error {
-				printer.Printf("WRITING ZONEFILE: %v\n", zonefile)
+				printer.Printf("WRITING ZONEFILE: %q (serial %d)\n", zonefile, serial)
 				fname, err := preprocessFilename(zonefile)
 				if err != nil {
 					return fmt.Errorf("could not create zonefile: %w", err)

--- a/providers/bind/bindProvider.go
+++ b/providers/bind/bindProvider.go
@@ -243,9 +243,9 @@ func findSoaRecord(recs models.Records) *models.RecordConfig {
 	return nil
 }
 
-func updateSerialNumber(recs models.Records, forcedSerial uint32) {
+func updateSerialNumber(desired, existing models.Records, forcedSerial uint32) {
 
-	recToUpdate := findSoaRecord(recs)
+	recToUpdate := findSoaRecord(desired)
 	if recToUpdate == nil {
 		return
 	}
@@ -255,7 +255,18 @@ func updateSerialNumber(recs models.Records, forcedSerial uint32) {
 	if forcedSerial != 0 {
 		f.Serial = forcedSerial
 	} else {
-		f.Serial = generateSerial(f.Serial)
+		// Base the new serial on the larger of the desired serial and the
+		// serial currently published in the existing zone file. The desired
+		// SOA is usually a freshly-built default (serial 1), so without this
+		// the serial would be regenerated from that default on every push and
+		// never advance past YYYYMMDD00. See issue #4840.
+		oldSerial := f.Serial
+		if existingSOA := findSoaRecord(existing); existingSOA != nil {
+			if s := existingSOA.AsSOA().Serial; s > oldSerial {
+				oldSerial = s
+			}
+		}
+		f.Serial = generateSerial(oldSerial)
 	}
 
 	recToUpdate.SetRDATA(f)
@@ -333,8 +344,9 @@ func (c *bindProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, foundR
 		),
 	)
 
-	// We know there are changes. Update the SOA record's serial number.
-	updateSerialNumber(result.DesiredPlus, uint32(bindserial.ForcedValue&0xFFFF))
+	// We know there are changes. Update the SOA record's serial number,
+	// basing it on the serial already published in the existing zone.
+	updateSerialNumber(result.DesiredPlus, foundRecords, uint32(bindserial.ForcedValue&0xFFFF))
 
 	corrections = append(corrections,
 		&models.Correction{

--- a/providers/bind/fnames.go
+++ b/providers/bind/fnames.go
@@ -92,6 +92,19 @@ func makeFileName(format string, ff domaintags.DomainNameVarieties) string {
 	return b.String()
 }
 
+func validateDirName(dir, format string) error {
+	full := filepath.Join(dir, format)
+	goodDir, goodFile := filepath.Split(full)
+	goodDir = strings.TrimSuffix(goodDir, "/")
+
+	// If format includes a "/", suggest that the user is trying to specify a subdirectory, which is not allowed.
+	if strings.Contains(format, "/") {
+		return fmt.Errorf("BIND filenameformat (%q) may not contain a slash. suggestion: use dir %q and fileformat %q", format, goodDir, goodFile)
+	}
+
+	return nil
+}
+
 // extractZonesFromFilenames extracts the zone names from a list of filenames
 // based on the format string used to create the files. It is mathematically
 // impossible to do this correctly for all format strings, but typical format

--- a/providers/bind/fnames_test.go
+++ b/providers/bind/fnames_test.go
@@ -208,3 +208,32 @@ func Test_extractZonesFromFilenames(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateDirName(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		dir     string
+		format  string
+		wantErr bool
+	}{
+		{"plan", "zone", "%U.zone", false},
+		{"bad", "zone", "z/y/%U.zone", true},
+		{"nilzonegood", "", "%U.zone", false},
+		{"nilzonebad", "", "z/y/%U.zone", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := validateDirName(tt.dir, tt.format)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("validateDirName() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("validateDirName() succeeded unexpectedly")
+			}
+		})
+	}
+}

--- a/providers/bind/serial.go
+++ b/providers/bind/serial.go
@@ -56,7 +56,12 @@ func generateSerial(oldSerial uint32) uint32 {
 	if oldSerial == newSerial {
 		log.Fatalf("%v: old_serial == new_serial (%v == %v) draft=%v method=%v", original, oldSerial, newSerial, draft, method)
 	}
-	if oldSerial > newSerial {
+	if oldSerial < 4294967000 && oldSerial > newSerial {
+		// If the old serial is very large, we allow it to wrap around to a
+		// smaller number. Otherwise, it should never be smaller than the new
+		// serial.  The constant 4294967000 is a bit arbitrary, but it is close
+		// to the maximum 32-bit unsigned integer (2^32 - 1 = 4294967295). This
+		// allows for some leeway in case of very large serial numbers.
 		log.Fatalf("%v: old_serial > new_serial (%v > %v) draft=%v method=%v", original, oldSerial, newSerial, draft, method)
 	}
 

--- a/providers/bind/serial_update_test.go
+++ b/providers/bind/serial_update_test.go
@@ -1,0 +1,68 @@
+package bind
+
+import (
+	"testing"
+	"time"
+
+	dnsv2 "codeberg.org/miekg/dns"
+	"github.com/DNSControl/dnscontrol/v5/models"
+)
+
+func makeSOAForTest(t *testing.T, serial uint32) *models.RecordConfig {
+	t.Helper()
+	dc := &models.DomainConfig{Name: "example.com"}
+	rc, err := dc.NewRecordConfig(
+		"@", 3600, dnsv2.TypeSOA,
+		"ns.example.com.", "hostmaster.example.com.",
+		serial, uint32(3600), uint32(600), uint32(604800), uint32(1440),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rc
+}
+
+// Test_updateSerialNumber verifies that the new SOA serial is based on the
+// serial already published in the existing zone, not on the (default) desired
+// SOA. See https://github.com/DNSControl/dnscontrol/issues/4840.
+func Test_updateSerialNumber(t *testing.T) {
+	day, _ := time.Parse("20060102", "20260901")
+	nowFunc = func() time.Time { return day }
+	defer func() { nowFunc = time.Now }()
+
+	tests := []struct {
+		name       string
+		desired    uint32 // serial on the desired SOA (AddSoaIfMissing produces 1)
+		existing   uint32 // serial on the existing/on-disk SOA (0 == no SOA on disk)
+		forced     uint32
+		wantSerial uint32
+	}{
+		// First push, nothing on disk: use today's default.
+		{name: "fresh zone", desired: 1, existing: 0, forced: 0, wantSerial: 2026090100},
+		// #4840: same-day re-push must advance past the on-disk serial rather
+		// than regenerate YYYYMMDD00 from the default desired serial.
+		{name: "same-day increment", desired: 1, existing: 2026090100, forced: 0, wantSerial: 2026090101},
+		{name: "same-day increment again", desired: 1, existing: 2026090101, forced: 0, wantSerial: 2026090102},
+		// On-disk serial from an earlier day: jump to today's default.
+		{name: "advance to today", desired: 1, existing: 2026083100, forced: 0, wantSerial: 2026090100},
+		// A forced serial (--bindserial) wins regardless of on-disk value.
+		{name: "forced serial", desired: 1, existing: 2026090100, forced: 2026, wantSerial: 2026},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			desiredSOA := makeSOAForTest(t, tc.desired)
+			desired := models.Records{desiredSOA}
+			var existing models.Records
+			if tc.existing != 0 {
+				existing = models.Records{makeSOAForTest(t, tc.existing)}
+			}
+
+			updateSerialNumber(desired, existing, tc.forced)
+
+			if got := desiredSOA.AsSOA().Serial; got != tc.wantSerial {
+				t.Errorf("serial = %d; want %d", got, tc.wantSerial)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4840.

* creds.json errors: Report which section had the error
* BIND: Validate directory/filenameformat and output suggestions if wrong
* BIND: SOA serial increment wasn't working. Fixed and added unit test.
* BIND: Add serial number to msg: `WRITING ZONEFILE: "full/path/to/zone.zone" (serial 12345)`
* BIND: SOA serial increment loops around properly when at 2^32-1

### Problem
With the BIND provider, the SOA serial never advances past `YYYYMMDD00` on same-day pushes:

```
push --bindserial 2026   -> serial 2026
push                     -> serial 2026090100
push (another change)    -> serial 2026090100   # should be 2026090101
```

### Root cause
`updateSerialNumber()` regenerated the serial from the **desired** SOA record. For BIND the desired SOA is almost always a freshly-built default (serial `1`, produced by `AddSoaIfMissing`), so `generateSerial()` was effectively called with `1` every time and returned `todayNum*100` (`YYYYMMDD00`) — never the increment path. The serial already published in the existing zone file (e.g. `2026090100`) was ignored.

`generateSerial()` itself is correct: given `2026090100` on the same day it returns `2026090101`. It just wasn't being given the on-disk serial.

### Fix
Base the new serial on the larger of the desired serial and the serial in the existing zone file, then run it through `generateSerial()`. Same-day re-pushes now advance (`…00 → …01 → …02`).

- `--bindserial` (forced serial) path: unchanged.
- First push / no existing zone: unchanged (still `YYYYMMDD00`).

### Tests
Adds `Test_updateSerialNumber` (deterministic via the existing `nowFunc` hook) covering: fresh zone, same-day increment (the #4840 case), same-day increment again, advance-to-today from an older serial, and forced serial. Existing `Test_generate_serial_1` still passes.

