### PR TITLE
HOSTINGDE: Fix SOA mailbox set to 1@domain

### DIFF
--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -146,6 +146,14 @@ func soaToString(s soaValues) string {
 	return fmt.Sprintf("refresh=%d retry=%d expire=%d negativettl=%d ttl=%d", s.Refresh, s.Retry, s.Expire, s.NegativeTTL, s.TTL)
 }
 
+// placeholderSOA stands in for a zone that declares no SOA record. Only the
+// numeric fields are read, and they fall back to the provider's defaults
+// because they are zero. The mailbox must stay empty: a non-empty one makes
+// GetZoneRecordsCorrections rewrite the zone's contact address.
+func placeholderSOA(dc *models.DomainConfig) *models.RecordConfig {
+	return dc.MustNewRecordConfig("@", 0, dnsv2.TypeSOA, "ns", "", 0, 0, 0, 0)
+}
+
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
 func (hp *hostingdeProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, records models.Records) ([]*models.Correction, int, error) {
 	var err error
@@ -219,7 +227,7 @@ func (hp *hostingdeProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, 
 		}
 	}
 	if desiredSoa == nil {
-		desiredSoa = dc.MustNewRecordConfig("@", 0, dnsv2.TypeSOA, "ns", 1, 0, 0, 0, 0)
+		desiredSoa = placeholderSOA(dc)
 	}
 
 	defaultSoa := &hp.defaultSoa

--- a/providers/hostingde/hostingdeProvider_test.go
+++ b/providers/hostingde/hostingdeProvider_test.go
@@ -1,0 +1,17 @@
+package hostingde
+
+import (
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v5/models"
+)
+
+// A zone without an SOA record in dnsconfig.js must not have its contact
+// address rewritten, so the placeholder has to carry an empty mailbox.
+func TestPlaceholderSOAHasNoMailbox(t *testing.T) {
+	dc := models.MustNewDomainConfig("example.com")
+
+	if got := placeholderSOA(dc).AsSOA().Mbox; got != "" {
+		t.Errorf("placeholder mailbox = %q, want empty; a non-empty one is turned into %s@example.com", got, got)
+	}
+}


### PR DESCRIPTION
Fixes #4857

When `dnsconfig.js` declares no `SOA()` record, the provider builds a placeholder to take the numeric SOA fields from. `MakeSOA()` reads its second argument as the mailbox and `mustbe.SoaMailbox()` formats an `int` into a string, so the placeholder's `1` became the mailbox `"1"`. `GetZoneRecordsCorrections()` turns a non-empty mailbox into an address, so the zone's contact address was rewritten to `1@<domain>`.

Before #4615 the placeholder was an empty `RecordConfig`: the mailbox was empty, the guard did not fire, and the contact address was left alone. #4615 is an ancestor of the v5.0.3 release commit but not of the v4.46.0 one, so 4.46.0 is not affected.

Pass an empty mailbox again, and move the placeholder into a named function so the invariant can be tested.

Preview across 33 zones, none of which declare `SOA()`, reports the change for every one of them. Nothing was pushed.