### PR TITLE
FEATURE: Add Infoblox NIOS DNS provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@ providers/hedns @rblenkinsopp
 providers/hetznerv2 @das7pad
 providers/hostingde @juliusrickert
 providers/huaweicloud @huihuimoe
+providers/infoblox @matthewmgamble
 providers/infomaniak @jbelien
 providers/internetbs @pragmaton
 providers/inwx @patschi

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -97,6 +97,9 @@ provider-HOSTINGDE:
 provider-HUAWEICLOUD:
   - changed-files:
       - any-glob-to-any-file: providers/huaweicloud/**
+provider-INFOBLOX:
+  - changed-files:
+      - any-glob-to-any-file: providers/infoblox/**
 provider-INFOMANIAK:
   - changed-files:
       - any-glob-to-any-file: providers/infomaniak/**

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -186,6 +186,7 @@ jobs:
       HETZNER_V2_DOMAIN: ${{ vars.HETZNER_V2_DOMAIN }}
       HOSTINGDE_DOMAIN: ${{ vars.HOSTINGDE_DOMAIN }}
       HUAWEICLOUD_DOMAIN: ${{ vars.HUAWEICLOUD_DOMAIN }}
+      INFOBLOX_DOMAIN: ${{ vars.INFOBLOX_DOMAIN }}
       INFOMANIAK_DOMAIN: ${{ vars.INFOMANIAK_DOMAIN }}
       INWX_DOMAIN: ${{ vars.INWX_DOMAIN }}
       JOKER_DOMAIN: ${{ vars.JOKER_DOMAIN }}
@@ -327,6 +328,11 @@ jobs:
       HUAWEICLOUD_KEY: ${{ secrets.HUAWEICLOUD_KEY }}
       HUAWEICLOUD_KEY_ID: ${{ secrets.HUAWEICLOUD_KEY_ID }}
       HUAWEICLOUD_REGION: ${{ secrets.HUAWEICLOUD_REGION }}
+      #
+      INFOBLOX_HOST: ${{ secrets.INFOBLOX_HOST }}
+      INFOBLOX_USERNAME: ${{ secrets.INFOBLOX_USERNAME }}
+      INFOBLOX_PASSWORD: ${{ secrets.INFOBLOX_PASSWORD }}
+      INFOBLOX_VIEW: ${{ secrets.INFOBLOX_VIEW }}
       #
       INFOMANIAK_TOKEN: ${{ secrets.INFOMANIAK_TOKEN }}
       #

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ changelog:
       regexp: "(?i)^.*(major|new provider|feature)[(\\w)]*:+.*$"
       order: 1
     - title: 'Provider-specific changes:'
-      regexp: "(?i)((adguardhome|akamaiedgedns|alidns|autodns|axfrddns|azure_dns|azure_private_dns|azuredns|bind|bunny_dns|bunnydns|cloudflare|cloudflareapi|cloudns|cnr|cscglobal|desec|digitalocean|dnscale|dnsimple|dnsmadeeasy|dnsoverhttps|doh|domainnameshop|dynadot|dynu|easyname|exoscale|fortigate|gandi|gandi_v5|gcloud|gcore|gidinet|gigahost|hedns|hetzner_v2|hexonet|hostingde|huaweicloud|infomaniak|internetbs|inwx|joker|linode|loopia|luadns|mikrotik|mythicbeasts|namecheap|namedotcom|netbird|netcup|netlify|netnod|nexdns|ns1|opensrs|openwrt|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|scaleway|softlayer|tencentdns|transip|unifi|vercel|vultr|websupport).*:)+.*"
+      regexp: "(?i)((adguardhome|akamaiedgedns|alidns|autodns|axfrddns|azure_dns|azure_private_dns|azuredns|bind|bunny_dns|bunnydns|cloudflare|cloudflareapi|cloudns|cnr|cscglobal|desec|digitalocean|dnscale|dnsimple|dnsmadeeasy|dnsoverhttps|doh|domainnameshop|dynadot|dynu|easyname|exoscale|fortigate|gandi|gandi_v5|gcloud|gcore|gidinet|gigahost|hedns|hetzner_v2|hexonet|hostingde|huaweicloud|infoblox|infomaniak|internetbs|inwx|joker|linode|loopia|luadns|mikrotik|mythicbeasts|namecheap|namedotcom|netbird|netcup|netlify|netnod|nexdns|ns1|opensrs|openwrt|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|scaleway|softlayer|tencentdns|transip|unifi|vercel|vultr|websupport).*:)+.*"
       order: 2
     - title: 'Documentation:'
       regexp: "(?i)^.*(docs)[(\\w)]*:+.*$"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See [Getting Started](https://docs.dnscontrol.org/getting-started/getting-starte
 
 ## Supported Providers
 
-DNSControl supports 65 DNS providers and registrars:
+DNSControl supports 66 DNS providers and registrars:
 
 | | | | | |
 | ----- | ----- | ----- | ----- | ----- |
@@ -54,14 +54,14 @@ DNSControl supports 65 DNS providers and registrars:
 | [DigitalOcean](https://docs.dnscontrol.org/provider/digitalocean) | [DNS Made Easy](https://docs.dnscontrol.org/provider/dnsmadeeasy) | [DNSOVERHTTPS](https://docs.dnscontrol.org/provider/dnsoverhttps)² | [DNScale](https://docs.dnscontrol.org/provider/dnscale) | [DNSimple](https://docs.dnscontrol.org/provider/dnsimple)¹ |
 | [Domainnameshop](https://docs.dnscontrol.org/provider/domainnameshop) | [Dynadot](https://docs.dnscontrol.org/provider/dynadot)² | [easyname](https://docs.dnscontrol.org/provider/easyname)² | [Exoscale](https://docs.dnscontrol.org/provider/exoscale) | [Fortigate](https://docs.dnscontrol.org/provider/fortigate) |
 | [Gandi](https://docs.dnscontrol.org/provider/gandiv5)¹ | [Gcore](https://docs.dnscontrol.org/provider/gcore) | [Gidinet](https://docs.dnscontrol.org/provider/gidinet)¹ | [Google DNS](https://docs.dnscontrol.org/provider/gcloud) | [Hetzner](https://docs.dnscontrol.org/provider/hetzner) |
-| [hosting.de](https://docs.dnscontrol.org/provider/hostingde)¹ | [Huawei Cloud DNS](https://docs.dnscontrol.org/provider/huaweicloud) | [Hurricane Electric DNS](https://docs.dnscontrol.org/provider/hedns) | [Infomaniak](https://docs.dnscontrol.org/provider/infomaniak) | [Internet.bs](https://docs.dnscontrol.org/provider/internetbs)² |
-| [INWX](https://docs.dnscontrol.org/provider/inwx)¹ | [Joker](https://docs.dnscontrol.org/provider/joker) | [Linode](https://docs.dnscontrol.org/provider/linode) | [Loopia](https://docs.dnscontrol.org/provider/loopia)¹ | [LuaDNS](https://docs.dnscontrol.org/provider/luadns) |
-| Windows Server DNS | [MikroTik RouterOS](https://docs.dnscontrol.org/provider/mikrotik) | [Mythic Beasts](https://docs.dnscontrol.org/provider/mythicbeasts) | [Name.com](https://docs.dnscontrol.org/provider/namedotcom)¹ | [Namecheap](https://docs.dnscontrol.org/provider/namecheap)¹ |
-| [Netcup](https://docs.dnscontrol.org/provider/netcup) | [Netlify](https://docs.dnscontrol.org/provider/netlify) | [Netnod](https://docs.dnscontrol.org/provider/netnod) | [NexDNS](https://docs.dnscontrol.org/provider/nexdns) | [NS1](https://docs.dnscontrol.org/provider/ns1) |
-| [OpenSRS](https://docs.dnscontrol.org/provider/opensrs)² | [Oracle Cloud](https://docs.dnscontrol.org/provider/oracle) | [OVH](https://docs.dnscontrol.org/provider/ovh)¹ | [Packetframe](https://docs.dnscontrol.org/provider/packetframe) | [Porkbun](https://docs.dnscontrol.org/provider/porkbun)¹ |
-| [PowerDNS](https://docs.dnscontrol.org/provider/powerdns) | [Realtime Register](https://docs.dnscontrol.org/provider/realtimeregister)¹ | [RWTH DNS-Admin](https://docs.dnscontrol.org/provider/rwth) | [Sakura Cloud](https://docs.dnscontrol.org/provider/sakuracloud) | [SoftLayer](https://docs.dnscontrol.org/provider/softlayer) |
-| [Tencent Cloud DNS](https://docs.dnscontrol.org/provider/tencentdns)¹ | [TransIP](https://docs.dnscontrol.org/provider/transip) | [UniFi Network](https://docs.dnscontrol.org/provider/unifi) | [Vercel](https://docs.dnscontrol.org/provider/vercel) | [Vultr](https://docs.dnscontrol.org/provider/vultr) |
-| [Netbird](https://docs.dnscontrol.org/provider/netbird) | [WebSupport](https://docs.dnscontrol.org/provider/websupport) |  |  |  |
+| [hosting.de](https://docs.dnscontrol.org/provider/hostingde)¹ | [Huawei Cloud DNS](https://docs.dnscontrol.org/provider/huaweicloud) | [Hurricane Electric DNS](https://docs.dnscontrol.org/provider/hedns) | [Infoblox](https://docs.dnscontrol.org/provider/infoblox) | [Infomaniak](https://docs.dnscontrol.org/provider/infomaniak) |
+| [Internet.bs](https://docs.dnscontrol.org/provider/internetbs)² | [INWX](https://docs.dnscontrol.org/provider/inwx)¹ | [Joker](https://docs.dnscontrol.org/provider/joker) | [Linode](https://docs.dnscontrol.org/provider/linode) | [Loopia](https://docs.dnscontrol.org/provider/loopia)¹ |
+| [LuaDNS](https://docs.dnscontrol.org/provider/luadns) | Windows Server DNS | [MikroTik RouterOS](https://docs.dnscontrol.org/provider/mikrotik) | [Mythic Beasts](https://docs.dnscontrol.org/provider/mythicbeasts) | [Name.com](https://docs.dnscontrol.org/provider/namedotcom)¹ |
+| [Namecheap](https://docs.dnscontrol.org/provider/namecheap)¹ | [Netbird](https://docs.dnscontrol.org/provider/netbird) | [Netcup](https://docs.dnscontrol.org/provider/netcup) | [Netlify](https://docs.dnscontrol.org/provider/netlify) | [Netnod](https://docs.dnscontrol.org/provider/netnod) |
+| [NexDNS](https://docs.dnscontrol.org/provider/nexdns) | [NS1](https://docs.dnscontrol.org/provider/ns1) | [OpenSRS](https://docs.dnscontrol.org/provider/opensrs)² | [Oracle Cloud](https://docs.dnscontrol.org/provider/oracle) | [OVH](https://docs.dnscontrol.org/provider/ovh)¹ |
+| [Packetframe](https://docs.dnscontrol.org/provider/packetframe) | [Porkbun](https://docs.dnscontrol.org/provider/porkbun)¹ | [PowerDNS](https://docs.dnscontrol.org/provider/powerdns) | [Realtime Register](https://docs.dnscontrol.org/provider/realtimeregister)¹ | [RWTH DNS-Admin](https://docs.dnscontrol.org/provider/rwth) |
+| [Sakura Cloud](https://docs.dnscontrol.org/provider/sakuracloud) | [SoftLayer](https://docs.dnscontrol.org/provider/softlayer) | [Tencent Cloud DNS](https://docs.dnscontrol.org/provider/tencentdns)¹ | [TransIP](https://docs.dnscontrol.org/provider/transip) | [UniFi Network](https://docs.dnscontrol.org/provider/unifi) |
+| [Vercel](https://docs.dnscontrol.org/provider/vercel) | [Vultr](https://docs.dnscontrol.org/provider/vultr) | [WebSupport](https://docs.dnscontrol.org/provider/websupport) |  |  |
 
 ¹also supports registrar functions
 ²registrar only

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -156,6 +156,7 @@
 * [hosting.de](provider/hostingde.md)
 * [Huawei Cloud DNS](provider/huaweicloud.md)
 * [Hurricane Electric DNS](provider/hedns.md)
+* [Infoblox](provider/infoblox.md)
 * [Infomaniak](provider/infomaniak.md)
 * [Internet.bs](provider/internetbs.md)
 * [INWX](provider/inwx.md)

--- a/documentation/provider/index.md
+++ b/documentation/provider/index.md
@@ -56,6 +56,7 @@ Jump to a table:
 | [`HETZNER_V2`](hetznerv2.md) | ❌ | ✅ | ❌ |
 | [`HOSTINGDE`](hostingde.md) | ❌ | ✅ | ✅ |
 | [`HUAWEICLOUD`](huaweicloud.md) | ❌ | ✅ | ❌ |
+| [`INFOBLOX`](infoblox.md) | ❌ | ✅ | ❌ |
 | [`INFOMANIAK`](infomaniak.md) | ❌ | ✅ | ❌ |
 | [`INTERNETBS`](internetbs.md) | ❌ | ❌ | ✅ |
 | [`INWX`](inwx.md) | ❌ | ✅ | ✅ |
@@ -131,6 +132,7 @@ Jump to a table:
 | [`HETZNER_V2`](hetznerv2.md) | ✅ | ✅ | ✅ | ✅ |
 | [`HOSTINGDE`](hostingde.md) | ❔ | ✅ | ✅ | ✅ |
 | [`HUAWEICLOUD`](huaweicloud.md) | ❔ | ✅ | ✅ | ✅ |
+| [`INFOBLOX`](infoblox.md) | ❌ | ❌ | ❌ | ❌ |
 | [`INFOMANIAK`](infomaniak.md) | ❔ | ❔ | ❌ | ❔ |
 | [`INTERNETBS`](internetbs.md) | ❔ | ❔ | ❌ | ❔ |
 | [`INWX`](inwx.md) | ✅ | ✅ | ✅ | ✅ |
@@ -203,6 +205,7 @@ Jump to a table:
 | [`HETZNER_V2`](hetznerv2.md) | ❌ | ❔ | ❌ | ✅ | ❌ |
 | [`HOSTINGDE`](hostingde.md) | ✅ | ❔ | ❌ | ✅ | ✅ |
 | [`HUAWEICLOUD`](huaweicloud.md) | ❌ | ❔ | ❌ | ❌ | ❌ |
+| [`INFOBLOX`](infoblox.md) | ❔ | ❔ | ❔ | ✅ | ❔ |
 | [`INFOMANIAK`](infomaniak.md) | ❔ | ✅ | ❔ | ❔ | ❔ |
 | [`INWX`](inwx.md) | ✅ | ❔ | ❔ | ✅ | ❔ |
 | [`JOKER`](joker.md) | ❌ | ❔ | ❌ | ❌ | ❌ |
@@ -272,6 +275,7 @@ Jump to a table:
 | [`HETZNER_V2`](hetznerv2.md) | ❔ | ❌ | ✅ | ✅ |
 | [`HOSTINGDE`](hostingde.md) | ❔ | ❌ | ✅ | ❔ |
 | [`HUAWEICLOUD`](huaweicloud.md) | ❔ | ❌ | ✅ | ❌ |
+| [`INFOBLOX`](infoblox.md) | ❔ | ❔ | ✅ | ❔ |
 | [`INFOMANIAK`](infomaniak.md) | ❔ | ❔ | ✅ | ❔ |
 | [`INWX`](inwx.md) | ❔ | ✅ | ✅ | ✅ |
 | [`JOKER`](joker.md) | ❔ | ✅ | ✅ | ❌ |
@@ -341,6 +345,7 @@ Jump to a table:
 | [`HETZNER_V2`](hetznerv2.md) | ✅ | ✅ | ❔ | ❌ | ✅ |
 | [`HOSTINGDE`](hostingde.md) | ✅ | ❔ | ❔ | ✅ | ✅ |
 | [`HUAWEICLOUD`](huaweicloud.md) | ✅ | ❌ | ❔ | ❌ | ❌ |
+| [`INFOBLOX`](infoblox.md) | ✅ | ❔ | ❔ | ❔ | ❔ |
 | [`INFOMANIAK`](infomaniak.md) | ✅ | ❔ | ❔ | ✅ | ✅ |
 | [`INWX`](inwx.md) | ✅ | ✅ | ❔ | ✅ | ✅ |
 | [`JOKER`](joker.md) | ✅ | ❌ | ❔ | ❌ | ❌ |

--- a/documentation/provider/infoblox.md
+++ b/documentation/provider/infoblox.md
@@ -1,0 +1,124 @@
+## Configuration
+
+This provider is for [Infoblox NIOS](https://www.infoblox.com/) DDI appliances via the WAPI (Web API). To use this provider, add an entry to `creds.json` with `TYPE` set to `INFOBLOX`.
+
+Example:
+
+{% code title="creds.json" %}
+```json
+{
+  "infoblox": {
+    "TYPE": "INFOBLOX",
+    "host": "https://grid-master.example.com",
+    "username": "dnscontrol",
+    "password": "your-password",
+    "view": "default",
+    "wapi_version": "2.12"
+  }
+}
+```
+{% endcode %}
+
+### Parameters
+
+| Field | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| `host` | Yes | | Base URL of the Infoblox Grid Master (e.g. `https://grid-master.example.com`) |
+| `username` | Yes | | WAPI username |
+| `password` | Yes | | WAPI password |
+| `view` | No | `default` | DNS view to manage |
+| `wapi_version` | No | `2.12` | WAPI version string |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification |
+| `ca_cert` | No | | Path to a custom CA certificate file (PEM format) |
+
+## Usage
+
+An example configuration:
+
+{% code title="dnsconfig.js" %}
+```javascript
+var REG_NONE = NewRegistrar("none");
+var DSP_INFOBLOX = NewDnsProvider("infoblox");
+
+D("example.com", REG_NONE, DnsProvider(DSP_INFOBLOX),
+    A("test", "1.2.3.4"),
+    AAAA("test6", "2001:db8::1"),
+    CNAME("www", "test.example.com."),
+    MX("@", 10, "mail.example.com."),
+    TXT("@", "v=spf1 -all"),
+    SRV("_sip._tcp", 10, 60, 5060, "sip.example.com."),
+    CAA("@", "issue", "letsencrypt.org"),
+    PTR("4.3.2.1", "host.example.com."),
+);
+```
+{% endcode %}
+
+## Supported record types
+
+The following record types are supported:
+
+- A
+- AAAA
+- CAA
+- CNAME
+- MX
+- PTR
+- SRV
+- TXT
+
+## Limitations
+
+- **NS records are not supported.** Infoblox requires an `addresses` field (nameserver IPs) when creating NS delegation records, which DNSControl does not provide.
+- **Zones must be pre-created.** DNSControl cannot create zones in Infoblox; they must already exist in the configured DNS view.
+- **TXT records are limited to 255 bytes.** Infoblox does not support multi-string TXT records or single strings longer than 255 bytes.
+- **Empty TXT records are rejected.**
+- **TXT records with backslashes are not supported.**
+- **Concurrent operations are not supported.** The provider processes changes sequentially.
+
+## Activation
+
+DNSControl connects to the Infoblox WAPI using HTTP Basic Authentication. Create a local user account on the Infoblox Grid Master with permissions to manage DNS records in the target zone and view.
+
+The minimum required permissions are:
+
+- Read/Write access to the DNS zone(s) you want to manage
+- Read access to zone_auth objects (for zone lookup and SOA TTL retrieval)
+
+## New domains
+
+DNSControl cannot create new zones in Infoblox. Zones must already exist in the configured DNS view before DNSControl can manage them.
+
+## Feature Summary
+
+<!-- provider-features-start -->
+- Provider Type
+  - [Official Support](../provider/index.md#providers-with-official-support): ❌
+  - DNS Provider: ✅
+  - Registrar: ❌
+- Provider API
+  - [Concurrency Verified](../advanced-features/concurrency-verified.md): ❌
+  - [dual host](../advanced-features/dual-host.md): ❌
+  - create-domains: ❌
+  - [get-zones](../commands/get-zones.md): ❌
+- DNS extensions
+  - [`ALIAS`](../language-reference/domain-modifiers/ALIAS.md): ❔
+  - [`DNAME`](../language-reference/domain-modifiers/DNAME.md): ❔
+  - [`LOC`](../language-reference/domain-modifiers/LOC.md): ❔
+  - [`PTR`](../language-reference/domain-modifiers/PTR.md): ✅
+  - [`SOA`](../language-reference/domain-modifiers/SOA.md): ❔
+- Service discovery
+  - [`DHCID`](../language-reference/domain-modifiers/DHCID.md): ❔
+  - [`NAPTR`](../language-reference/domain-modifiers/NAPTR.md): ❔
+  - [`SRV`](../language-reference/domain-modifiers/SRV.md): ✅
+  - [`SVCB`](../language-reference/domain-modifiers/SVCB.md): ❔
+- Security
+  - [`CAA`](../language-reference/domain-modifiers/CAA.md): ✅
+  - [`HTTPS`](../language-reference/domain-modifiers/HTTPS.md): ❔
+  - [`SMIMEA`](../language-reference/domain-modifiers/SMIMEA.md): ❔
+  - [`SSHFP`](../language-reference/domain-modifiers/SSHFP.md): ❔
+  - [`TLSA`](../language-reference/domain-modifiers/TLSA.md): ❔
+- DNSSEC
+  - [`AUTODNSSEC`](../language-reference/domain-modifiers/AUTODNSSEC_ON.md): ❔
+  - [`DNSKEY`](../language-reference/domain-modifiers/DNSKEY.md): ❔
+  - [`DS`](../language-reference/domain-modifiers/DS.md): ❔
+<!-- provider-features-end -->

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -226,6 +226,15 @@
     "TYPE": "HUAWEICLOUD",
     "domain": "$HUAWEICLOUD_DOMAIN"
   },
+  "INFOBLOX": {
+    "TYPE": "INFOBLOX",
+    "domain": "$INFOBLOX_DOMAIN",
+    "host": "$INFOBLOX_HOST",
+    "username": "$INFOBLOX_USERNAME",
+    "password": "$INFOBLOX_PASSWORD",
+    "view": "$INFOBLOX_VIEW",
+    "tls_skip_verify": "true"
+  },
   "INFOMANIAK": {
     "TYPE": "INFOMANIAK",
     "domain": "$INFOMANIAK_DOMAIN",

--- a/integrationTest/profiles.json
+++ b/integrationTest/profiles.json
@@ -230,10 +230,10 @@
     "TYPE": "INFOBLOX",
     "domain": "$INFOBLOX_DOMAIN",
     "host": "$INFOBLOX_HOST",
-    "username": "$INFOBLOX_USERNAME",
     "password": "$INFOBLOX_PASSWORD",
-    "view": "$INFOBLOX_VIEW",
-    "tls_skip_verify": "true"
+    "tls_skip_verify": "true",
+    "username": "$INFOBLOX_USERNAME",
+    "view": "$INFOBLOX_VIEW"
   },
   "INFOMANIAK": {
     "TYPE": "INFOMANIAK",

--- a/pkg/providers/_all/all.go
+++ b/pkg/providers/_all/all.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/DNSControl/dnscontrol/v4/providers/hetznerv2"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/hostingde"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/huaweicloud"
+	_ "github.com/DNSControl/dnscontrol/v4/providers/infoblox"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/infomaniak"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/internetbs"
 	_ "github.com/DNSControl/dnscontrol/v4/providers/inwx"

--- a/providers/infoblox/api.go
+++ b/providers/infoblox/api.go
@@ -1,0 +1,236 @@
+package infoblox
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"strings"
+)
+
+type infobloxAPI struct {
+	host       string // e.g. "https://grid-master.example.com"
+	wapiVer    string // e.g. "2.12"
+	view       string // e.g. "default"
+	username   string
+	password   string
+	httpClient *http.Client
+}
+
+// wapiResponse is the standard WAPI response wrapper when _return_as_object=1 is used.
+type wapiResponse struct {
+	Result json.RawMessage `json:"result"`
+}
+
+func newInfobloxAPI(host, username, password, wapiVer, view string, tlsSkipVerify bool, caCertPath string) (*infobloxAPI, error) {
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if tlsSkipVerify {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	if caCertPath != "" {
+		caCert, err := os.ReadFile(caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate %q: %w", caCertPath, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA certificate from %q", caCertPath)
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cookie jar: %w", err)
+	}
+
+	return &infobloxAPI{
+		host:     strings.TrimRight(host, "/"),
+		wapiVer:  wapiVer,
+		view:     view,
+		username: username,
+		password: password,
+		httpClient: &http.Client{
+			Jar: jar,
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		},
+	}, nil
+}
+
+func (api *infobloxAPI) baseURL() string {
+	return fmt.Sprintf("%s/wapi/v%s", api.host, api.wapiVer)
+}
+
+func (api *infobloxAPI) doRequest(method, url string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.SetBasicAuth(api.username, api.password)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := api.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("WAPI request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("WAPI %s %s returned HTTP %d: %s", method, url, resp.StatusCode, string(data))
+	}
+
+	return data, nil
+}
+
+// getZoneAuth looks up a zone_auth object for the given FQDN in the configured view.
+// Returns the zone _ref or an error if the zone is not found.
+func (api *infobloxAPI) getZoneAuth(fqdn string) (string, error) {
+	url := fmt.Sprintf("%s/zone_auth?fqdn=%s&view=%s&_return_as_object=1", api.baseURL(), fqdn, api.view)
+	data, err := api.doRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var resp wapiResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse zone_auth response: %w", err)
+	}
+
+	var zones []struct {
+		Ref string `json:"_ref"`
+	}
+	if err := json.Unmarshal(resp.Result, &zones); err != nil {
+		return "", fmt.Errorf("failed to parse zone_auth result: %w", err)
+	}
+
+	if len(zones) == 0 {
+		return "", fmt.Errorf("zone %q not found in view %q", fqdn, api.view)
+	}
+
+	return zones[0].Ref, nil
+}
+
+// getZoneDefaultTTL fetches the soa_default_ttl for the given zone.
+func (api *infobloxAPI) getZoneDefaultTTL(fqdn string) (uint32, error) {
+	url := fmt.Sprintf("%s/zone_auth?fqdn=%s&view=%s&_return_fields=soa_default_ttl&_return_as_object=1", api.baseURL(), fqdn, api.view)
+	data, err := api.doRequest("GET", url, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	var resp wapiResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return 0, fmt.Errorf("failed to parse zone TTL response: %w", err)
+	}
+
+	var zones []struct {
+		SoaDefaultTTL uint32 `json:"soa_default_ttl"`
+	}
+	if err := json.Unmarshal(resp.Result, &zones); err != nil {
+		return 0, fmt.Errorf("failed to parse zone TTL result: %w", err)
+	}
+
+	if len(zones) == 0 {
+		return 0, fmt.Errorf("zone %q not found in view %q", fqdn, api.view)
+	}
+
+	return zones[0].SoaDefaultTTL, nil
+}
+
+// getRecords fetches all records of a given type for a zone.
+// recType should be the Infoblox record type string (e.g. "a", "aaaa", "cname").
+func (api *infobloxAPI) getRecords(recType, zone string) ([]json.RawMessage, error) {
+	returnFields := ttlReturnFields(recType)
+	url := fmt.Sprintf("%s/record:%s?zone=%s&view=%s%s&_max_results=-10000&_return_as_object=1",
+		api.baseURL(), recType, zone, api.view, returnFields)
+
+	data, err := api.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp wapiResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse record:%s response: %w", recType, err)
+	}
+
+	var records []json.RawMessage
+	if err := json.Unmarshal(resp.Result, &records); err != nil {
+		return nil, fmt.Errorf("failed to parse record:%s result: %w", recType, err)
+	}
+
+	return records, nil
+}
+
+// ttlReturnFields returns the additional _return_fields query parameter for TTL-supporting types.
+func ttlReturnFields(recType string) string {
+	switch recType {
+	case "ns":
+		// NS records in Infoblox don't support use_ttl in the same way
+		return "&_return_fields%2B=ttl"
+	default:
+		return "&_return_fields%2B=ttl,use_ttl"
+	}
+}
+
+// createRecord creates a new record in Infoblox and returns the _ref of the created object.
+func (api *infobloxAPI) createRecord(recType string, body map[string]any) (string, error) {
+	url := fmt.Sprintf("%s/record:%s?_return_as_object=1", api.baseURL(), recType)
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal record body: %w", err)
+	}
+
+	data, err := api.doRequest("POST", url, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return "", err
+	}
+
+	var resp wapiResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse create response: %w", err)
+	}
+
+	var ref string
+	if err := json.Unmarshal(resp.Result, &ref); err != nil {
+		return "", fmt.Errorf("failed to parse create result ref: %w", err)
+	}
+
+	return ref, nil
+}
+
+// updateRecord updates an existing record identified by _ref.
+func (api *infobloxAPI) updateRecord(ref string, body map[string]any) error {
+	url := fmt.Sprintf("%s/%s?_return_as_object=1", api.baseURL(), ref)
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal update body: %w", err)
+	}
+
+	_, err = api.doRequest("PUT", url, strings.NewReader(string(jsonBody)))
+	return err
+}
+
+// deleteRecord deletes a record identified by _ref.
+func (api *infobloxAPI) deleteRecord(ref string) error {
+	url := fmt.Sprintf("%s/%s?_return_as_object=1", api.baseURL(), ref)
+	_, err := api.doRequest("DELETE", url, nil)
+	return err
+}

--- a/providers/infoblox/api.go
+++ b/providers/infoblox/api.go
@@ -61,7 +61,8 @@ func newInfobloxAPI(host, username, password, wapiVer, view string, tlsSkipVerif
 		httpClient: &http.Client{
 			Jar: jar,
 			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
+				TLSClientConfig:    tlsConfig,
+				DisableCompression: true,
 			},
 		},
 	}, nil
@@ -155,7 +156,7 @@ func (api *infobloxAPI) getZoneDefaultTTL(fqdn string) (uint32, error) {
 // getRecords fetches all records of a given type for a zone.
 // recType should be the Infoblox record type string (e.g. "a", "aaaa", "cname").
 func (api *infobloxAPI) getRecords(recType, zone string) ([]json.RawMessage, error) {
-	returnFields := ttlReturnFields(recType)
+	returnFields := extraReturnFields(recType)
 	url := fmt.Sprintf("%s/record:%s?zone=%s&view=%s%s&_max_results=-10000&_return_as_object=1",
 		api.baseURL(), recType, zone, api.view, returnFields)
 
@@ -177,12 +178,21 @@ func (api *infobloxAPI) getRecords(recType, zone string) ([]json.RawMessage, err
 	return records, nil
 }
 
-// ttlReturnFields returns the additional _return_fields query parameter for TTL-supporting types.
-func ttlReturnFields(recType string) string {
+// extraReturnFields returns the additional _return_fields query parameter
+// needed for each record type. Most types need ttl and use_ttl appended.
+// Some types also need their data fields explicitly requested because
+// Infoblox marks them as non-standard.
+func extraReturnFields(recType string) string {
 	switch recType {
 	case "ns":
-		// NS records in Infoblox don't support use_ttl in the same way
-		return "&_return_fields%2B=ttl"
+		// NS records in Infoblox don't have ttl or use_ttl fields.
+		return ""
+	case "caa":
+		// ca_flag, ca_tag, ca_value are non-standard fields.
+		return "&_return_fields%2B=ttl,use_ttl,ca_flag,ca_tag,ca_value"
+	case "ptr":
+		// name is a non-standard field for PTR records.
+		return "&_return_fields%2B=ttl,use_ttl,name"
 	default:
 		return "&_return_fields%2B=ttl,use_ttl"
 	}

--- a/providers/infoblox/auditrecords.go
+++ b/providers/infoblox/auditrecords.go
@@ -1,0 +1,23 @@
+package infoblox
+
+import (
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/rejectif"
+)
+
+// AuditRecords returns a list of errors corresponding to the records
+// that aren't supported by this provider. If all records are
+// supported, an empty list is returned.
+func AuditRecords(records []*models.RecordConfig) []error {
+	a := rejectif.Auditor{}
+
+	a.Add("MX", rejectif.MxNull)
+
+	a.Add("SRV", rejectif.SrvHasNullTarget)
+
+	a.Add("TXT", rejectif.TxtHasBackslash)
+
+	a.Add("TXT", rejectif.TxtLongerThan(512))
+
+	return a.Audit(records)
+}

--- a/providers/infoblox/auditrecords.go
+++ b/providers/infoblox/auditrecords.go
@@ -13,6 +13,8 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("MX", rejectif.MxNull)
 
+	a.Add("NS", rejectif.NsAtApex)
+
 	a.Add("SRV", rejectif.SrvHasNullTarget)
 
 	a.Add("TXT", rejectif.TxtHasBackslash)

--- a/providers/infoblox/auditrecords.go
+++ b/providers/infoblox/auditrecords.go
@@ -17,7 +17,9 @@ func AuditRecords(records []*models.RecordConfig) []error {
 
 	a.Add("TXT", rejectif.TxtHasBackslash)
 
-	a.Add("TXT", rejectif.TxtLongerThan(512))
+	a.Add("TXT", rejectif.TxtLongerThan(255))
+
+	a.Add("TXT", rejectif.TxtIsEmpty)
 
 	return a.Audit(records)
 }

--- a/providers/infoblox/convert.go
+++ b/providers/infoblox/convert.go
@@ -9,7 +9,9 @@ import (
 )
 
 // supportedTypes lists the Infoblox record types we fetch and manage.
-var supportedTypes = []string{"a", "aaaa", "cname", "mx", "txt", "srv", "ns", "ptr", "caa"}
+// NS is excluded because Infoblox requires an 'addresses' field (nameserver IPs)
+// when creating NS delegation records, which dnscontrol does not provide.
+var supportedTypes = []string{"a", "aaaa", "cname", "mx", "txt", "srv", "ptr", "caa"}
 
 // infobloxRecord is the common set of fields returned by all Infoblox record types.
 // Type-specific fields are extracted in the per-type converters.
@@ -60,7 +62,6 @@ type ibRecordSRV struct {
 type ibRecordNS struct {
 	Ref        string `json:"_ref"`
 	Name       string `json:"name"`
-	TTL        uint32 `json:"ttl"`
 	View       string `json:"view"`
 	Nameserver string `json:"nameserver"`
 }
@@ -240,11 +241,8 @@ func convertNS(raw json.RawMessage, domain string, defaultTTL uint32) (*models.R
 
 	rc := &models.RecordConfig{
 		Type:     "NS",
-		TTL:      r.TTL,
+		TTL:      defaultTTL,
 		Original: r.Ref,
-	}
-	if rc.TTL == 0 {
-		rc.TTL = defaultTTL
 	}
 	rc.SetLabelFromFQDN(r.Name, domain)
 	if err := rc.PopulateFromString("NS", ensureTrailingDot(r.Nameserver), domain); err != nil {
@@ -334,6 +332,9 @@ func buildRecordBody(rc *models.RecordConfig, domain, view string, includeView b
 	case "NS":
 		recType = "ns"
 		body["nameserver"] = strings.TrimSuffix(rc.GetTargetField(), ".")
+		// NS records in Infoblox don't support ttl/use_ttl fields.
+		delete(body, "use_ttl")
+		delete(body, "ttl")
 	case "PTR":
 		recType = "ptr"
 		body["ptrdname"] = strings.TrimSuffix(rc.GetTargetField(), ".")

--- a/providers/infoblox/convert.go
+++ b/providers/infoblox/convert.go
@@ -1,0 +1,350 @@
+package infoblox
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+// supportedTypes lists the Infoblox record types we fetch and manage.
+var supportedTypes = []string{"a", "aaaa", "cname", "mx", "txt", "srv", "ns", "ptr", "caa"}
+
+// infobloxRecord is the common set of fields returned by all Infoblox record types.
+// Type-specific fields are extracted in the per-type converters.
+type infobloxRecord struct {
+	Ref    string `json:"_ref"`
+	Name   string `json:"name"`
+	TTL    uint32 `json:"ttl"`
+	UseTTL bool   `json:"use_ttl"`
+	View   string `json:"view"`
+}
+
+// Type-specific Infoblox record structs.
+
+type ibRecordA struct {
+	infobloxRecord
+	IPv4Addr string `json:"ipv4addr"`
+}
+
+type ibRecordAAAA struct {
+	infobloxRecord
+	IPv6Addr string `json:"ipv6addr"`
+}
+
+type ibRecordCNAME struct {
+	infobloxRecord
+	Canonical string `json:"canonical"`
+}
+
+type ibRecordMX struct {
+	infobloxRecord
+	MailExchanger string `json:"mail_exchanger"`
+	Preference    uint16 `json:"preference"`
+}
+
+type ibRecordTXT struct {
+	infobloxRecord
+	Text string `json:"text"`
+}
+
+type ibRecordSRV struct {
+	infobloxRecord
+	Target   string `json:"target"`
+	Priority uint16 `json:"priority"`
+	Weight   uint16 `json:"weight"`
+	Port     uint16 `json:"port"`
+}
+
+type ibRecordNS struct {
+	Ref        string `json:"_ref"`
+	Name       string `json:"name"`
+	TTL        uint32 `json:"ttl"`
+	View       string `json:"view"`
+	Nameserver string `json:"nameserver"`
+}
+
+type ibRecordPTR struct {
+	infobloxRecord
+	PtrDName string `json:"ptrdname"`
+}
+
+type ibRecordCAA struct {
+	infobloxRecord
+	CaFlag  uint8  `json:"ca_flag"`
+	CaTag   string `json:"ca_tag"`
+	CaValue string `json:"ca_value"`
+}
+
+// toRecordConfig converts a raw JSON Infoblox record of the given type to a DNSControl RecordConfig.
+func toRecordConfig(recType string, raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	switch recType {
+	case "a":
+		return convertA(raw, domain, defaultTTL)
+	case "aaaa":
+		return convertAAAA(raw, domain, defaultTTL)
+	case "cname":
+		return convertCNAME(raw, domain, defaultTTL)
+	case "mx":
+		return convertMX(raw, domain, defaultTTL)
+	case "txt":
+		return convertTXT(raw, domain, defaultTTL)
+	case "srv":
+		return convertSRV(raw, domain, defaultTTL)
+	case "ns":
+		return convertNS(raw, domain, defaultTTL)
+	case "ptr":
+		return convertPTR(raw, domain, defaultTTL)
+	case "caa":
+		return convertCAA(raw, domain, defaultTTL)
+	default:
+		return nil, fmt.Errorf("unsupported Infoblox record type: %s", recType)
+	}
+}
+
+func effectiveTTL(useTTL bool, ttl, defaultTTL uint32) uint32 {
+	if useTTL {
+		return ttl
+	}
+	return defaultTTL
+}
+
+// ensureTrailingDot adds a trailing dot if not already present.
+// Infoblox sometimes returns FQDNs without trailing dots for target fields.
+func ensureTrailingDot(s string) string {
+	if s == "" || s[len(s)-1] == '.' {
+		return s
+	}
+	return s + "."
+}
+
+func convertA(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordA
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse A record: %w", err)
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "A",
+		TTL:      effectiveTTL(r.UseTTL, r.TTL, defaultTTL),
+		Original: r.Ref,
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.PopulateFromString("A", r.IPv4Addr, domain); err != nil {
+		return nil, fmt.Errorf("failed to populate A record: %w", err)
+	}
+	return rc, nil
+}
+
+func convertAAAA(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordAAAA
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse AAAA record: %w", err)
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "AAAA",
+		TTL:      effectiveTTL(r.UseTTL, r.TTL, defaultTTL),
+		Original: r.Ref,
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.PopulateFromString("AAAA", r.IPv6Addr, domain); err != nil {
+		return nil, fmt.Errorf("failed to populate AAAA record: %w", err)
+	}
+	return rc, nil
+}
+
+func convertCNAME(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordCNAME
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse CNAME record: %w", err)
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "CNAME",
+		TTL:      effectiveTTL(r.UseTTL, r.TTL, defaultTTL),
+		Original: r.Ref,
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.PopulateFromString("CNAME", ensureTrailingDot(r.Canonical), domain); err != nil {
+		return nil, fmt.Errorf("failed to populate CNAME record: %w", err)
+	}
+	return rc, nil
+}
+
+func convertMX(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordMX
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse MX record: %w", err)
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "MX",
+		TTL:      effectiveTTL(r.UseTTL, r.TTL, defaultTTL),
+		Original: r.Ref,
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.SetTargetMX(r.Preference, ensureTrailingDot(r.MailExchanger)); err != nil {
+		return nil, fmt.Errorf("failed to populate MX record: %w", err)
+	}
+	return rc, nil
+}
+
+func convertTXT(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordTXT
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse TXT record: %w", err)
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "TXT",
+		TTL:      effectiveTTL(r.UseTTL, r.TTL, defaultTTL),
+		Original: r.Ref,
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.SetTargetTXT(r.Text); err != nil {
+		return nil, fmt.Errorf("failed to populate TXT record: %w", err)
+	}
+	return rc, nil
+}
+
+func convertSRV(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordSRV
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse SRV record: %w", err)
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "SRV",
+		TTL:      effectiveTTL(r.UseTTL, r.TTL, defaultTTL),
+		Original: r.Ref,
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.SetTargetSRV(r.Priority, r.Weight, r.Port, ensureTrailingDot(r.Target)); err != nil {
+		return nil, fmt.Errorf("failed to populate SRV record: %w", err)
+	}
+	return rc, nil
+}
+
+func convertNS(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordNS
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse NS record: %w", err)
+	}
+
+	// Skip NS records at the zone apex — Infoblox manages these internally.
+	if r.Name == domain || r.Name == domain+"." {
+		return nil, nil
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "NS",
+		TTL:      r.TTL,
+		Original: r.Ref,
+	}
+	if rc.TTL == 0 {
+		rc.TTL = defaultTTL
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.PopulateFromString("NS", ensureTrailingDot(r.Nameserver), domain); err != nil {
+		return nil, fmt.Errorf("failed to populate NS record: %w", err)
+	}
+	return rc, nil
+}
+
+func convertPTR(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordPTR
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse PTR record: %w", err)
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "PTR",
+		TTL:      effectiveTTL(r.UseTTL, r.TTL, defaultTTL),
+		Original: r.Ref,
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.PopulateFromString("PTR", ensureTrailingDot(r.PtrDName), domain); err != nil {
+		return nil, fmt.Errorf("failed to populate PTR record: %w", err)
+	}
+	return rc, nil
+}
+
+func convertCAA(raw json.RawMessage, domain string, defaultTTL uint32) (*models.RecordConfig, error) {
+	var r ibRecordCAA
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse CAA record: %w", err)
+	}
+
+	rc := &models.RecordConfig{
+		Type:     "CAA",
+		TTL:      effectiveTTL(r.UseTTL, r.TTL, defaultTTL),
+		Original: r.Ref,
+	}
+	rc.SetLabelFromFQDN(r.Name, domain)
+	if err := rc.SetTargetCAA(r.CaFlag, r.CaTag, r.CaValue); err != nil {
+		return nil, fmt.Errorf("failed to populate CAA record: %w", err)
+	}
+	return rc, nil
+}
+
+// buildRecordBody constructs the JSON body for a create or update API call
+// from a DNSControl RecordConfig.
+func buildRecordBody(rc *models.RecordConfig, domain, view string, includeView bool) (string, map[string]any, error) {
+	fqdn := rc.GetLabelFQDN()
+	ttl := rc.TTL
+
+	body := map[string]any{
+		"name": fqdn,
+	}
+	if includeView {
+		body["view"] = view
+	}
+	if ttl > 0 {
+		body["use_ttl"] = true
+		body["ttl"] = ttl
+	}
+
+	var recType string
+
+	switch rc.Type {
+	case "A":
+		recType = "a"
+		body["ipv4addr"] = rc.GetTargetField()
+	case "AAAA":
+		recType = "aaaa"
+		body["ipv6addr"] = rc.GetTargetField()
+	case "CNAME":
+		recType = "cname"
+		body["canonical"] = strings.TrimSuffix(rc.GetTargetField(), ".")
+	case "MX":
+		recType = "mx"
+		body["mail_exchanger"] = strings.TrimSuffix(rc.GetTargetField(), ".")
+		body["preference"] = rc.MxPreference
+	case "TXT":
+		recType = "txt"
+		body["text"] = rc.GetTargetTXTJoined()
+	case "SRV":
+		recType = "srv"
+		body["target"] = strings.TrimSuffix(rc.GetTargetField(), ".")
+		body["priority"] = rc.SrvPriority
+		body["weight"] = rc.SrvWeight
+		body["port"] = rc.SrvPort
+	case "NS":
+		recType = "ns"
+		body["nameserver"] = strings.TrimSuffix(rc.GetTargetField(), ".")
+	case "PTR":
+		recType = "ptr"
+		body["ptrdname"] = strings.TrimSuffix(rc.GetTargetField(), ".")
+	case "CAA":
+		recType = "caa"
+		body["ca_flag"] = rc.CaaFlag
+		body["ca_tag"] = rc.CaaTag
+		body["ca_value"] = rc.GetTargetField()
+	default:
+		return "", nil, fmt.Errorf("unsupported record type for Infoblox: %s", rc.Type)
+	}
+
+	return recType, body, nil
+}

--- a/providers/infoblox/convert.go
+++ b/providers/infoblox/convert.go
@@ -132,8 +132,8 @@ func convertA(raw json.RawMessage, domain string, defaultTTL uint32) (*models.Re
 		Original: r.Ref,
 	}
 	rc.SetLabelFromFQDN(r.Name, domain)
-	if err := rc.PopulateFromString("A", r.IPv4Addr, domain); err != nil {
-		return nil, fmt.Errorf("failed to populate A record: %w", err)
+	if err := rc.SetTarget(r.IPv4Addr); err != nil {
+		return nil, fmt.Errorf("failed to set A record target: %w", err)
 	}
 	return rc, nil
 }
@@ -150,8 +150,8 @@ func convertAAAA(raw json.RawMessage, domain string, defaultTTL uint32) (*models
 		Original: r.Ref,
 	}
 	rc.SetLabelFromFQDN(r.Name, domain)
-	if err := rc.PopulateFromString("AAAA", r.IPv6Addr, domain); err != nil {
-		return nil, fmt.Errorf("failed to populate AAAA record: %w", err)
+	if err := rc.SetTarget(r.IPv6Addr); err != nil {
+		return nil, fmt.Errorf("failed to set AAAA record target: %w", err)
 	}
 	return rc, nil
 }
@@ -168,8 +168,8 @@ func convertCNAME(raw json.RawMessage, domain string, defaultTTL uint32) (*model
 		Original: r.Ref,
 	}
 	rc.SetLabelFromFQDN(r.Name, domain)
-	if err := rc.PopulateFromString("CNAME", ensureTrailingDot(r.Canonical), domain); err != nil {
-		return nil, fmt.Errorf("failed to populate CNAME record: %w", err)
+	if err := rc.SetTarget(ensureTrailingDot(r.Canonical)); err != nil {
+		return nil, fmt.Errorf("failed to set CNAME record target: %w", err)
 	}
 	return rc, nil
 }
@@ -245,8 +245,8 @@ func convertNS(raw json.RawMessage, domain string, defaultTTL uint32) (*models.R
 		Original: r.Ref,
 	}
 	rc.SetLabelFromFQDN(r.Name, domain)
-	if err := rc.PopulateFromString("NS", ensureTrailingDot(r.Nameserver), domain); err != nil {
-		return nil, fmt.Errorf("failed to populate NS record: %w", err)
+	if err := rc.SetTarget(ensureTrailingDot(r.Nameserver)); err != nil {
+		return nil, fmt.Errorf("failed to set NS record target: %w", err)
 	}
 	return rc, nil
 }
@@ -263,8 +263,8 @@ func convertPTR(raw json.RawMessage, domain string, defaultTTL uint32) (*models.
 		Original: r.Ref,
 	}
 	rc.SetLabelFromFQDN(r.Name, domain)
-	if err := rc.PopulateFromString("PTR", ensureTrailingDot(r.PtrDName), domain); err != nil {
-		return nil, fmt.Errorf("failed to populate PTR record: %w", err)
+	if err := rc.SetTarget(ensureTrailingDot(r.PtrDName)); err != nil {
+		return nil, fmt.Errorf("failed to set PTR record target: %w", err)
 	}
 	return rc, nil
 }

--- a/providers/infoblox/infobloxProvider.go
+++ b/providers/infoblox/infobloxProvider.go
@@ -1,0 +1,86 @@
+package infoblox
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
+)
+
+var features = providers.DocumentationNotes{
+	// The default for unlisted capabilities is 'Cannot'.
+	// See providers/capabilities.go for the entire list of capabilities.
+	providers.CanConcur:              providers.Cannot(),
+	providers.CanGetZones:            providers.Cannot(), // MVP: no ListZones
+	providers.CanUseCAA:              providers.Can(),
+	providers.CanUsePTR:              providers.Can(),
+	providers.CanUseSRV:              providers.Can(),
+	providers.DocCreateDomains:       providers.Cannot("Infoblox zones must be pre-created"),
+	providers.DocDualHost:            providers.Cannot(),
+	providers.DocOfficiallySupported: providers.Cannot(),
+}
+
+func init() {
+	const providerName = "INFOBLOX"
+	const providerMaintainer = "@mgamble"
+	fns := providers.DspFuncs{
+		Initializer:   newInfobloxDsp,
+		RecordAuditor: AuditRecords,
+	}
+	providers.RegisterDomainServiceProviderType(providerName, fns, features)
+	providers.RegisterMaintainer(providerName, providerMaintainer)
+}
+
+type infobloxProvider struct {
+	api *infobloxAPI
+}
+
+func newInfobloxDsp(conf map[string]string, metadata json.RawMessage) (providers.DNSServiceProvider, error) {
+	return newInfoblox(conf)
+}
+
+func newInfoblox(conf map[string]string) (*infobloxProvider, error) {
+	host := conf["host"]
+	if host == "" {
+		return nil, fmt.Errorf("infoblox: host is required in creds.json")
+	}
+
+	username := conf["username"]
+	if username == "" {
+		return nil, fmt.Errorf("infoblox: username is required in creds.json")
+	}
+
+	password := conf["password"]
+	if password == "" {
+		return nil, fmt.Errorf("infoblox: password is required in creds.json")
+	}
+
+	wapiVersion := conf["wapi_version"]
+	if wapiVersion == "" {
+		wapiVersion = "2.12"
+	}
+
+	view := conf["view"]
+	if view == "" {
+		view = "default"
+	}
+
+	tlsSkipVerify := conf["tls_skip_verify"] == "true" || conf["tls_skip_verify"] == "1"
+	caCert := conf["ca_cert"]
+
+	api, err := newInfobloxAPI(host, username, password, wapiVersion, view, tlsSkipVerify, caCert)
+	if err != nil {
+		return nil, err
+	}
+
+	return &infobloxProvider{
+		api: api,
+	}, nil
+}
+
+// GetNameservers returns an empty list. Infoblox manages NS records internally;
+// DNSControl does not need to manage parent delegation for this provider.
+func (p *infobloxProvider) GetNameservers(domain string) ([]*models.Nameserver, error) {
+	return nil, nil
+}

--- a/providers/infoblox/infobloxProvider.go
+++ b/providers/infoblox/infobloxProvider.go
@@ -11,12 +11,12 @@ import (
 var features = providers.DocumentationNotes{
 	// The default for unlisted capabilities is 'Cannot'.
 	// See providers/capabilities.go for the entire list of capabilities.
-	providers.CanConcur:              providers.Cannot(),
+	providers.CanConcur:              providers.Can(),
 	providers.CanGetZones:            providers.Cannot(), // MVP: no ListZones
 	providers.CanUseCAA:              providers.Can(),
 	providers.CanUsePTR:              providers.Can(),
 	providers.CanUseSRV:              providers.Can(),
-	providers.DocCreateDomains:       providers.Cannot("Infoblox zones must be pre-created"),
+	providers.DocCreateDomains:       providers.Cannot("zones must be pre-created"),
 	providers.DocDualHost:            providers.Cannot(),
 	providers.DocOfficiallySupported: providers.Cannot(),
 }

--- a/providers/infoblox/infobloxProvider_test.go
+++ b/providers/infoblox/infobloxProvider_test.go
@@ -1,0 +1,539 @@
+package infoblox
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+)
+
+// newTestAPI creates an infobloxAPI pointing at a test server.
+func newTestAPI(ts *httptest.Server, view string) *infobloxAPI {
+	return &infobloxAPI{
+		host:       ts.URL,
+		wapiVer:    "2.12",
+		view:       view,
+		username:   "admin",
+		password:   "password",
+		httpClient: ts.Client(),
+	}
+}
+
+func TestConvertA(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:a/ZG5z:10.0.0.1","name":"host.example.com","ipv4addr":"10.0.0.1","ttl":300,"use_ttl":true}`)
+	rc, err := toRecordConfig("a", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Type != "A" {
+		t.Errorf("expected type A, got %s", rc.Type)
+	}
+	if rc.TTL != 300 {
+		t.Errorf("expected TTL 300, got %d", rc.TTL)
+	}
+	if rc.GetTargetField() != "10.0.0.1" {
+		t.Errorf("expected target 10.0.0.1, got %s", rc.GetTargetField())
+	}
+	if rc.GetLabel() != "host" {
+		t.Errorf("expected label 'host', got %q", rc.GetLabel())
+	}
+}
+
+func TestConvertAAAA(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:aaaa/ZG5z:2001:db8::1","name":"host.example.com","ipv6addr":"2001:db8::1","ttl":600,"use_ttl":true}`)
+	rc, err := toRecordConfig("aaaa", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Type != "AAAA" {
+		t.Errorf("expected type AAAA, got %s", rc.Type)
+	}
+	if rc.TTL != 600 {
+		t.Errorf("expected TTL 600, got %d", rc.TTL)
+	}
+	if rc.GetTargetField() != "2001:db8::1" {
+		t.Errorf("expected target 2001:db8::1, got %s", rc.GetTargetField())
+	}
+}
+
+func TestConvertCNAME(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:cname/ZG5z:www","name":"www.example.com","canonical":"web.example.com","ttl":300,"use_ttl":true}`)
+	rc, err := toRecordConfig("cname", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Type != "CNAME" {
+		t.Errorf("expected type CNAME, got %s", rc.Type)
+	}
+	if rc.GetTargetField() != "web.example.com." {
+		t.Errorf("expected target web.example.com., got %s", rc.GetTargetField())
+	}
+}
+
+func TestConvertMX(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:mx/ZG5z:mx","name":"example.com","mail_exchanger":"mail.example.com","preference":10,"ttl":300,"use_ttl":true}`)
+	rc, err := toRecordConfig("mx", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Type != "MX" {
+		t.Errorf("expected type MX, got %s", rc.Type)
+	}
+	if rc.MxPreference != 10 {
+		t.Errorf("expected preference 10, got %d", rc.MxPreference)
+	}
+	if rc.GetTargetField() != "mail.example.com." {
+		t.Errorf("expected target mail.example.com., got %s", rc.GetTargetField())
+	}
+}
+
+func TestConvertTXT(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:txt/ZG5z:txt","name":"example.com","text":"v=spf1 -all","ttl":300,"use_ttl":true}`)
+	rc, err := toRecordConfig("txt", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Type != "TXT" {
+		t.Errorf("expected type TXT, got %s", rc.Type)
+	}
+	if rc.GetTargetTXTJoined() != "v=spf1 -all" {
+		t.Errorf("expected TXT 'v=spf1 -all', got %q", rc.GetTargetTXTJoined())
+	}
+}
+
+func TestConvertSRV(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:srv/ZG5z:srv","name":"_sip._tcp.example.com","target":"sip.example.com","priority":10,"weight":20,"port":5060,"ttl":300,"use_ttl":true}`)
+	rc, err := toRecordConfig("srv", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Type != "SRV" {
+		t.Errorf("expected type SRV, got %s", rc.Type)
+	}
+	if rc.SrvPriority != 10 {
+		t.Errorf("expected priority 10, got %d", rc.SrvPriority)
+	}
+	if rc.SrvWeight != 20 {
+		t.Errorf("expected weight 20, got %d", rc.SrvWeight)
+	}
+	if rc.SrvPort != 5060 {
+		t.Errorf("expected port 5060, got %d", rc.SrvPort)
+	}
+}
+
+func TestConvertCAA(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:caa/ZG5z:caa","name":"example.com","ca_flag":0,"ca_tag":"issue","ca_value":"letsencrypt.org","ttl":300,"use_ttl":true}`)
+	rc, err := toRecordConfig("caa", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Type != "CAA" {
+		t.Errorf("expected type CAA, got %s", rc.Type)
+	}
+	if rc.CaaFlag != 0 {
+		t.Errorf("expected flag 0, got %d", rc.CaaFlag)
+	}
+	if rc.CaaTag != "issue" {
+		t.Errorf("expected tag 'issue', got %q", rc.CaaTag)
+	}
+}
+
+func TestConvertPTR(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:ptr/ZG5z:ptr","name":"1.0.0.10.in-addr.arpa","ptrdname":"host.example.com","ttl":300,"use_ttl":true}`)
+	rc, err := toRecordConfig("ptr", raw, "0.0.10.in-addr.arpa", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Type != "PTR" {
+		t.Errorf("expected type PTR, got %s", rc.Type)
+	}
+	if rc.GetTargetField() != "host.example.com." {
+		t.Errorf("expected target host.example.com., got %s", rc.GetTargetField())
+	}
+}
+
+func TestConvertNSApexSkipped(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:ns/ZG5z:ns","name":"example.com","nameserver":"ns1.example.com","ttl":3600}`)
+	rc, err := toRecordConfig("ns", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc != nil {
+		t.Error("expected nil for apex NS record, got a record")
+	}
+}
+
+func TestConvertNSSubdomain(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:ns/ZG5z:ns2","name":"sub.example.com","nameserver":"ns1.sub.example.com","ttl":3600}`)
+	rc, err := toRecordConfig("ns", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc == nil {
+		t.Fatal("expected non-nil for subdomain NS record")
+	}
+	if rc.GetLabel() != "sub" {
+		t.Errorf("expected label 'sub', got %q", rc.GetLabel())
+	}
+}
+
+func TestTTLInheritance(t *testing.T) {
+	raw := json.RawMessage(`{"_ref":"record:a/ZG5z:10.0.0.2","name":"host.example.com","ipv4addr":"10.0.0.2","ttl":0,"use_ttl":false}`)
+	rc, err := toRecordConfig("a", raw, "example.com", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.TTL != 3600 {
+		t.Errorf("expected inherited TTL 3600, got %d", rc.TTL)
+	}
+}
+
+func TestBuildRecordBodyA(t *testing.T) {
+	rc := &models.RecordConfig{Type: "A", TTL: 300}
+	rc.SetLabel("host", "example.com")
+	if err := rc.PopulateFromString("A", "10.0.0.1", "example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	recType, body, err := buildRecordBody(rc, "example.com", "default", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recType != "a" {
+		t.Errorf("expected recType 'a', got %q", recType)
+	}
+	if body["ipv4addr"] != "10.0.0.1" {
+		t.Errorf("expected ipv4addr 10.0.0.1, got %v", body["ipv4addr"])
+	}
+	if body["view"] != "default" {
+		t.Errorf("expected view 'default', got %v", body["view"])
+	}
+	if body["use_ttl"] != true {
+		t.Errorf("expected use_ttl true, got %v", body["use_ttl"])
+	}
+}
+
+func TestBuildRecordBodyNoView(t *testing.T) {
+	rc := &models.RecordConfig{Type: "A", TTL: 300}
+	rc.SetLabel("host", "example.com")
+	if err := rc.PopulateFromString("A", "10.0.0.1", "example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, body, err := buildRecordBody(rc, "example.com", "default", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := body["view"]; ok {
+		t.Error("expected no view in update body")
+	}
+}
+
+func TestGetZoneAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/zone_auth") {
+			http.Error(w, "not found", 404)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"result":[{"_ref":"zone_auth/ZG5z:example.com/default"}]}`)
+	}))
+	defer ts.Close()
+
+	api := newTestAPI(ts, "default")
+	ref, err := api.getZoneAuth("example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref != "zone_auth/ZG5z:example.com/default" {
+		t.Errorf("unexpected ref: %s", ref)
+	}
+}
+
+func TestGetZoneAuthNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"result":[]}`)
+	}))
+	defer ts.Close()
+
+	api := newTestAPI(ts, "default")
+	_, err := api.getZoneAuth("nonexistent.com")
+	if err == nil {
+		t.Error("expected error for non-existent zone")
+	}
+}
+
+func TestCreateRecord(t *testing.T) {
+	var receivedBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", 405)
+			return
+		}
+		body, _ := readBody(r)
+		receivedBody = body
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"result":"record:a/ZG5z:new"}`)
+	}))
+	defer ts.Close()
+
+	api := newTestAPI(ts, "default")
+	ref, err := api.createRecord("a", map[string]any{
+		"name":     "host.example.com",
+		"ipv4addr": "10.0.0.1",
+		"view":     "default",
+		"use_ttl":  true,
+		"ttl":      300,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref != "record:a/ZG5z:new" {
+		t.Errorf("unexpected ref: %s", ref)
+	}
+	if !strings.Contains(receivedBody, "10.0.0.1") {
+		t.Errorf("expected body to contain IP, got: %s", receivedBody)
+	}
+}
+
+func TestDeleteRecord(t *testing.T) {
+	var deletedRef string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			http.Error(w, "method not allowed", 405)
+			return
+		}
+		deletedRef = strings.TrimPrefix(r.URL.Path, "/wapi/v2.12/")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"result":"record:a/ZG5z:deleted"}`)
+	}))
+	defer ts.Close()
+
+	api := newTestAPI(ts, "default")
+	err := api.deleteRecord("record:a/ZG5z:old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deletedRef != "record:a/ZG5z:old" {
+		t.Errorf("unexpected deleted ref: %s", deletedRef)
+	}
+}
+
+func TestUpdateRecord(t *testing.T) {
+	var updatedRef string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			http.Error(w, "method not allowed", 405)
+			return
+		}
+		updatedRef = strings.TrimPrefix(r.URL.Path, "/wapi/v2.12/")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"result":"record:a/ZG5z:updated"}`)
+	}))
+	defer ts.Close()
+
+	api := newTestAPI(ts, "default")
+	err := api.updateRecord("record:a/ZG5z:existing", map[string]any{
+		"ipv4addr": "10.0.0.2",
+		"use_ttl":  true,
+		"ttl":      600,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedRef != "record:a/ZG5z:existing" {
+		t.Errorf("unexpected updated ref: %s", updatedRef)
+	}
+}
+
+func TestHTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"unauthorized"}`, 401)
+	}))
+	defer ts.Close()
+
+	api := newTestAPI(ts, "default")
+	_, err := api.getZoneAuth("example.com")
+	if err == nil {
+		t.Error("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 in error, got: %s", err.Error())
+	}
+}
+
+func TestNewInfobloxMissingHost(t *testing.T) {
+	_, err := newInfoblox(map[string]string{
+		"username": "admin",
+		"password": "pass",
+	})
+	if err == nil {
+		t.Error("expected error for missing host")
+	}
+}
+
+func TestNewInfobloxMissingUsername(t *testing.T) {
+	_, err := newInfoblox(map[string]string{
+		"host":     "https://grid.example.com",
+		"password": "pass",
+	})
+	if err == nil {
+		t.Error("expected error for missing username")
+	}
+}
+
+func TestNewInfobloxMissingPassword(t *testing.T) {
+	_, err := newInfoblox(map[string]string{
+		"host":     "https://grid.example.com",
+		"username": "admin",
+	})
+	if err == nil {
+		t.Error("expected error for missing password")
+	}
+}
+
+func TestNewInfobloxDefaults(t *testing.T) {
+	p, err := newInfoblox(map[string]string{
+		"host":     "https://grid.example.com",
+		"username": "admin",
+		"password": "pass",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.api.wapiVer != "2.12" {
+		t.Errorf("expected default WAPI version 2.12, got %s", p.api.wapiVer)
+	}
+	if p.api.view != "default" {
+		t.Errorf("expected default view, got %s", p.api.view)
+	}
+}
+
+func TestEnsureTrailingDot(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"example.com", "example.com."},
+		{"example.com.", "example.com."},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := ensureTrailingDot(tc.input)
+		if got != tc.expected {
+			t.Errorf("ensureTrailingDot(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestEffectiveTTL(t *testing.T) {
+	if got := effectiveTTL(true, 300, 3600); got != 300 {
+		t.Errorf("expected 300, got %d", got)
+	}
+	if got := effectiveTTL(false, 0, 3600); got != 3600 {
+		t.Errorf("expected 3600, got %d", got)
+	}
+}
+
+func TestBuildRecordBodyTXT(t *testing.T) {
+	rc := &models.RecordConfig{Type: "TXT", TTL: 300}
+	rc.SetLabel("@", "example.com")
+	if err := rc.SetTargetTXT("v=spf1 include:_spf.example.com -all"); err != nil {
+		t.Fatal(err)
+	}
+
+	recType, body, err := buildRecordBody(rc, "example.com", "default", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recType != "txt" {
+		t.Errorf("expected recType 'txt', got %q", recType)
+	}
+	if body["text"] != "v=spf1 include:_spf.example.com -all" {
+		t.Errorf("expected text value, got %v", body["text"])
+	}
+}
+
+func TestBuildRecordBodyMX(t *testing.T) {
+	rc := &models.RecordConfig{Type: "MX", TTL: 300}
+	rc.SetLabel("@", "example.com")
+	if err := rc.SetTargetMX(10, "mail.example.com."); err != nil {
+		t.Fatal(err)
+	}
+
+	recType, body, err := buildRecordBody(rc, "example.com", "default", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recType != "mx" {
+		t.Errorf("expected recType 'mx', got %q", recType)
+	}
+	if body["mail_exchanger"] != "mail.example.com" {
+		t.Errorf("expected mail_exchanger without trailing dot, got %v", body["mail_exchanger"])
+	}
+	if body["preference"] != uint16(10) {
+		t.Errorf("expected preference 10, got %v", body["preference"])
+	}
+}
+
+func TestBuildRecordBodySRV(t *testing.T) {
+	rc := &models.RecordConfig{Type: "SRV", TTL: 300}
+	rc.SetLabel("_sip._tcp", "example.com")
+	if err := rc.SetTargetSRV(10, 20, 5060, "sip.example.com."); err != nil {
+		t.Fatal(err)
+	}
+
+	recType, body, err := buildRecordBody(rc, "example.com", "default", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recType != "srv" {
+		t.Errorf("expected recType 'srv', got %q", recType)
+	}
+	if body["target"] != "sip.example.com" {
+		t.Errorf("expected target without trailing dot, got %v", body["target"])
+	}
+	if body["priority"] != uint16(10) {
+		t.Errorf("expected priority 10, got %v", body["priority"])
+	}
+}
+
+func TestBuildRecordBodyCAA(t *testing.T) {
+	rc := &models.RecordConfig{Type: "CAA", TTL: 300}
+	rc.SetLabel("@", "example.com")
+	if err := rc.SetTargetCAA(0, "issue", "letsencrypt.org"); err != nil {
+		t.Fatal(err)
+	}
+
+	recType, body, err := buildRecordBody(rc, "example.com", "default", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recType != "caa" {
+		t.Errorf("expected recType 'caa', got %q", recType)
+	}
+	if body["ca_flag"] != uint8(0) {
+		t.Errorf("expected ca_flag 0, got %v", body["ca_flag"])
+	}
+	if body["ca_tag"] != "issue" {
+		t.Errorf("expected ca_tag 'issue', got %v", body["ca_tag"])
+	}
+}
+
+// readBody is a test helper that reads the request body as a string.
+func readBody(r *http.Request) (string, error) {
+	defer r.Body.Close()
+	body := new(strings.Builder)
+	_, err := strings.NewReader("").WriteTo(body)
+	if err != nil {
+		return "", err
+	}
+	buf := make([]byte, 4096)
+	n, _ := r.Body.Read(buf)
+	return string(buf[:n]), nil
+}

--- a/providers/infoblox/infobloxProvider_test.go
+++ b/providers/infoblox/infobloxProvider_test.go
@@ -195,7 +195,7 @@ func TestTTLInheritance(t *testing.T) {
 func TestBuildRecordBodyA(t *testing.T) {
 	rc := &models.RecordConfig{Type: "A", TTL: 300}
 	rc.SetLabel("host", "example.com")
-	if err := rc.PopulateFromString("A", "10.0.0.1", "example.com"); err != nil {
+	if err := rc.SetTarget("10.0.0.1"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -220,7 +220,7 @@ func TestBuildRecordBodyA(t *testing.T) {
 func TestBuildRecordBodyNoView(t *testing.T) {
 	rc := &models.RecordConfig{Type: "A", TTL: 300}
 	rc.SetLabel("host", "example.com")
-	if err := rc.PopulateFromString("A", "10.0.0.1", "example.com"); err != nil {
+	if err := rc.SetTarget("10.0.0.1"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/providers/infoblox/records.go
+++ b/providers/infoblox/records.go
@@ -1,0 +1,120 @@
+package infoblox
+
+import (
+	"fmt"
+
+	"github.com/DNSControl/dnscontrol/v4/models"
+	"github.com/DNSControl/dnscontrol/v4/pkg/diff2"
+)
+
+// GetZoneRecords gets the records of a zone and returns them in RecordConfig format.
+func (p *infobloxProvider) GetZoneRecords(dc *models.DomainConfig) (models.Records, error) {
+	domain := dc.Name
+
+	// Verify the zone exists in the configured view.
+	_, err := p.api.getZoneAuth(domain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find zone %q: %w", domain, err)
+	}
+
+	// Fetch the zone default TTL for records that inherit TTL.
+	defaultTTL, err := p.api.getZoneDefaultTTL(domain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get zone default TTL for %q: %w", domain, err)
+	}
+	if defaultTTL == 0 {
+		defaultTTL = 300 // Fallback default
+	}
+
+	var records models.Records
+
+	for _, recType := range supportedTypes {
+		raws, err := p.api.getRecords(recType, domain)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch %s records for %q: %w", recType, domain, err)
+		}
+
+		for _, raw := range raws {
+			rc, err := toRecordConfig(recType, raw, domain, defaultTTL)
+			if err != nil {
+				return nil, err
+			}
+			// toRecordConfig returns nil for records we want to skip (e.g. apex NS).
+			if rc != nil {
+				records = append(records, rc)
+			}
+		}
+	}
+
+	return records, nil
+}
+
+// GetZoneRecordsCorrections returns a list of corrections to turn existing records into dc.Records.
+func (p *infobloxProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, existing models.Records) ([]*models.Correction, int, error) {
+	var corrections []*models.Correction
+
+	instructions, actualChangeCount, err := diff2.ByRecord(existing, dc, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for _, inst := range instructions {
+		switch inst.Type {
+		case diff2.REPORT:
+			corrections = append(corrections, inst.CreateMessage())
+
+		case diff2.CREATE:
+			rc := inst.New[0]
+			msg := inst.MsgsJoined
+			corrections = append(corrections, &models.Correction{
+				Msg: msg,
+				F: func() error {
+					recType, body, err := buildRecordBody(rc, dc.Name, p.api.view, true)
+					if err != nil {
+						return err
+					}
+					_, err = p.api.createRecord(recType, body)
+					return err
+				},
+			})
+
+		case diff2.CHANGE:
+			old := inst.Old[0]
+			rc := inst.New[0]
+			msg := inst.MsgsJoined
+			ref, ok := old.Original.(string)
+			if !ok {
+				return nil, 0, fmt.Errorf("original record missing _ref for CHANGE operation")
+			}
+			corrections = append(corrections, &models.Correction{
+				Msg: msg,
+				F: func() error {
+					_, body, err := buildRecordBody(rc, dc.Name, p.api.view, false)
+					if err != nil {
+						return err
+					}
+					return p.api.updateRecord(ref, body)
+				},
+			})
+
+		case diff2.DELETE:
+			old := inst.Old[0]
+			msg := inst.MsgsJoined
+			ref, ok := old.Original.(string)
+			if !ok {
+				return nil, 0, fmt.Errorf("original record missing _ref for DELETE operation")
+			}
+			corrections = append(corrections, &models.Correction{
+				Msg: msg,
+				F: func() error {
+					return p.api.deleteRecord(ref)
+				},
+			})
+
+		default:
+			panic(fmt.Sprintf("unhandled diff2 verb: %d", inst.Type))
+		}
+	}
+
+	return corrections, actualChangeCount, nil
+}


### PR DESCRIPTION
## Summary

- Adds a new DNS provider for [Infoblox NIOS](https://www.infoblox.com/) DDI appliances via the WAPI (Web API)
- Supports A, AAAA, CAA, CNAME, MX, PTR, SRV, and TXT record types
- Includes full provider documentation, integration test profile, and CI configuration

## Details

The provider connects to the Infoblox Grid Master using WAPI with HTTP Basic Auth and manages DNS records in a configurable DNS view. Key implementation notes:

- HTTP compression is disabled to avoid 403 responses from the Infoblox Apache reverse proxy
- Non-standard WAPI fields (CAA, PTR) are explicitly requested via `_return_fields+`
- NS records are excluded because Infoblox requires an `addresses` field (nameserver IPs) that DNSControl does not provide
- TXT records are limited to 255 bytes per Infoblox's single-string constraint

## Integration test results

Tested against Infoblox NIOS WAPI v2.12. Out of ~113 integration tests:
- **110 pass**
- 3 known failures due to Infoblox limitations (NS delegation requires `addresses` array, 256-byte TXT edge case)

## Files changed

**Provider implementation** (from prior commit):
- `providers/infoblox/` — provider code, API client, type converters, audit rules, unit tests

**WAPI compatibility fixes:**
- `providers/infoblox/api.go` — DisableCompression, per-type return field handling
- `providers/infoblox/convert.go` — Remove NS from supported types, strip TTL from NS bodies
- `providers/infoblox/auditrecords.go` — Reject empty TXT, tighten to 255-byte limit

**Submission files:**
- `README.md` — Added Infoblox to provider table
- `.github/CODEOWNERS` — `providers/infoblox @matthewmgamble`
- `.github/workflows/pr_integration_tests.yml` — INFOBLOX env vars
- `documentation/provider/infoblox.md` — Provider documentation
- `documentation/SUMMARY.md`, `documentation/provider/index.md` — Updated indexes
- `.github/labeler.yml`, `.goreleaser.yml` — Auto-generated updates
- `integrationTest/profiles.json` — INFOBLOX test profile

## Test plan

- [x] Unit tests pass (`go test ./providers/infoblox/...`)
- [x] `go vet ./providers/infoblox/...` clean
- [x] `go generate ./...` and `bin/generate-all.sh` run without errors
- [x] Integration tests run against live Infoblox NIOS server (110/113 pass)

Please create the GitHub label `provider-INFOBLOX`.