### PR TITLE
ci: automate releases via Conventional Commits + develop/main (#4829)

### DIFF
--- a/.github/workflows/pr_conventional_title.yml
+++ b/.github/workflows/pr_conventional_title.yml
@@ -1,0 +1,62 @@
+name: "PR: Conventional title"
+
+# Enforce Conventional Commits on the PR TITLE (issue #4829). PRs are
+# squash-merged into `develop`, and GitHub uses the PR title as the squash
+# commit subject, so the title is what later drives version bumping (svu) and
+# the release changelog (GoReleaser).
+#
+# Only PRs targeting `develop` are checked: `main` only receives the
+# `develop -> main` merge commit, which is not a conventional commit.
+#
+# Provider-specific changes use the "p/<name>" scope, e.g.
+#   fix(p/route53): ...      feat(p/azure_dns): ...
+# Scopes are otherwise free-form (we validate the type, not the scope), so
+# there is no per-provider list to maintain.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conventional-title:
+    name: Validate PR title
+    # Only gate PRs into develop. PRs into main (the release merge) are exempt.
+    if: github.base_ref == 'develop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that the PR title is a Conventional Commit
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed commit types. A trailing "!" (e.g. feat!:) marks a breaking
+          # change and is always allowed.
+          types: |
+            feat
+            fix
+            docs
+            chore
+            ci
+            build
+            refactor
+            perf
+            test
+            revert
+          # A scope is optional (global changes have none). When present it is
+          # free-form; provider changes should use "p/<name>".
+          requireScope: false
+          # Subject must be non-empty and not start with an uppercase letter is
+          # NOT enforced here to keep the barrier low; type correctness is what
+          # the release automation depends on.
+          validateSingleCommit: false

--- a/.github/workflows/release_gate.yml
+++ b/.github/workflows/release_gate.yml
@@ -1,0 +1,86 @@
+name: "RELEASE gate: full integration"
+
+# The release gate for the `develop -> main` merge (issue #4829).
+#
+# Releases happen when a human merges `develop -> main`. That merge is
+# infrequent (~weekly), so we can afford to run the ENTIRE longtest
+# integration suite here as a required check before the merge is allowed.
+#
+# Emergency bypass: add the `skip-longtest` label to the PR. The gate then
+# reports success WITHOUT running the suite, but records a loud warning and a
+# job-summary note so the skip is auditable.
+#
+# Make the `release-gate` job a REQUIRED status check on `main` in branch
+# protection. It is a single job that always runs and reflects either the
+# longtest result or the emergency skip, so branch protection never gets stuck
+# on a skipped check.
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # Decide whether the emergency bypass label is present.
+  guard:
+    if: github.repository == 'DNSControl/dnscontrol'
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.decide.outputs.skip }}
+    steps:
+      - id: decide
+        env:
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-longtest') }}
+        run: echo "skip=$HAS_LABEL" >> "$GITHUB_OUTPUT"
+
+  # Run the full integration suite unless the bypass label is set.
+  longtest:
+    needs: guard
+    if: needs.guard.outputs.skip == 'false'
+    uses: ./.github/workflows/pr_integration_tests.yml
+    with:
+      full: true
+    secrets: inherit
+
+  # The single required check. Always runs; green if tests passed OR the
+  # emergency skip was requested; red if the suite failed.
+  release-gate:
+    needs: [guard, longtest]
+    if: always() && github.repository == 'DNSControl/dnscontrol'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate gate
+        env:
+          SKIP: ${{ needs.guard.outputs.skip }}
+          LONGTEST_RESULT: ${{ needs.longtest.result }}
+        run: |
+          set -eu
+          if [ "$SKIP" = "true" ]; then
+            echo "::warning title=longtest SKIPPED::Release longtest gate was skipped via the 'skip-longtest' label on PR #${{ github.event.pull_request.number }}."
+            {
+              echo "## ⚠️ Release longtest gate SKIPPED"
+              echo ""
+              echo "The full integration suite was **not run** because the \`skip-longtest\` label is present on this PR."
+              echo "This should only be used for emergencies."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$LONGTEST_RESULT" = "success" ]; then
+            echo "Full longtest integration suite passed."
+            exit 0
+          fi
+          echo "::error title=longtest failed::Release gate failed (longtest result: ${LONGTEST_RESULT})."
+          exit 1

--- a/.github/workflows/release_on_merge.yml
+++ b/.github/workflows/release_on_merge.yml
@@ -1,0 +1,179 @@
+name: "RELEASE: auto-release on merge to main"
+
+# Fully-automated release (issue #4829).
+#
+# Development happens on `develop`; `main` only ever receives a `develop -> main`
+# merge. So any push to `main` means "release". This workflow:
+#
+#   1. Computes the next version from Conventional Commits with `svu`
+#      (feat -> minor, fix/perf -> patch, `!`/BREAKING CHANGE -> major;
+#      chore/ci/docs/etc. -> no bump).
+#   2. If nothing releasable landed since the last tag, it does nothing.
+#   3. Otherwise it tags `vX.Y.Z` and runs GoReleaser, which publishes the
+#      release (draft: false in .goreleaser.yml).
+#
+# The tag is pushed with GITHUB_TOKEN. GitHub deliberately does NOT re-trigger
+# workflows for GITHUB_TOKEN tag pushes, so this job runs GoReleaser itself
+# rather than relying on the tag-push path in release_draft.yml (which remains
+# the manual escape hatch). There is therefore no double release.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  # Never cancel an in-flight release; serialize if two merges land quickly.
+  group: release-on-merge
+  cancel-in-progress: false
+
+jobs:
+  # version: compute the next semver and, if there is one, create the tag.
+  version:
+    name: compute version
+    # Safety switch for rollout: this workflow is inert until the repository
+    # variable AUTO_RELEASE_ENABLED is set to "true"
+    # (Settings -> Secrets and variables -> Actions -> Variables). That lets the
+    # automation land on main without cutting a release, and lets you turn it
+    # off instantly if something goes wrong.
+    if: github.repository == 'DNSControl/dnscontrol' && vars.AUTO_RELEASE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.svu.outputs.release }}
+      version: ${{ steps.svu.outputs.version }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "stable"
+
+      - name: Compute next version with svu
+        id: svu
+        run: |
+          set -eu
+          go install github.com/caarlos0/svu/v3@latest
+          SVU="$(go env GOPATH)/bin/svu"
+          CURRENT="$("$SVU" current)"
+          NEXT="$("$SVU" next)"
+          echo "current=$CURRENT next=$NEXT"
+          if [ "$NEXT" = "$CURRENT" ]; then
+            echo "No releasable commits since ${CURRENT} (only chore/ci/docs/etc.). Nothing to release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## No release"
+              echo ""
+              echo "No \`feat\`/\`fix\`/breaking commits since \`${CURRENT}\`, so no version was cut."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "release=true"   >> "$GITHUB_OUTPUT"
+            echo "version=$NEXT"  >> "$GITHUB_OUTPUT"
+            {
+              echo "## Releasing ${NEXT}"
+              echo ""
+              echo "Previous release: \`${CURRENT}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Create and push tag
+        if: steps.svu.outputs.release == 'true'
+        env:
+          VERSION: ${{ steps.svu.outputs.version }}
+        run: |
+          set -eu
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release ${VERSION}"
+          git push origin "refs/tags/${VERSION}"
+
+  # release: build and publish with GoReleaser (only if a version was cut).
+  release:
+    name: goreleaser
+    needs: version
+    if: needs.version.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          # Build from the tag we just created.
+          ref: ${{ needs.version.outputs.version }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "stable"
+
+      # Stringer is needed because .goreleaser includes "go generate ./...".
+      - name: Install stringer
+        run: go install golang.org/x/tools/cmd/stringer@latest
+
+      # Compute the changelog range: current = the tag we just cut; previous =
+      # the most recent non-rc release older than it (so notes cover the full
+      # range since the last stable release). Mirrors release_draft.yml.
+      - name: Compute changelog previous/current tags
+        env:
+          CURRENT_TAG: ${{ needs.version.outputs.version }}
+        run: |
+          set -eu
+          cur="$CURRENT_TAG"
+          echo "GORELEASER_CURRENT_TAG=$cur" >> "$GITHUB_ENV"
+          base="${cur%%-*}"   # strip any -rc suffix
+          prev="$(
+            { git tag --list 'v[0-9]*.[0-9]*.[0-9]*'; echo "$base"; } \
+              | awk '!/-/' \
+              | sort -V -u \
+              | awk -v base="$base" '$0==base{print prev; exit} {prev=$0}'
+          )"
+          if [ -n "$prev" ]; then
+            echo "GORELEASER_PREVIOUS_TAG=$prev" >> "$GITHUB_ENV"
+            echo "current=$cur previous=$prev (most recent non-rc release)"
+          else
+            echo "No prior non-rc release found for $cur; letting GoReleaser auto-detect."
+          fi
+
+      - name: Goreleaser release
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,30 +29,42 @@ before:
 changelog:
   sort: asc
   use: github
+  # Grouping is driven by Conventional Commits (see issue #4829). Two rules to
+  # know when editing this list:
+  #   1. A commit lands in the FIRST group (by list order) whose regexp
+  #      matches; `order:` only controls the DISPLAY position. So the
+  #      provider-specific group must be LISTED before the generic feat/fix
+  #      groups, and the catch-all "Other" group must be LISTED last.
+  #   2. Provider-specific changes are identified by the "p/<name>" scope,
+  #      e.g. "fix(p/route53): ...". This means there is NO per-provider list
+  #      to maintain here: adding a new provider needs no changes to this file.
   groups:
     - title: 'Breaking changes:'
-      regexp: "(?i)^.*breaking[(\\w)]*:+.*$"
+      regexp: '(?i)^[a-z]+(\([^)]*\))?!:|breaking change'
       order: 0
-    - title: 'Major features:'
-      regexp: "(?i)^.*(major|new provider|feature)[(\\w)]*:+.*$"
-      order: 1
     - title: 'Provider-specific changes:'
-      regexp: "(?i)((adguardhome|akamaiedgedns|alidns|autodns|axfrddns|azure_dns|azure_private_dns|azuredns|bind|bunny_dns|bunnydns|cloudflare|cloudflareapi|cloudns|cnr|cscglobal|desec|digitalocean|dnscale|dnsimple|dnsmadeeasy|dnsoverhttps|doh|domainnameshop|dynadot|dynu|easyname|exoscale|fortigate|gandi|gandi_v5|gcloud|gcore|gidinet|gigahost|hedns|hetzner_v2|hexonet|hostingde|huaweicloud|infomaniak|internetbs|inwx|joker|linode|loopia|luadns|mikrotik|mythicbeasts|namecheap|namedotcom|netbird|netcup|netlify|netnod|nexdns|ns1|opensrs|openwrt|oracle|ovh|packetframe|porkbun|powerdns|realtimeregister|route53|rwth|sakuracloud|scaleway|softlayer|tencentdns|transip|unifi|vercel|vultr|websupport).*:)+.*"
+      regexp: '(?i)^(feat|fix|refactor|perf)\(p/[^)]+\):'
       order: 2
-    - title: 'Documentation:'
-      regexp: "(?i)^.*(docs)[(\\w)]*:+.*$"
+    - title: 'New features:'
+      regexp: '(?i)^feat(\([^)]*\))?:'
+      order: 1
+    - title: 'Bug fixes:'
+      regexp: '(?i)^fix(\([^)]*\))?:'
       order: 3
-    - title: 'CI/CD:'
-      regexp: "(?i)^.*(build|ci|cicd)[(\\w)]*:+.*$"
+    - title: 'Documentation:'
+      regexp: '(?i)^docs(\([^)]*\))?:'
       order: 4
-    - title: 'Dependencies:'
-      regexp: "(?i)^.*\\b(deps|dependencies)\\b.*$"
+    - title: 'CI/CD:'
+      regexp: '(?i)^(build|ci)(\([^)]*\))?:'
       order: 5
+    - title: 'Dependencies:'
+      regexp: '(?i)^\w+\([^)]*deps[^)]*\):|\bdependencies\b'
+      order: 6
+    - title: 'Deprecation warnings:'
+      regexp: '(?i)deprecate'
+      order: 8
     - title: 'Other changes and improvements:'
       order: 9
-    - title: 'Deprecation warnings:'
-      regexp: "(?i)^.*Deprecate[(\\w)]*:+.*$"
-      order: 10
   filters:
     exclude:
     - '^test:'
@@ -146,7 +158,9 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
 
 release:
-  draft: true
+  # Fully automated releases (issue #4829): publish immediately, no draft to
+  # hand-edit. The human gate is the `develop -> main` merge, not note editing.
+  draft: false
   prerelease: auto
   mode: append
   header: |

--- a/bin/auto_release.sh
+++ b/bin/auto_release.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# bin/auto_release.sh -- kick off a DNSControl release.
+#
+# A release is simply "merge develop into main". This script opens (or reuses)
+# the `develop -> main` pull request and turns on GitHub auto-merge. From there
+# it is hands-off: the release gate (the full longtest integration suite) runs
+# on the PR, and when it passes GitHub merges the PR automatically. That merge
+# to `main` triggers .github/workflows/release_on_merge.yml, which picks the
+# version with svu, tags it, and publishes via GoReleaser.
+#
+# You do NOT choose a version number, and there is no "Release vX.Y.Z" commit:
+# the version is computed from the Conventional Commits on `develop` and lives
+# only in the git tag.
+#
+# Usage:
+#   bin/auto_release.sh [-y] [-w] [--skip-longtest]
+#     -y, --yes           Do not prompt for confirmation.
+#     -w, --watch         Watch the PR's checks after enabling auto-merge.
+#     --skip-longtest     EMERGENCY: label the PR so the longtest gate is
+#                         skipped. Use only when you must ship immediately.
+#     -h, --help          Show this help.
+#
+# Requirements: git, and the GitHub CLI `gh` authenticated with write access.
+# The repo must have "Allow auto-merge" enabled (Settings -> General).
+
+set -euo pipefail
+
+BASE="main"
+HEAD="develop"
+ASSUME_YES=0
+WATCH=0
+SKIP_LONGTEST=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -y|--yes)          ASSUME_YES=1 ;;
+    -w|--watch)        WATCH=1 ;;
+    --skip-longtest)   SKIP_LONGTEST=1 ;;
+    -h|--help)         grep '^#' "$0" | sed -e 's/^#!.*//' -e 's/^# \{0,1\}//'; exit 0 ;;
+    *)                 echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+command -v gh >/dev/null 2>&1 || { echo "ERROR: the GitHub CLI 'gh' is required." >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "ERROR: 'gh' is not authenticated (run: gh auth login)." >&2; exit 1; }
+
+echo "Fetching origin..."
+git fetch --quiet origin --tags
+
+git show-ref --verify --quiet "refs/remotes/origin/$HEAD" || {
+  echo "ERROR: origin/$HEAD does not exist. Create the '$HEAD' branch first." >&2; exit 1; }
+git show-ref --verify --quiet "refs/remotes/origin/$BASE" || {
+  echo "ERROR: origin/$BASE does not exist." >&2; exit 1; }
+
+# Is there anything to release?
+ahead="$(git rev-list --count "origin/$BASE..origin/$HEAD")"
+if [ "$ahead" -eq 0 ]; then
+  echo "Nothing to release: origin/$HEAD is not ahead of origin/$BASE."
+  exit 0
+fi
+
+echo
+echo "Commits on '$HEAD' not yet on '$BASE' that would trigger a version bump:"
+if ! git log --no-merges --format='  %s' "origin/$BASE..origin/$HEAD" \
+      | grep -Ei '^[[:space:]]*(feat|fix|perf)(\(|!|:)'; then
+  echo "  (none matched feat/fix/perf -- svu may compute NO release)"
+fi
+echo
+echo "Total commits ahead: $ahead"
+
+# Best-effort: warn if the release automation is still disabled.
+if enabled="$(gh variable list 2>/dev/null | awk '$1=="AUTO_RELEASE_ENABLED"{print $2}')" \
+   && [ -n "$enabled" ] && [ "$enabled" != "true" ]; then
+  echo
+  echo "WARNING: repo variable AUTO_RELEASE_ENABLED='$enabled' (not 'true')."
+  echo "         The PR will merge, but NO release is cut until it is 'true'."
+fi
+
+if [ "$ASSUME_YES" -ne 1 ]; then
+  echo
+  printf "Open / enable auto-merge for the %s -> %s release PR? [y/N] " "$HEAD" "$BASE"
+  read -r reply
+  case "$reply" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 0 ;;
+  esac
+fi
+
+# Create the PR if one does not already exist for this branch.
+if pr_url="$(gh pr view "$HEAD" --json url --jq .url 2>/dev/null)" && [ -n "$pr_url" ]; then
+  echo "Reusing existing PR: $pr_url"
+else
+  pr_url="$(gh pr create --base "$BASE" --head "$HEAD" \
+    --title "Release: merge $HEAD into $BASE" \
+    --body "Automated release PR opened by \`bin/auto_release.sh\`. When the release gate passes this auto-merges (as a merge commit) and a release is cut; svu picks the version.")"
+  echo "Opened PR: $pr_url"
+fi
+
+if [ "$SKIP_LONGTEST" -eq 1 ]; then
+  echo "EMERGENCY: adding 'skip-longtest' label (the integration gate will be bypassed)."
+  gh pr edit "$pr_url" --add-label skip-longtest
+fi
+
+# Enable auto-merge with a MERGE COMMIT. Never squash: squashing would collapse
+# develop's Conventional Commits into one and break both the version bump and
+# the changelog.
+gh pr merge "$pr_url" --auto --merge
+
+echo
+echo "Auto-merge enabled. When the required checks pass, GitHub will merge"
+echo "$HEAD -> $BASE and the release will publish automatically."
+echo "(If branch protection on '$BASE' requires an approval, the PR waits for it.)"
+
+if [ "$WATCH" -eq 1 ]; then
+  echo
+  echo "Watching checks (Ctrl-C to stop; stopping does not cancel the release)..."
+  gh pr checks "$pr_url" --watch || true
+fi

--- a/documentation/release/release-engineering.md
+++ b/documentation/release/release-engineering.md
@@ -1,16 +1,15 @@
 # How to build and ship a release
 
+DNSControl releases are **automated** (see [issue #4829](https://github.com/DNSControl/dnscontrol/issues/4829)). Day-to-day development happens on the `develop` branch. **A release is cut by merging `develop` into `main`** — that merge is the only human action required. Everything else (version number, tag, changelog, binaries, packages, Docker images, Homebrew tap, and the published GitHub Release) happens automatically.
+
 - [How to build and ship a release](#how-to-build-and-ship-a-release)
-  - [Step 1. Verify everything is up to date](#step-1-verify-everything-is-up-to-date)
-    - [Automated](#automated)
-    - [Manual](#manual)
-  - [Step 2. Cut the release](#step-2-cut-the-release)
-    - [Create an empty PR for the release](#create-an-empty-pr-for-the-release)
-    - [Start the release automation](#start-the-release-automation)
-  - [Manual (escape hatch)](#manual-escape-hatch)
-  - [Release it to the public](#release-it-to-the-public)
-  - [Step 3. Create the release notes](#step-3-create-the-release-notes)
-  - [Step 4. Announce it via email](#step-4-announce-it-via-email)
+  - [The model in one picture](#the-model-in-one-picture)
+  - [Contributor rules: Conventional Commits](#contributor-rules-conventional-commits)
+  - [How to cut a release](#how-to-cut-a-release)
+  - [Emergency: skip the integration gate](#emergency-skip-the-integration-gate)
+  - [What happens automatically](#what-happens-automatically)
+  - [Manual escape hatch](#manual-escape-hatch)
+  - [One-time setup / repo settings](#one-time-setup--repo-settings)
   - [Tip: How to bump the major version](#tip-how-to-bump-the-major-version)
   - [Tip: Configuring GHA integration tests](#tip-configuring-gha-integration-tests)
     - [Overview](#overview)
@@ -20,202 +19,88 @@
   - [Tip: How to update modules](#tip-how-to-update-modules)
   - [Tip: How to test GoReleaser](#tip-how-to-test-goreleaser)
 
-These are the instructions for producing a release.
-
-GitHub Actions (GHA) will do most of the work for you. You will need to edit the draft release notes and click a button to make the release public.
-
-Please change the version number as appropriate.  Substitute (for example) `v4.2.0` any place you see `$VERSION` in this doc.
-
-## Step 1. Verify everything is up to date
-
-### Automated
-
-This script will run `bin/generate-all.sh` and prompt to upgrade depenencies.
-It must be run from branch `main` or `prep_release`.
-
-```shell
-git checkout main
-git config remote.origin.prune true ; git config fetch.prune true
-git pull --rebase --ff-only --prune
-bin/prepare_release.sh
-```
-
-### Manual
-
-Dependencies:
-
-```shell
-git checkout main
-git checkout -b update_deps
-go install github.com/oligot/go-mod-upgrade@latest
-go-mod-upgrade
-go mod tidy
-git commit -m "CHORE: Update dependencies" go.sum go.mod
-```
-
-Generated files, linting, etc:
-
-```shell
-git fetch origin main
-git reset --hard origin/main
-git checkout -b generate
-bin/generate-all.sh
-git status
-git commit -am "CHORE: generate-all.sh"
-```
-
-## Step 2. Cut the release
-
-Pick the next release number:
-
-```shell
-git tag -l |grep -F v5. | sort --version-sort --field-separator=. --key=2,2 | tail
-```
-
-The manual dance below (empty PR → wait for tests → merge → tag) is now done by
-creating an empty "release" PR, then a single GitHub Actions run.
-
-### Create an empty PR for the release
-
-```shell
-git fetch origin main
-git checkout main
-git config remote.origin.prune true ; git config fetch.prune true
-git pull --rebase --ff-only --prune
-git reset --hard origin/main
-git checkout -b "release_$VERSION"
-git commit --allow-empty -m "Release $VERSION"
-git push
-gh pr create --base main --title "Release $VERSION" --body ""
-```
-
-### Start the release automation
-
-1. Go to **Actions → "RELEASE: Make release candidate" → Run workflow**.
-2. In the **"Use workflow from"** dropdown, choose the branch to release from (usually `main`; any branch is supported).
-3. Fill in the inputs:
-   - **version** (required): e.g. `v4.44.0` or `v4.44.0-rc1`. The run **fails fast if that tag already exists**.
-   - **previous_tag** (optional): the tag the changelog compares against. Leave blank to auto-detect the most recent non-RC release (almost always what you want; set it only when releasing from an unusual branch).
-   - **skip_longtest** (optional, default off): **danger** — skips the full `longtest` integration gate. Use only for an emergency release or when the suite is known-broken. When set, the run is loudly annotated and the job summary records that tests were skipped. (`preflight` still runs, so an invalid version or an existing tag still blocks the release.)
-4. Click **Run workflow**.
-
-The workflow then, in order:
-
-1. **preflight** — validates the version; refuses if the tag already exists.
-2. **verify** — runs the **entire** `longtest` integration suite as a gate. If anything fails, nothing is tagged or published.
-3. **release** — tags the tip of the selected branch and runs GoReleaser to produce the **draft** release.
-
-The release is tagged directly (not via an empty `Release <version>` commit):
-this org forbids GitHub Actions from opening pull requests and `main` is
-protected, so a PAT-free automated PR is not possible. The changelog range is
-still correct because it is computed by version, not by commit ancestry.
-
-## Manual (escape hatch)
-
-You can still do the release by hand. Pushing a tag runs GoReleaser directly, but it
-**skips** the integration-test gate — so run/verify tests yourself first.
-
-```shell
-# Set the version we are going to release
-
-export VERSION=v4.43.2
-
-# Create an empty PR for the release
-
-git fetch origin main
-git checkout main
-git config remote.origin.prune true ; git config fetch.prune true
-git pull --rebase --ff-only --prune
-git reset --hard origin/main
-git checkout -b "release_$VERSION"
-git commit --allow-empty -m "Release $VERSION"
-git push
-gh pr create --base main --title "Release $VERSION" --body ""
-```
-
-Wait to tests to complete and merge.
-
-```shell
-gh run list -b "release_$VERSION"
-gh run watch
-```
-
-WAIT for the GHA to complete. If there are errors, stop and fix them.
-
-Merge it either manually or with this command:
-
-```shell
-gh pr merge --squash --delete-branch  $PR
-```
-
-Create the release
-
-```shell
-git fetch origin main
-git checkout main
-git config remote.origin.prune true ; git config fetch.prune true
-git pull --rebase --ff-only --prune
-git tag -m "Release $VERSION" -a $VERSION
-git push origin HEAD --tags
-```
-
-Soon after GitHub will start an [Action](https://github.com/DNSControl/dnscontrol/actions) Workflow called "draft release" which will build all release binaries and write the draft release notes.
-
-Wait to tests to complete and merge.
-
-```shell
-gh run list -b "$VERSION"
-gh run watch
-```
-
-WAIT for the GHA to complete. If there are errors, stop and fix them.
-
-## Release it to the public
-
-Find the release and edit the notes.
+## The model in one picture
 
 ```text
-https://github.com/DNSControl/dnscontrol/releases
+   feature PRs  ─(squash, Conventional Commit title)─▶  develop
+                                                          │
+                                    you open & merge PR   │  (merge commit, NOT squash)
+                                    (full longtest gate)  ▼
+                                                         main
+                                                          │  push to main
+                                    svu computes version  │  → tag vX.Y.Z
+                                    GoReleaser publishes   ▼
+                                                     GitHub Release
 ```
 
-When you submit it:
+- **`develop`** — the integration branch. All contributor PRs squash-merge here.
+- **`main`** — the release branch. It only ever receives the `develop -> main` merge.
 
-- "Pre-Release" for rc releases, "Latest" for real releases.
-- Create a discussion for this release
+## Contributor rules: Conventional Commits
 
-## Step 3. Create the release notes
+PR **titles** must follow [Conventional Commits](https://www.conventionalcommits.org/). PRs are squash-merged into `develop` and GitHub uses the PR title as the commit subject, so the title is what drives the version bump and the changelog. This is enforced by the `PR: Conventional title` check on every PR into `develop`.
 
-The draft release notes are created for you. In this step you'll edit them.
+Format: `type(scope): description`
 
-The GHA workflow uses [GoReleaser](https://goreleaser.com/) which produces the [GitHub Release](https://github.com/DNSControl/dnscontrol/releases) with Release Notes derived from the commit history between now and the last tag. These notes are just a draft and needs considerable editing. These release notes are used elsewhere, in particular the email step.
+- **Types** that trigger a release: `feat` (→ minor), `fix` (→ patch). A trailing `!` (e.g. `feat!:`) or a `BREAKING CHANGE` footer → major.
+- **Types** that do **not** trigger a release: `docs`, `chore`, `ci`, `build`, `refactor`, `perf`, `test`, `revert`.
+- **Provider-specific changes** use the scope **`p/<name>`**, e.g.:
 
-Release notes style guide:
+  ```text
+  fix(p/route53): stop sending unchanged CAA records
+  feat(p/azure_dns): support private zones
+  ```
 
-- Entries in the bullet list should be phrased in the positive: "Feature FOO now does BAR".  This is often the opposite of the related issue, which was probably phrased, "Feature FOO is broken because of BAR".
-- Every item should include the ID of the issue related to the change. If there was no issue, create one and close it.
-- Sort the list most important/exciting changes earlier in the list.
-- Items related to a specific provider should begin with the all-caps name of the provider, such as "ROUTE53: Added support for sandwiches (#100)"
-- The `Deprecation warnings` section should just copy from `README.md`.  If you change one, change it in the README too (you can make that change in this PR).
+  The `p/` scope is the *only* thing that marks a change as provider-specific. There is **no per-provider list to maintain** anywhere — adding a new provider needs no changelog or config edits. Non-provider scopes are free-form (`feat(spf):`, `fix(core):`, `chore(deps):`, …).
 
-See [https://github.com/DNSControl/dnscontrol/releases](https://github.com/DNSControl/dnscontrol/releases) for examples for recent release notes and copy that style.
+## How to cut a release
 
-## Step 4. Announce it via email
+1. Open a pull request from `develop` into `main`.
+2. Wait for the **`release-gate`** check to go green. It runs the **entire** `longtest` integration suite (this is why it can be slow — and why releases are batched rather than one-per-merge).
+3. **Merge it as a merge commit — NOT a squash.** Squashing would collapse every `feat`/`fix` into one commit and destroy both the version computation and the changelog.
 
-Email the release notes to the mailing list: (note the format of the Subject line and that the first line of the email is the URL of the release)
+That's it. The merge lands on `main`, which triggers the automation below.
 
-```text
-To: dnscontrol-discuss@googlegroups.com
-Subject: New release: dnscontrol v$VERSION
+## Emergency: skip the integration gate
 
-https://github.com/DNSControl/dnscontrol/releases/tag/v$VERSION
+If you must release without waiting for the full `longtest` suite (e.g. the suite is broken by an external provider outage, or a hotfix must ship now):
 
-[insert the release notes here]
-```
+- Add the label **`skip-longtest`** to the `develop -> main` PR.
+- The `release-gate` check then reports success **without** running the suite, but records a loud warning and a job-summary note so the bypass is auditable in the PR.
+- Merge as usual.
 
-{% hint style="info" %}
-**NOTE**: You won't be able to post to the mailing list unless you are on
-it.  [Click here to join](https://groups.google.com/g/dnscontrol-discuss).
-{% endhint %}
+The fully-manual escape hatch below is also always available.
+
+## What happens automatically
+
+On every push to `main` (i.e. every `develop -> main` merge), `.github/workflows/release_on_merge.yml`:
+
+1. Runs [`svu`](https://github.com/caarlos0/svu) to compute the next version from the Conventional Commits since the last tag. If there is nothing releasable (only `chore`/`ci`/`docs`/etc.), it **stops** — no tag, no release.
+2. Creates and pushes the annotated tag `vX.Y.Z`.
+3. Runs [GoReleaser](https://goreleaser.com/), which builds every artifact and **publishes** the GitHub Release (no draft — `release.draft: false` in `.goreleaser.yml`).
+
+The release notes are generated by GoReleaser from the commit history, grouped by Conventional-Commit type (Breaking / New features / Provider-specific / Bug fixes / Documentation / CI/CD / Dependencies / …). The standing "welcome", monthly-call announcement, deprecation warnings, and install instructions live in the GoReleaser `header`/`footer` in `.goreleaser.yml` — edit them there.
+
+> **Tags are pushed with `GITHUB_TOKEN`**, which by design does *not* re-trigger workflows, so the `release_on_merge` job runs GoReleaser itself. That is why this does not double-fire with the tag-push escape hatch below.
+
+## Manual escape hatch
+
+You can still cut a release by hand — useful if `develop -> main` itself is wedged. Two ways, both in `.github/workflows/release_draft.yml`:
+
+1. **Actions → "RELEASE: Make release candidate" → Run workflow.** Pick the branch (usually `main`), enter the `version` (e.g. `v5.1.0` or `v5.1.0-rc1`), optionally a `previous_tag`, and optionally `skip_longtest` (danger: skips the integration gate). This runs preflight → the full `longtest` gate → tag → GoReleaser.
+2. **Push a tag** (`git push origin vX.Y.Z`). This runs GoReleaser directly and **skips** the integration gate, so verify tests yourself first.
+
+Both paths use the same GoReleaser config, so they also publish (non-draft).
+
+## One-time setup / repo settings
+
+These are GitHub settings (not in the repo) that the model depends on:
+
+- **Squash merges use the PR title** as the commit subject (Settings → General → Pull Requests → "Default commit message" → *Pull request title*).
+- **`develop` and `main` both allow the right merge methods:** feature PRs into `develop` use *Squash*; the `develop -> main` PR uses *Create a merge commit*. Both methods must be enabled.
+- **Branch protection on `main`** requires the `release-gate` status check.
+- **Branch protection on `develop`** requires the `PR: Conventional title` check.
+- The `skip-longtest` label must exist in the repo.
 
 ## Tip: How to bump the major version
 

--- a/documentation/release/release-engineering.md
+++ b/documentation/release/release-engineering.md
@@ -55,11 +55,23 @@ Format: `type(scope): description`
 
 ## How to cut a release
 
-1. Open a pull request from `develop` into `main`.
-2. Wait for the **`release-gate`** check to go green. It runs the **entire** `longtest` integration suite (this is why it can be slow — and why releases are batched rather than one-per-merge).
-3. **Merge it as a merge commit — NOT a squash.** Squashing would collapse every `feat`/`fix` into one commit and destroy both the version computation and the changelog.
+Run:
 
-That's it. The merge lands on `main`, which triggers the automation below.
+```shell
+bin/auto_release.sh
+```
+
+That's the whole thing. The script opens (or reuses) the `develop → main` pull request and turns on **GitHub auto-merge**. From there it is hands-off:
+
+1. The **`release-gate`** check runs the **entire** `longtest` integration suite (this is why it can be slow — and why releases are batched rather than one-per-merge).
+2. When the gate passes, GitHub **auto-merges** the PR **as a merge commit** (auto-merge is configured to merge, never squash — squashing would collapse every `feat`/`fix` into one commit and destroy both the version computation and the changelog).
+3. The merge lands on `main`, triggering the automation below.
+
+You never choose a version and there is no `Release vX.Y.Z` commit: `svu` computes the version from the merged Conventional Commits and it lives only in the tag.
+
+Useful flags: `-y` (no confirmation prompt), `-w` (watch the checks), `--skip-longtest` (emergency; see below). If you prefer to do it by hand, open the `develop → main` PR yourself and enable auto-merge (or just merge once green) — but **use a merge commit, not a squash**.
+
+> If branch protection on `main` requires a review approval, auto-merge waits for it. Configure `main` to require the `release-gate` status check (and, if you want zero human clicks, no required approvals).
 
 ## Emergency: skip the integration gate
 
@@ -98,7 +110,8 @@ These are GitHub settings (not in the repo) that the model depends on:
 
 - **Squash merges use the PR title** as the commit subject (Settings → General → Pull Requests → "Default commit message" → *Pull request title*).
 - **`develop` and `main` both allow the right merge methods:** feature PRs into `develop` use *Squash*; the `develop -> main` PR uses *Create a merge commit*. Both methods must be enabled.
-- **Branch protection on `main`** requires the `release-gate` status check.
+- **"Allow auto-merge" is enabled** (Settings → General → Pull Requests), so `bin/auto_release.sh` can turn it on.
+- **Branch protection on `main`** requires the `release-gate` status check (and, for a fully hands-off merge, does not require a review approval).
 - **Branch protection on `develop`** requires the `PR: Conventional title` check.
 - The `skip-longtest` label must exist in the repo.
 

--- a/documentation/release/release-engineering.md
+++ b/documentation/release/release-engineering.md
@@ -61,17 +61,16 @@ Run:
 bin/auto_release.sh
 ```
 
-That's the whole thing. The script opens (or reuses) the `develop → main` pull request and turns on **GitHub auto-merge**. From there it is hands-off:
+The script opens (or reuses) the `develop → main` pull request and turns on **GitHub auto-merge**. Then:
 
 1. The **`release-gate`** check runs the **entire** `longtest` integration suite (this is why it can be slow — and why releases are batched rather than one-per-merge).
-2. When the gate passes, GitHub **auto-merges** the PR **as a merge commit** (auto-merge is configured to merge, never squash — squashing would collapse every `feat`/`fix` into one commit and destroy both the version computation and the changelog).
-3. The merge lands on `main`, triggering the automation below.
+2. A maintainer **approves** the PR. Branch protection on `main` requires one approval — this is the deliberate human sign-off on the release. (GitHub does not let you approve your own PR, so if you ran the script, **someone else approves**.)
+3. Once the gate is green **and** the PR is approved, GitHub **auto-merges** it **as a merge commit** (never a squash — squashing would collapse every `feat`/`fix` into one commit and destroy both the version computation and the changelog).
+4. The merge lands on `main`, triggering the automation below.
 
-You never choose a version and there is no `Release vX.Y.Z` commit: `svu` computes the version from the merged Conventional Commits and it lives only in the tag.
+So a release takes two human actions — running the script and approving the PR. Everything else (version, tag, changelog, publishing) is automatic. You never choose a version and there is no `Release vX.Y.Z` commit: `svu` computes the version from the merged Conventional Commits and it lives only in the tag.
 
-Useful flags: `-y` (no confirmation prompt), `-w` (watch the checks), `--skip-longtest` (emergency; see below). If you prefer to do it by hand, open the `develop → main` PR yourself and enable auto-merge (or just merge once green) — but **use a merge commit, not a squash**.
-
-> If branch protection on `main` requires a review approval, auto-merge waits for it. Configure `main` to require the `release-gate` status check (and, if you want zero human clicks, no required approvals).
+Useful flags: `-y` (no confirmation prompt), `-w` (watch the checks), `--skip-longtest` (emergency; see below). If you prefer to do it by hand, open the `develop → main` PR yourself and enable auto-merge (or just merge once green and approved) — but **use a merge commit, not a squash**.
 
 ## Emergency: skip the integration gate
 
@@ -111,7 +110,7 @@ These are GitHub settings (not in the repo) that the model depends on:
 - **Squash merges use the PR title** as the commit subject (Settings → General → Pull Requests → "Default commit message" → *Pull request title*).
 - **`develop` and `main` both allow the right merge methods:** feature PRs into `develop` use *Squash*; the `develop -> main` PR uses *Create a merge commit*. Both methods must be enabled.
 - **"Allow auto-merge" is enabled** (Settings → General → Pull Requests), so `bin/auto_release.sh` can turn it on.
-- **Branch protection on `main`** requires the `release-gate` status check (and, for a fully hands-off merge, does not require a review approval).
+- **Branch protection on `main`** requires the `release-gate` status check **and one review approval** (the human sign-off on the release; the approver cannot be the PR author).
 - **Branch protection on `develop`** requires the `PR: Conventional title` check.
 - The `skip-longtest` label must exist in the repo.
 


### PR DESCRIPTION
Implements the release-automation design from #4829. **Draft** — needs review, the one-time repo settings below, and a live dry-run before it goes live.

## Model
- Contributor PRs **squash-merge into `develop`** with Conventional-Commit titles (enforced).
- A human **opens + merges `develop → main` as a merge commit** to cut a release (this is the only manual step).
- The push to `main` triggers full automation: `svu` computes the next semver → tag → GoReleaser publishes.

## What's here
- **`pr_conventional_title.yml`** — enforces Conventional-Commit PR titles on PRs into `develop` (`amannn/action-semantic-pull-request@v6`). Types that release: `feat`→minor, `fix`→patch, `!`/BREAKING→major. `chore/ci/docs/…`→no release.
- **`release_gate.yml`** — runs the full `longtest` suite as a required check on `develop → main` PRs; a **`skip-longtest`** label is an auditable emergency bypass (single always-running `release-gate` check so branch protection never sticks on a skipped job).
- **`release_on_merge.yml`** — on push to `main`: `svu` → tag → GoReleaser. Skips entirely if nothing releasable landed. **Gated behind the `AUTO_RELEASE_ENABLED` repo variable** so this PR can merge *dormant*.
- **`.goreleaser.yml`** — `draft: false` (auto-publish), and the hand-maintained provider-name regexp is replaced by a permanent **`p/<name>` scope** rule (`fix(p/route53): …`) → **no per-provider list to maintain ever again**.
- **`release-engineering.md`** — rewritten around the new flow; manual dispatch/tag escape hatch and all Tips preserved.

## Provider changelog: how the giant regexp went away
Provider changes use the `p/<name>` scope. The changelog group is now a permanent one-liner. Because the *type* stays `feat`/`fix`, `svu` and the title-linter need zero special knowledge. I verified GoReleaser's routing end-to-end (matching is by list order, display by `order`):

```
### Breaking changes:        fix(p/route53)!, feat!
### New features:            feat, feat(core)
### Provider-specific:       feat(p/route53), fix(p/bind), perf(p/bind)
### Bug fixes:               fix, fix(spf)
### Documentation:           docs, docs(p/route53)
### CI/CD:                    build, ci
### Dependencies:            chore(deps)
### Deprecation warnings:    chore: deprecate ...
### Other:                    refactor, chore
```

## Validation done
- `svu` bump semantics probed on a scratch repo (chore/ci/docs → no bump; fix→patch; feat→minor; `!`→major).
- GoReleaser changelog routing tested end-to-end on a scratch repo (table above).
- `goreleaser check` passes on the real `.goreleaser.yml`; all workflows pass `actionlint`.

## ⚠️ Not yet validated / needs a live dry-run
The workflows only run in GHA. Before enabling: cut a throwaway `-rc` (or run on a fork) to confirm `release_on_merge` tags + GoReleaser publishes correctly.

## One-time rollout (settings + order)
1. Create `develop` from `main`; point contributions at it.
2. Repo settings: squash-merge uses **PR title**; enable **merge commits** (for `develop→main`) and **squash** (for feature PRs); create the **`skip-longtest`** label.
3. Branch protection: require **`release-gate`** on `main`; require **`PR: Conventional title`** on `develop`.
4. Merge this PR (lands dormant — `AUTO_RELEASE_ENABLED` unset).
5. When ready, set repo variable **`AUTO_RELEASE_ENABLED=true`** and do a controlled first `develop→main` release.

Note: the existing `release_draft.yml` (dispatch / tag push) stays as the manual escape hatch. There's some GoReleaser-step overlap between it and `release_on_merge.yml`; happy to DRY it into a `workflow_call` reusable in a follow-up once this is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update: one-command releases + auto-merge
- **`bin/auto_release.sh`** opens/reuses the `develop → main` PR and enables **GitHub auto-merge** (as a *merge commit*, never squash). Once the `release-gate` passes, GitHub merges automatically and the release publishes — the only human action is running the script. Flags: `-y`, `-w` (watch), `--skip-longtest` (emergency).
- **No `Release vX.Y.Z` commit** is needed: the version is computed by `svu` and lives only in the tag; the merge commit is filtered out of the changelog.
- Extra one-time setting: enable **"Allow auto-merge"**; for zero clicks, `main` protection should require `release-gate` but not a review approval.