### PR TITLE
BUG: Fix DMARC_BUILDER TypeScript types for psd= and t=

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -1050,7 +1050,7 @@ declare function DKIM_BUILDER(opts: { selector: string; pubkey?: string; label?:
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/dmarc_builder
  */
-declare function DMARC_BUILDER(opts: { label?: string; version?: string; policy: 'none' | 'quarantine' | 'reject'; subdomainPolicy?: 'none' | 'quarantine' | 'reject'; nonexistentSubdomainPolicy?: 'none' | 'quarantine' | 'reject'; alignmentSPF?: 'strict' | 's' | 'relaxed' | 'r'; alignmentDKIM?: 'strict' | 's' | 'relaxed' | 'r'; percent?: number; rua?: string[]; ruf?: string[]; publicSuffixDomain: 'y' | 'n' | 'u'; testMode: 'y' | 'n'; failureOptions?: { SPF: boolean, DKIM: boolean } | string; failureFormat?: string; reportInterval?: Duration | number; ttl?: Duration }): DomainModifier;
+declare function DMARC_BUILDER(opts: { label?: string; version?: string; policy: 'none' | 'quarantine' | 'reject'; subdomainPolicy?: 'none' | 'quarantine' | 'reject'; nonexistentSubdomainPolicy?: 'none' | 'quarantine' | 'reject'; alignmentSPF?: 'strict' | 's' | 'relaxed' | 'r'; alignmentDKIM?: 'strict' | 's' | 'relaxed' | 'r'; percent?: number; rua?: string[]; ruf?: string[]; publicSuffixDomain?: 'y' | 'n' | 'u'; testMode?: 'y' | 'n'; failureOptions?: { SPF: boolean, DKIM: boolean } | string; failureFormat?: string; reportInterval?: Duration | number; ttl?: Duration }): DomainModifier;
 
 /**
  * `DNAME` adds a [Delegation name record](https://www.rfc-editor.org/rfc/rfc6672) to the domain.

--- a/documentation/language-reference/domain-modifiers/DMARC_BUILDER.md
+++ b/documentation/language-reference/domain-modifiers/DMARC_BUILDER.md
@@ -29,8 +29,8 @@ parameter_types:
   percent: number?
   rua: string[]?
   ruf: string[]?
-  publicSuffixDomain: "'y' | 'n' | 'u'"
-  testMode: "'y' | 'n'"
+  publicSuffixDomain: "'y' | 'n' | 'u'?"
+  testMode: "'y' | 'n'?"
   failureOptions: "{ SPF: boolean, DKIM: boolean } | string?"
   failureFormat: string?
   reportInterval: "Duration | number?"


### PR DESCRIPTION
DMARC_BUILDER was updated to include new tags from RFC 9989 in https://github.com/DNSControl/dnscontrol/pull/4794, which added new arguments to `DMARC_BUILDER`: `publicSuffixDomain` and `testMode`. Like all arguments to that function, they don't have to be specified (there are implicit default values), but the TypeScript types didn't reflect that, causing auto-generated TS types to throw an error on otherwise valid usage.

This PR fixes that.

<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

    bin/generate-all.sh

(this runs commands like "go generate", fixes formatting, and so on)

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
