### PR TITLE
HOSTINGDE: Fix TXT quoting on read and write

### DIFF
--- a/providers/hostingde/types.go
+++ b/providers/hostingde/types.go
@@ -8,6 +8,7 @@ import (
 
 	dnsv2 "codeberg.org/miekg/dns"
 	"github.com/DNSControl/dnscontrol/v5/models"
+	"github.com/DNSControl/dnscontrol/v5/pkg/printer"
 	"github.com/pkg/errors"
 )
 
@@ -160,7 +161,14 @@ func (r record) nativeToRecord(dc *models.DomainConfig) (*models.RecordConfig, e
 	case "SRV":
 		rc, err = dc.NewRecordConfigParse(label, ttl, r.Type, fmt.Sprintf("%d %s", r.Priority, r.Content))
 	case "TXT":
-		rc, err = dc.NewRecordConfig(label, ttl, r.Type, r.Content)
+		// hosting.de returns TXT content in presentation format. Anything
+		// else is used as-is, so that one unexpected record does not fail
+		// the read of the entire zone.
+		rc, err = dc.NewRecordConfigParse(label, ttl, r.Type, r.Content)
+		if err != nil {
+			printer.Warnf("hostingde: TXT record %q is not in presentation format, using it as-is: %v\n", r.Name, err)
+			rc, err = dc.NewRecordConfig(label, ttl, r.Type, r.Content)
+		}
 	default:
 		rc, err = dc.NewRecordConfigParse(label, ttl, r.Type, r.Content)
 	}
@@ -180,19 +188,8 @@ func recordToNative(rc *models.RecordConfig) *record {
 
 	switch rc.TypeNum {
 	case dnsv2.TypeTXT:
-		// TODO(tlim): I think all of this can be replaced by:
-		// record.Content = rc.AsTXT().String()
-
-		// TODO(tlim): Move this to a function with unit tests.
-		txtStrings := make([]string, rc.GetTargetTXTSegmentCount())
-		copy(txtStrings, rc.GetTargetTXTSegmented())
-
-		// Escape quotes
-		for i := range txtStrings {
-			txtStrings[i] = fmt.Sprintf(`"%s"`, strings.ReplaceAll(txtStrings[i], `"`, `\"`))
-		}
-
-		record.Content = strings.Join(txtStrings, " ")
+		// hosting.de expects presentation format, quotes and all.
+		record.Content = rc.AsTXT().String()
 	case dnsv2.TypeMX:
 		mx := rc.AsMX()
 		record.Priority = mx.Preference

--- a/providers/hostingde/types_test.go
+++ b/providers/hostingde/types_test.go
@@ -1,0 +1,95 @@
+package hostingde
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v5/models"
+)
+
+// hosting.de stores and returns TXT content in presentation format, so
+// nativeToRecord has to parse it rather than take it literally.
+func TestNativeToRecordTXT(t *testing.T) {
+	long := strings.Repeat("a", 255)
+
+	tests := []struct {
+		name     string
+		content  string
+		want     string
+		wantSegs int
+	}{
+		{"simple", `"v=spf1 -all"`, "v=spf1 -all", 1},
+		{"spaces", `"one two three"`, "one two three", 1},
+		{"escaped quotes", `"say \"hi\""`, `say "hi"`, 1},
+		{"escaped backslash", `"a\\b"`, `a\b`, 1},
+		{"empty", `""`, "", 1},
+		{"multiple strings", `"` + long + `" "bcd"`, long + "bcd", 2},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			dc := models.MustNewDomainConfig("example.com")
+			r := record{Name: "example.com", Type: "TXT", Content: tst.content, TTL: 300}
+
+			rc, err := r.nativeToRecord(dc)
+			if err != nil {
+				t.Fatalf("nativeToRecord returned error: %v", err)
+			}
+			if got := rc.GetTargetTXTJoined(); got != tst.want {
+				t.Errorf("joined target = %q, want %q", got, tst.want)
+			}
+			if got := rc.GetTargetTXTSegmentCount(); got != tst.wantSegs {
+				t.Errorf("segment count = %d, want %d", got, tst.wantSegs)
+			}
+		})
+	}
+}
+
+// The old write path escaped quotes but not backslashes, so DNSControl
+// itself could have stored content like this. Reading it back must not fail
+// the whole zone.
+func TestNativeToRecordTXTNotPresentationFormat(t *testing.T) {
+	const content = `"a\"`
+
+	dc := models.MustNewDomainConfig("example.com")
+	r := record{Name: "example.com", Type: "TXT", Content: content, TTL: 300}
+
+	rc, err := r.nativeToRecord(dc)
+	if err != nil {
+		t.Fatalf("nativeToRecord returned error: %v", err)
+	}
+	if got := rc.GetTargetTXTJoined(); got != content {
+		t.Errorf("joined target = %q, want %q", got, content)
+	}
+}
+
+// A record written by recordToNative must read back unchanged, otherwise
+// every push reports the same TXT records as modified again.
+func TestTXTRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"simple", "v=spf1 -all"},
+		{"spaces", "one two three"},
+		{"escaped quotes", `say "hi"`},
+		{"backslash", `a\b`},
+		{"empty", ""},
+		{"multiple strings", strings.Repeat("a", 255) + "bcd"},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			dc := models.MustNewDomainConfig("example.com")
+			rc := dc.MustNewRecordConfig("@", 300, "TXT", tst.value)
+
+			back, err := recordToNative(rc).nativeToRecord(dc)
+			if err != nil {
+				t.Fatalf("nativeToRecord returned error: %v", err)
+			}
+			if got := back.GetTargetTXTJoined(); got != tst.value {
+				t.Errorf("round trip = %q, want %q", got, tst.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4850

The hosting.de API returns TXT content in presentation format. The read path handed that to `NewRecordConfig()`, which takes the value literally, so the quotes became part of the value and every TXT record was reported as a correction on every run. Multi-string content (`"abc" "def"`) was not joined either.

The unquoting was lost in #4426, which rewrote `PopulateFromString()` as a wrapper around `PopulateFromStringFunc(..., nil)` and dropped its `SetTargetTXTs(ParseQuotedTxt(contents))` call. #4555 later replaced that call with `NewRecordConfig()`, which made the already-literal behavior explicit but did not change it. #4426 is an ancestor of the v5.0.3 release commit but not of the v4.46.0 one, which is why 4.46.0 still strips the quotes and 5.x does not.

TXT is now parsed with `NewRecordConfigParse()`. `ParseQuotedTxt()` returned no error, so a TXT read could not fail before this; content that does not parse is reported and used as-is rather than failing `GetZoneRecords()` for the whole zone.

The write path had the mirror problem: the escaping loop handled `"` but not `\`, so `a\b` was sent as `"a\b"` and read back as `ab`. `rc.AsTXT().String()` escapes both and settles the two `TODO(tlim)` comments sitting there. TXT values containing a backslash were therefore stored without it; the next push corrects the published value once.

Verified with `preview` against a live hosting.de zone: the TXT corrections disappear, no new ones appear, and the fallback never triggers. `types_test.go` covers 13 cases in both directions.