### PR TITLE
BUGFIX: print-ir and --ir should round-trip

### DIFF
--- a/models/record.go
+++ b/models/record.go
@@ -69,20 +69,71 @@ type RecordConfig struct {
 	UnknownTypeName string `json:"unknown_type_name,omitempty"`
 }
 
-// MarshalJSON marshals RecordConfig.
+// MarshalJSON marshals RecordConfig. .rdata is written as its zone-file-style
+// text presentation (RDATA.String()) rather than as a JSON object, so that it
+// can be read back with MyNewData/NewRecordConfigParse — the same parser
+// already used to build a RecordConfig from dnsconfig.js and zone imports.
 func (rc *RecordConfig) MarshalJSON() ([]byte, error) {
 	recj := &struct {
 		RecordConfig
-		RDATA dnsv2.RDATA `json:"rdata,omitempty"`
+		RDATA string `json:"rdata,omitempty"`
 	}{
 		RecordConfig: *rc,
 	}
-	recj.RDATA = rc.GetRDATA()
+	recj.RDATA = rc.GetRDATA().String()
 	j, err := json.Marshal(*recj)
 	if err != nil {
 		return nil, err
 	}
 	return j, nil
+}
+
+// UnmarshalJSON unmarshals RecordConfig. This is needed because .rdata is an
+// unexported field whose type is the dnsv2.RDATA interface: encoding/json
+// can't populate it on its own since it doesn't know which concrete type
+// (A, MX, TXT, etc.) to instantiate. Instead of decoding "rdata" as
+// structured JSON, we treat it as the text presentation format (the same
+// format used in zone files and dnsconfig.js) and parse it with MyNewData,
+// the same helper NewRecordConfigParse uses. This also handles types like
+// SVCB/HTTPS whose RDATA embeds further interfaces (svcb.Pair) that have no
+// generic JSON-object representation.
+func (rc *RecordConfig) UnmarshalJSON(data []byte) error {
+	type recordConfigAlias RecordConfig // avoid infinite recursion into UnmarshalJSON
+	recj := &struct {
+		*recordConfigAlias
+		RDATA string `json:"rdata,omitempty"`
+	}{
+		recordConfigAlias: (*recordConfigAlias)(rc),
+	}
+	if err := json.Unmarshal(data, recj); err != nil {
+		return err
+	}
+
+	typeNum := rc.TypeNum
+	if typeNum == 0 && rc.Type != "" {
+		typeNum = dnsv2.StringToType[rc.Type]
+	}
+	if typeNum == 0 {
+		return fmt.Errorf("UnmarshalJSON: record %q has no usable typenum/type", rc.Name)
+	}
+	rc.TypeNum = typeNum
+	if rc.Type == "" {
+		rc.Type = dnsv2.TypeToString[typeNum]
+	}
+
+	if recj.RDATA == "" {
+		return fmt.Errorf("UnmarshalJSON: record %q (type %s) is missing its rdata", rc.Name, rc.Type)
+	}
+
+	// The text presentation format written by MarshalJSON always has fully
+	// qualified (dot-terminated) target hostnames, so no origin is needed to
+	// resolve relative names here.
+	rd, err := MyNewData(typeNum, recj.RDATA, "")
+	if err != nil {
+		return fmt.Errorf("UnmarshalJSON: record %q (type %s): %w", rc.Name, rc.Type, err)
+	}
+	rc.SetRDATA(rd)
+	return nil
 }
 
 // FixPosition takes the string representation of a position in a file that

--- a/models/record_json_test.go
+++ b/models/record_json_test.go
@@ -1,0 +1,89 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	dnsv2 "codeberg.org/miekg/dns"
+	"github.com/DNSControl/dnscontrol/v5/pkg/privatetypes"
+)
+
+// TestRecordConfigJSONRoundTrip verifies that marshaling a RecordConfig to
+// JSON (the IR format used by `print-ir`) and unmarshaling it back produces
+// an equivalent RDATA. This guards against
+// https://github.com/DNSControl/dnscontrol/issues/4854, where .rdata was
+// silently dropped on unmarshal because it is an unexported field typed as
+// the dnsv2.RDATA interface. RDATA.String()/MyNewData() are used to read
+// it back, which also covers types like SVCB whose RDATA embeds further
+// interfaces (svcb.Pair) with no generic JSON-object representation.
+func TestRecordConfigJSONRoundTrip(t *testing.T) {
+	dc := MustNewDomainConfig("example.com")
+
+	tests := []struct {
+		name string
+		rc   *RecordConfig
+	}{
+		{"A", dc.MustNewRecordConfig("@", 300, dnsv2.TypeA, "1.2.3.4")},
+		{"MX", dc.MustNewRecordConfig("@", 300, dnsv2.TypeMX, 10, "mail.example.com.")},
+		{"TXT", dc.MustNewRecordConfig("@", 300, dnsv2.TypeTXT, "hello world")},
+		{"CAA", dc.MustNewRecordConfig("@", 300, dnsv2.TypeCAA, 0, "issue", "letsencrypt.org")},
+		{"SRV", dc.MustNewRecordConfig("@", 300, dnsv2.TypeSRV, 10, 20, 5060, "sip.example.com.")},
+		{"SVCB", dc.MustNewRecordConfig("@", 300, dnsv2.TypeSVCB, 1, ".", "alpn=h2,h3")},
+		{"CLOUDFLAREAPI_SINGLE_REDIRECT", dc.MustNewRecordConfig("@", 300, privatetypes.TypeCLOUDFLAREAPISINGLEREDIRECT, "name", 301, "when", "then")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			original := tc.rc
+
+			data, err := json.Marshal(original)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+
+			var got RecordConfig
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+
+			if got.GetRDATA() == nil {
+				t.Fatalf("RDATA is nil after round-trip; want %+v", original.GetRDATA())
+			}
+
+			wantStr := original.GetRDATA().String()
+			gotStr := got.GetRDATA().String()
+			if gotStr != wantStr {
+				t.Errorf("RDATA.String() after round-trip = %q, want %q", gotStr, wantStr)
+			}
+
+			if got.TypeNum != original.TypeNum {
+				t.Errorf("TypeNum after round-trip = %d, want %d", got.TypeNum, original.TypeNum)
+			}
+			if got.Type != original.Type {
+				t.Errorf("Type after round-trip = %q, want %q", got.Type, original.Type)
+			}
+
+			// Marshaling the round-tripped record should reproduce the same JSON.
+			data2, err := json.Marshal(&got)
+			if err != nil {
+				t.Fatalf("re-Marshal: %v", err)
+			}
+			if string(data2) != string(data) {
+				t.Errorf("re-marshaled JSON differs:\n got=%s\nwant=%s", data2, data)
+			}
+		})
+	}
+}
+
+// TestRecordConfigJSONUnmarshalMissingRDATA verifies that a record missing
+// its "rdata" object fails to unmarshal with a clear error instead of
+// silently producing a record with nil RDATA that panics later.
+func TestRecordConfigJSONUnmarshalMissingRDATA(t *testing.T) {
+	data := []byte(`{"typenum":1,"type":"A","name":"@","ttl":300}`)
+
+	var rc RecordConfig
+	err := json.Unmarshal(data, &rc)
+	if err == nil {
+		t.Fatalf("expected an error for a record missing rdata, got nil (RDATA=%+v)", rc.GetRDATA())
+	}
+}

--- a/pkg/js/parse_tests/001-basic.json
+++ b/pkg/js/parse_tests/001-basic.json
@@ -17,9 +17,7 @@
           "filepos": "[line:5:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/002-ttl.json
+++ b/pkg/js/parse_tests/002-ttl.json
@@ -17,9 +17,7 @@
           "filepos": "[line:5:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 42,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/003-meta.json
+++ b/pkg/js/parse_tests/003-meta.json
@@ -13,9 +13,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/004-ips.json
+++ b/pkg/js/parse_tests/004-ips.json
@@ -17,9 +17,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -29,9 +27,7 @@
           "filepos": "[line:8:5]",
           "name": "p1",
           "name_unicode": "p1",
-          "rdata": {
-            "Addr": "1.2.3.5"
-          },
+          "rdata": "1.2.3.5",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -41,9 +37,7 @@
           "filepos": "[line:9:5]",
           "name": "p255",
           "name_unicode": "p255",
-          "rdata": {
-            "Addr": "1.2.4.3"
-          },
+          "rdata": "1.2.4.3",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -53,9 +47,7 @@
           "filepos": "[line:12:5]",
           "name": "yyy",
           "name_unicode": "yyy",
-          "rdata": {
-            "Addr": "190.2.3.4"
-          },
+          "rdata": "190.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/006-transforms.json
+++ b/pkg/js/parse_tests/006-transforms.json
@@ -20,9 +20,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "3.3.3.3"
-          },
+          "rdata": "3.3.3.3",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -35,9 +33,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "4.4.4.4"
-          },
+          "rdata": "4.4.4.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -50,9 +46,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "5.5.5.5"
-          },
+          "rdata": "5.5.5.5",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/007-importTransformTTL.json
+++ b/pkg/js/parse_tests/007-importTransformTTL.json
@@ -10,9 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "bar",
           "name_unicode": "bar",
-          "rdata": {
-            "Addr": "1.1.1.1"
-          },
+          "rdata": "1.1.1.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -22,9 +20,7 @@
           "filepos": "[line:3:5]",
           "name": "foo",
           "name_unicode": "foo",
-          "rdata": {
-            "Addr": "5.5.5.5"
-          },
+          "rdata": "5.5.5.5",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -42,9 +38,7 @@
           "filepos": "[line:2:5]",
           "name": "bar.foo1.com",
           "name_unicode": "bar",
-          "rdata": {
-            "Addr": "4.4.4.101"
-          },
+          "rdata": "4.4.4.101",
           "ttl": 60,
           "type": "A",
           "typenum": 1
@@ -54,9 +48,7 @@
           "filepos": "[line:3:5]",
           "name": "foo.foo1.com",
           "name_unicode": "foo",
-          "rdata": {
-            "Addr": "6.6.6.3"
-          },
+          "rdata": "6.6.6.3",
           "ttl": 60,
           "type": "A",
           "typenum": 1
@@ -74,9 +66,7 @@
           "filepos": "[line:2:5]",
           "name": "bar.foo1",
           "name_unicode": "bar",
-          "rdata": {
-            "Addr": "1.1.1.1"
-          },
+          "rdata": "1.1.1.1",
           "ttl": 99,
           "type": "A",
           "typenum": 1
@@ -86,9 +76,7 @@
           "filepos": "[line:3:5]",
           "name": "foo.foo1",
           "name_unicode": "foo",
-          "rdata": {
-            "Addr": "7.7.7.7"
-          },
+          "rdata": "7.7.7.7",
           "ttl": 99,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/008-import.json
+++ b/pkg/js/parse_tests/008-import.json
@@ -10,9 +10,7 @@
           "filepos": "[line:1:1]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/010-alias.json
+++ b/pkg/js/parse_tests/010-alias.json
@@ -10,9 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Target": "foo.com."
-          },
+          "rdata": "foo.com.",
           "ttl": 300,
           "type": "ALIAS",
           "typenum": 65285

--- a/pkg/js/parse_tests/011-cfRedirect.json
+++ b/pkg/js/parse_tests/011-cfRedirect.json
@@ -10,14 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 301,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "301,test1.foo.com,https://goo.com/$1",
-            "SRThen": "concat(\"https://goo.com\", http.request.uri.path)",
-            "SRWhen": "http.host eq \"test1.foo.com\" and http.request.uri.path eq \"/\""
-          },
+          "rdata": "\"301,test1.foo.com,https://goo.com/$1\" 301 \"http.host eq \\\"test1.foo.com\\\" and http.request.uri.path eq \\\"/\\\"\" \"concat(\\\"https://goo.com\\\", http.request.uri.path)\"",
           "ttl": 1,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289
@@ -27,14 +20,7 @@
           "filepos": "[line:3:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 302,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "302,test2.foo.com,https://goo.com/$1",
-            "SRThen": "concat(\"https://goo.com\", http.request.uri.path)",
-            "SRWhen": "http.host eq \"test2.foo.com\" and http.request.uri.path eq \"/\""
-          },
+          "rdata": "\"302,test2.foo.com,https://goo.com/$1\" 302 \"http.host eq \\\"test2.foo.com\\\" and http.request.uri.path eq \\\"/\\\"\" \"concat(\\\"https://goo.com\\\", http.request.uri.path)\"",
           "ttl": 1,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289

--- a/pkg/js/parse_tests/012-duration.json
+++ b/pkg/js/parse_tests/012-duration.json
@@ -10,9 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -22,9 +20,7 @@
           "filepos": "[line:3:5]",
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Addr": "1.2.3.5"
-          },
+          "rdata": "1.2.3.5",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -34,9 +30,7 @@
           "filepos": "[line:4:5]",
           "name": "b",
           "name_unicode": "b",
-          "rdata": {
-            "Addr": "1.2.3.6"
-          },
+          "rdata": "1.2.3.6",
           "ttl": 180,
           "type": "A",
           "typenum": 1
@@ -46,9 +40,7 @@
           "filepos": "[line:5:5]",
           "name": "c",
           "name_unicode": "c",
-          "rdata": {
-            "Addr": "1.2.3.7"
-          },
+          "rdata": "1.2.3.7",
           "ttl": 10800,
           "type": "A",
           "typenum": 1
@@ -58,9 +50,7 @@
           "filepos": "[line:6:5]",
           "name": "d",
           "name_unicode": "d",
-          "rdata": {
-            "Addr": "1.2.3.8"
-          },
+          "rdata": "1.2.3.8",
           "ttl": 259200,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/013-mx.json
+++ b/pkg/js/parse_tests/013-mx.json
@@ -10,10 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Mx": "foo.com.",
-            "Preference": 15
-          },
+          "rdata": "15 foo.com.",
           "ttl": 300,
           "type": "MX",
           "typenum": 15

--- a/pkg/js/parse_tests/014-caa.json
+++ b/pkg/js/parse_tests/014-caa.json
@@ -10,11 +10,7 @@
           "filepos": "[line:12:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flag": 128,
-            "Tag": "iodef",
-            "Value": "https://example.com"
-          },
+          "rdata": "128 iodef \"https://example.com\"",
           "ttl": 300,
           "type": "CAA",
           "typenum": 257
@@ -24,11 +20,7 @@
           "filepos": "[line:8:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flag": 128,
-            "Tag": "iodef",
-            "Value": "mailto:test@example.com"
-          },
+          "rdata": "128 iodef \"mailto:test@example.com\"",
           "ttl": 300,
           "type": "CAA",
           "typenum": 257
@@ -38,11 +30,7 @@
           "filepos": "[line:10:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flag": 0,
-            "Tag": "iodef",
-            "Value": "http://example.com"
-          },
+          "rdata": "0 iodef \"http://example.com\"",
           "ttl": 300,
           "type": "CAA",
           "typenum": 257
@@ -52,11 +40,7 @@
           "filepos": "[line:3:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flag": 0,
-            "Tag": "issue",
-            "Value": "letsencrypt.org"
-          },
+          "rdata": "0 issue \"letsencrypt.org\"",
           "ttl": 300,
           "type": "CAA",
           "typenum": 257
@@ -66,11 +50,7 @@
           "filepos": "[line:5:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flag": 0,
-            "Tag": "issuewild",
-            "Value": ";"
-          },
+          "rdata": "0 issuewild \";\"",
           "ttl": 300,
           "type": "CAA",
           "typenum": 257

--- a/pkg/js/parse_tests/015-tlsa.json
+++ b/pkg/js/parse_tests/015-tlsa.json
@@ -10,12 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "_443._tcp",
           "name_unicode": "_443._tcp",
-          "rdata": {
-            "Certificate": "MDFIYTQ3MTLJODBINMZLOTEXYJA5MWE3YZA1MTI0YJY0ZWVLY2U5NJRLMDLJMDU4ZWY4ZJK4MDVKYWNHNTQ2YIAGLQO=",
-            "MatchingType": 1,
-            "Selector": 1,
-            "Usage": 3
-          },
+          "rdata": "3 1 1 MDFIYTQ3MTLJODBINMZLOTEXYJA5MWE3YZA1MTI0YJY0ZWVLY2U5NJRLMDLJMDU4ZWY4ZJK4MDVKYWNHNTQ2YIAGLQO=",
           "ttl": 300,
           "type": "TLSA",
           "typenum": 52

--- a/pkg/js/parse_tests/017-txt.json
+++ b/pkg/js/parse_tests/017-txt.json
@@ -10,11 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Txt": [
-              "simple"
-            ]
-          },
+          "rdata": "\"simple\"",
           "ttl": 300,
           "type": "TXT",
           "typenum": 16
@@ -24,11 +20,7 @@
           "filepos": "[line:3:5]",
           "name": "b",
           "name_unicode": "b",
-          "rdata": {
-            "Txt": [
-              "ws at end "
-            ]
-          },
+          "rdata": "\"ws at end \"",
           "ttl": 300,
           "type": "TXT",
           "typenum": 16
@@ -38,11 +30,7 @@
           "filepos": "[line:4:5]",
           "name": "c",
           "name_unicode": "c",
-          "rdata": {
-            "Txt": [
-              "one"
-            ]
-          },
+          "rdata": "\"one\"",
           "ttl": 300,
           "type": "TXT",
           "typenum": 16
@@ -52,11 +40,7 @@
           "filepos": "[line:5:5]",
           "name": "d",
           "name_unicode": "d",
-          "rdata": {
-            "Txt": [
-              "bonieclyde"
-            ]
-          },
+          "rdata": "\"bonieclyde\"",
           "ttl": 300,
           "type": "TXT",
           "typenum": 16
@@ -66,11 +50,7 @@
           "filepos": "[line:6:5]",
           "name": "e",
           "name_unicode": "e",
-          "rdata": {
-            "Txt": [
-              "strawwoodbrick"
-            ]
-          },
+          "rdata": "\"strawwoodbrick\"",
           "ttl": 300,
           "type": "TXT",
           "typenum": 16

--- a/pkg/js/parse_tests/018-dkim.json
+++ b/pkg/js/parse_tests/018-dkim.json
@@ -10,12 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "dkimtest2",
           "name_unicode": "dkimtest2",
-          "rdata": {
-            "Txt": [
-              "this string is 255 bytes long.hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnKZogtjOlHoeY8iZ5o5brlPOsj/a2Q9Bopu1kHxlxrdw7tZVL9FzUMngiIYGrl8dbP7Rvk7TLMoxHxVkRZPBtIpsKIab/gOUoPLQVYbrAmzyguHYBwAApi3H/pvjUsK8+XF0dKY17AR96lokAPqvfBaUb+DSx8zNw2hrYWYVqvCtnxHUGEUhT1bTlEZBptH3j",
-              "this is the remainder. it is 156 bytes long.mOhl2JmbsFKy+RoMTwbkk0/meRvcEFWLHkr4MSgbnie6OpQvM4Y51+kO6DUVr3rwjrdVO9wpFt+n/hdQ92TNif17RMJtE5AGaQ6BN3yJQIDAQAB;"
-            ]
-          },
+          "rdata": "\"this string is 255 bytes long.hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnKZogtjOlHoeY8iZ5o5brlPOsj/a2Q9Bopu1kHxlxrdw7tZVL9FzUMngiIYGrl8dbP7Rvk7TLMoxHxVkRZPBtIpsKIab/gOUoPLQVYbrAmzyguHYBwAApi3H/pvjUsK8+XF0dKY17AR96lokAPqvfBaUb+DSx8zNw2hrYWYVqvCtnxHUGEUhT1bTlEZBptH3j\" \"this is the remainder. it is 156 bytes long.mOhl2JmbsFKy+RoMTwbkk0/meRvcEFWLHkr4MSgbnie6OpQvM4Y51+kO6DUVr3rwjrdVO9wpFt+n/hdQ92TNif17RMJtE5AGaQ6BN3yJQIDAQAB;\"",
           "ttl": 300,
           "type": "TXT",
           "typenum": 16

--- a/pkg/js/parse_tests/019-r53-alias.json
+++ b/pkg/js/parse_tests/019-r53-alias.json
@@ -13,12 +13,7 @@
           },
           "name": "aaaatest",
           "name_unicode": "aaaatest",
-          "rdata": {
-            "AliasType": "AAAA",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "AAAA foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -31,12 +26,7 @@
           },
           "name": "aaaatest",
           "name_unicode": "aaaatest",
-          "rdata": {
-            "AliasType": "AAAA",
-            "EvalTargetHealth": "false",
-            "Target": "foo.com.",
-            "ZoneID": "ERERTFGFGF"
-          },
+          "rdata": "AAAA foo.com. false ERERTFGFGF",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -49,12 +39,7 @@
           },
           "name": "aevaltargethealthtest",
           "name_unicode": "aevaltargethealthtest",
-          "rdata": {
-            "AliasType": "A",
-            "EvalTargetHealth": "true",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "A foo.com. true \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -67,12 +52,7 @@
           },
           "name": "aevaltargethealthtest2",
           "name_unicode": "aevaltargethealthtest2",
-          "rdata": {
-            "AliasType": "A",
-            "EvalTargetHealth": "false",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "A foo.com. false \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -85,12 +65,7 @@
           },
           "name": "atest",
           "name_unicode": "atest",
-          "rdata": {
-            "AliasType": "A",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "A foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -103,12 +78,7 @@
           },
           "name": "atest",
           "name_unicode": "atest",
-          "rdata": {
-            "AliasType": "A",
-            "EvalTargetHealth": "false",
-            "Target": "foo.com.",
-            "ZoneID": "Z2FTEDLFRTF"
-          },
+          "rdata": "A foo.com. false Z2FTEDLFRTF",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -121,12 +91,7 @@
           },
           "name": "caatest",
           "name_unicode": "caatest",
-          "rdata": {
-            "AliasType": "CAA",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "CAA foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -139,12 +104,7 @@
           },
           "name": "cftest",
           "name_unicode": "cftest",
-          "rdata": {
-            "AliasType": "A",
-            "EvalTargetHealth": "",
-            "Target": "d111111abcdef8.cloudfront.net.",
-            "ZoneID": ""
-          },
+          "rdata": "A d111111abcdef8.cloudfront.net. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -157,12 +117,7 @@
           },
           "name": "cfzonetest",
           "name_unicode": "cfzonetest",
-          "rdata": {
-            "AliasType": "A",
-            "EvalTargetHealth": "false",
-            "Target": "d222222abcdef8.cloudfront.net.",
-            "ZoneID": "Z2FDTNDATAQYW2"
-          },
+          "rdata": "A d222222abcdef8.cloudfront.net. false Z2FDTNDATAQYW2",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -175,12 +130,7 @@
           },
           "name": "cnametest",
           "name_unicode": "cnametest",
-          "rdata": {
-            "AliasType": "CNAME",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "CNAME foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -193,12 +143,7 @@
           },
           "name": "dstest",
           "name_unicode": "dstest",
-          "rdata": {
-            "AliasType": "DS",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "DS foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -211,12 +156,7 @@
           },
           "name": "httpstest",
           "name_unicode": "httpstest",
-          "rdata": {
-            "AliasType": "HTTPS",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "HTTPS foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -229,12 +169,7 @@
           },
           "name": "mxtest",
           "name_unicode": "mxtest",
-          "rdata": {
-            "AliasType": "MX",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "MX foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -247,12 +182,7 @@
           },
           "name": "naptrtest",
           "name_unicode": "naptrtest",
-          "rdata": {
-            "AliasType": "NAPTR",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "NAPTR foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -265,12 +195,7 @@
           },
           "name": "ptrtest",
           "name_unicode": "ptrtest",
-          "rdata": {
-            "AliasType": "PTR",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "PTR foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -283,12 +208,7 @@
           },
           "name": "soatest",
           "name_unicode": "soatest",
-          "rdata": {
-            "AliasType": "SOA",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "SOA foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -301,12 +221,7 @@
           },
           "name": "spftest",
           "name_unicode": "spftest",
-          "rdata": {
-            "AliasType": "SPF",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "SPF foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -319,12 +234,7 @@
           },
           "name": "srvtest",
           "name_unicode": "srvtest",
-          "rdata": {
-            "AliasType": "SRV",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "SRV foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -337,12 +247,7 @@
           },
           "name": "sshfptest",
           "name_unicode": "sshfptest",
-          "rdata": {
-            "AliasType": "SSHFP",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "SSHFP foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -355,12 +260,7 @@
           },
           "name": "svcbtest",
           "name_unicode": "svcbtest",
-          "rdata": {
-            "AliasType": "SVCB",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "SVCB foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -373,12 +273,7 @@
           },
           "name": "tlsatest",
           "name_unicode": "tlsatest",
-          "rdata": {
-            "AliasType": "TLSA",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "TLSA foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298
@@ -391,12 +286,7 @@
           },
           "name": "txttest",
           "name_unicode": "txttest",
-          "rdata": {
-            "AliasType": "TXT",
-            "EvalTargetHealth": "",
-            "Target": "foo.com.",
-            "ZoneID": ""
-          },
+          "rdata": "TXT foo.com. \"\" \"\"",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298

--- a/pkg/js/parse_tests/020-complexRequire.json
+++ b/pkg/js/parse_tests/020-complexRequire.json
@@ -10,9 +10,7 @@
           "filepos": "[line:1:1]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -22,9 +20,7 @@
           "filepos": "[line:1:1]",
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Target": "foo.com."
-          },
+          "rdata": "foo.com.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -34,9 +30,7 @@
           "filepos": "[line:1:1]",
           "name": "b",
           "name_unicode": "b",
-          "rdata": {
-            "Target": "foo.com."
-          },
+          "rdata": "foo.com.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -46,9 +40,7 @@
           "filepos": "[line:1:1]",
           "name": "c",
           "name_unicode": "c",
-          "rdata": {
-            "Target": "foo.com."
-          },
+          "rdata": "foo.com.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -58,9 +50,7 @@
           "filepos": "[line:1:1]",
           "name": "d",
           "name_unicode": "d",
-          "rdata": {
-            "Target": "foo.com."
-          },
+          "rdata": "foo.com.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5

--- a/pkg/js/parse_tests/021-srv.json
+++ b/pkg/js/parse_tests/021-srv.json
@@ -10,12 +10,7 @@
           "filepos": "[line:6:5]",
           "name": "_ntp._udp",
           "name_unicode": "_ntp._udp",
-          "rdata": {
-            "Port": 1,
-            "Priority": 0,
-            "Target": "zeros.foo.com.",
-            "Weight": 0
-          },
+          "rdata": "0 0 1 zeros.foo.com.",
           "ttl": 300,
           "type": "SRV",
           "typenum": 33
@@ -25,12 +20,7 @@
           "filepos": "[line:2:5]",
           "name": "_ntp._udp",
           "name_unicode": "_ntp._udp",
-          "rdata": {
-            "Port": 123,
-            "Priority": 1,
-            "Target": "one.foo.com.",
-            "Weight": 100
-          },
+          "rdata": "1 100 123 one.foo.com.",
           "ttl": 300,
           "type": "SRV",
           "typenum": 33
@@ -40,12 +30,7 @@
           "filepos": "[line:3:5]",
           "name": "_ntp._udp",
           "name_unicode": "_ntp._udp",
-          "rdata": {
-            "Port": 123,
-            "Priority": 2,
-            "Target": "two.foo.com.",
-            "Weight": 100
-          },
+          "rdata": "2 100 123 two.foo.com.",
           "ttl": 300,
           "type": "SRV",
           "typenum": 33
@@ -55,12 +40,7 @@
           "filepos": "[line:4:5]",
           "name": "_ntp._udp",
           "name_unicode": "_ntp._udp",
-          "rdata": {
-            "Port": 123,
-            "Priority": 3,
-            "Target": "localhost.foo.com.",
-            "Weight": 100
-          },
+          "rdata": "3 100 123 localhost.foo.com.",
           "ttl": 300,
           "type": "SRV",
           "typenum": 33
@@ -70,12 +50,7 @@
           "filepos": "[line:5:5]",
           "name": "_ntp._udp",
           "name_unicode": "_ntp._udp",
-          "rdata": {
-            "Port": 123,
-            "Priority": 4,
-            "Target": "three.example.com.",
-            "Weight": 100
-          },
+          "rdata": "4 100 123 three.example.com.",
           "ttl": 300,
           "type": "SRV",
           "typenum": 33

--- a/pkg/js/parse_tests/022-sshfp.json
+++ b/pkg/js/parse_tests/022-sshfp.json
@@ -10,11 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 1,
-            "FingerPrint": "66C7D5540B7D75A1FB4C84FEBFA178AD99BDD67C",
-            "Type": 1
-          },
+          "rdata": "1 1 66C7D5540B7D75A1FB4C84FEBFA178AD99BDD67C",
           "ttl": 300,
           "type": "SSHFP",
           "typenum": 44
@@ -24,11 +20,7 @@
           "filepos": "[line:3:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 1,
-            "FingerPrint": "745A635BC46A397A5C4F21D437483005BCC40D7511FF15FBFAFE913A081559BC",
-            "Type": 2
-          },
+          "rdata": "1 2 745A635BC46A397A5C4F21D437483005BCC40D7511FF15FBFAFE913A081559BC",
           "ttl": 300,
           "type": "SSHFP",
           "typenum": 44
@@ -38,11 +30,7 @@
           "filepos": "[line:4:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 2,
-            "FingerPrint": "66C7D5540B7D75A1FB4C84FEBFA178AD99BDD67C",
-            "Type": 1
-          },
+          "rdata": "2 1 66C7D5540B7D75A1FB4C84FEBFA178AD99BDD67C",
           "ttl": 300,
           "type": "SSHFP",
           "typenum": 44
@@ -52,11 +40,7 @@
           "filepos": "[line:5:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 2,
-            "FingerPrint": "745A635BC46A397A5C4F21D437483005BCC40D7511FF15FBFAFE913A081559BC",
-            "Type": 2
-          },
+          "rdata": "2 2 745A635BC46A397A5C4F21D437483005BCC40D7511FF15FBFAFE913A081559BC",
           "ttl": 300,
           "type": "SSHFP",
           "typenum": 44
@@ -66,11 +50,7 @@
           "filepos": "[line:6:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 3,
-            "FingerPrint": "66C7D5540B7D75A1FB4C84FEBFA178AD99BDD67C",
-            "Type": 1
-          },
+          "rdata": "3 1 66C7D5540B7D75A1FB4C84FEBFA178AD99BDD67C",
           "ttl": 300,
           "type": "SSHFP",
           "typenum": 44
@@ -80,11 +60,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 3,
-            "FingerPrint": "745A635BC46A397A5C4F21D437483005BCC40D7511FF15FBFAFE913A081559BC",
-            "Type": 2
-          },
+          "rdata": "3 2 745A635BC46A397A5C4F21D437483005BCC40D7511FF15FBFAFE913A081559BC",
           "ttl": 300,
           "type": "SSHFP",
           "typenum": 44
@@ -94,11 +70,7 @@
           "filepos": "[line:8:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 4,
-            "FingerPrint": "66C7D5540B7D75A1FB4C84FEBFA178AD99BDD67C",
-            "Type": 1
-          },
+          "rdata": "4 1 66C7D5540B7D75A1FB4C84FEBFA178AD99BDD67C",
           "ttl": 300,
           "type": "SSHFP",
           "typenum": 44
@@ -108,11 +80,7 @@
           "filepos": "[line:9:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 4,
-            "FingerPrint": "745A635BC46A397A5C4F21D437483005BCC40D7511FF15FBFAFE913A081559BC",
-            "Type": 2
-          },
+          "rdata": "4 2 745A635BC46A397A5C4F21D437483005BCC40D7511FF15FBFAFE913A081559BC",
           "ttl": 300,
           "type": "SSHFP",
           "typenum": 44

--- a/pkg/js/parse_tests/024-json-import.json
+++ b/pkg/js/parse_tests/024-json-import.json
@@ -10,9 +10,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.1.1.1"
-          },
+          "rdata": "1.1.1.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/026-azure-alias.json
+++ b/pkg/js/parse_tests/026-azure-alias.json
@@ -13,10 +13,7 @@
           },
           "name": "aaaatest",
           "name_unicode": "aaaatest",
-          "rdata": {
-            "AliasType": "AAAA",
-            "Target": "foo.com."
-          },
+          "rdata": "AAAA foo.com.",
           "ttl": 300,
           "type": "AZURE_ALIAS",
           "typenum": 65286
@@ -29,10 +26,7 @@
           },
           "name": "atest",
           "name_unicode": "atest",
-          "rdata": {
-            "AliasType": "A",
-            "Target": "foo.com."
-          },
+          "rdata": "A foo.com.",
           "ttl": 300,
           "type": "AZURE_ALIAS",
           "typenum": 65286
@@ -45,10 +39,7 @@
           },
           "name": "cnametest",
           "name_unicode": "cnametest",
-          "rdata": {
-            "AliasType": "CNAME",
-            "Target": "foo.com."
-          },
+          "rdata": "CNAME foo.com.",
           "ttl": 300,
           "type": "AZURE_ALIAS",
           "typenum": 65286

--- a/pkg/js/parse_tests/027-ds.json
+++ b/pkg/js/parse_tests/027-ds.json
@@ -10,12 +10,7 @@
           "filepos": "[line:3:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 1,
-            "Digest": "FFFF",
-            "DigestType": 1,
-            "KeyTag": 1
-          },
+          "rdata": "1 1 1 FFFF",
           "ttl": 300,
           "type": "DS",
           "typenum": 43
@@ -25,12 +20,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 13,
-            "Digest": "AABBCCDDEEFF",
-            "DigestType": 2,
-            "KeyTag": 1000
-          },
+          "rdata": "1000 13 2 AABBCCDDEEFF",
           "ttl": 300,
           "type": "DS",
           "typenum": 43

--- a/pkg/js/parse_tests/028-dextend.json
+++ b/pkg/js/parse_tests/028-dextend.json
@@ -17,9 +17,7 @@
           "filepos": "[line:6:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "10.1.1.1"
-          },
+          "rdata": "10.1.1.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -29,9 +27,7 @@
           "filepos": "[line:7:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "10.2.2.2"
-          },
+          "rdata": "10.2.2.2",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -51,9 +47,7 @@
           "filepos": "[line:10:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "10.3.3.3"
-          },
+          "rdata": "10.3.3.3",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -63,9 +57,7 @@
           "filepos": "[line:11:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "10.4.4.4"
-          },
+          "rdata": "10.4.4.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -85,9 +77,7 @@
           "filepos": "[line:16:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "10.5.5.5"
-          },
+          "rdata": "10.5.5.5",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -97,9 +87,7 @@
           "filepos": "[line:20:5]",
           "name": "more1",
           "name_unicode": "more1",
-          "rdata": {
-            "Addr": "10.7.7.7"
-          },
+          "rdata": "10.7.7.7",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -109,9 +97,7 @@
           "filepos": "[line:21:5]",
           "name": "more2",
           "name_unicode": "more2",
-          "rdata": {
-            "Addr": "10.8.8.8"
-          },
+          "rdata": "10.8.8.8",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -121,9 +107,7 @@
           "filepos": "[line:17:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "10.6.6.6"
-          },
+          "rdata": "10.6.6.6",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/029-dextendsub.json
+++ b/pkg/js/parse_tests/029-dextendsub.json
@@ -17,9 +17,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "10.1.1.1"
-          },
+          "rdata": "10.1.1.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -29,9 +27,7 @@
           "filepos": "[line:11:5]",
           "name": "bar",
           "name_unicode": "bar",
-          "rdata": {
-            "Addr": "10.3.3.3"
-          },
+          "rdata": "10.3.3.3",
           "subdomain": "bar",
           "ttl": 300,
           "type": "A",
@@ -42,9 +38,7 @@
           "filepos": "[line:12:5]",
           "name": "www.bar",
           "name_unicode": "www.bar",
-          "rdata": {
-            "Addr": "10.4.4.4"
-          },
+          "rdata": "10.4.4.4",
           "subdomain": "bar",
           "ttl": 300,
           "type": "A",
@@ -55,9 +49,7 @@
           "filepos": "[line:70:5]",
           "name": "a.long.path.of.sub.domains",
           "name_unicode": "a.long.path.of.sub.domains",
-          "rdata": {
-            "Addr": "10.25.25.25"
-          },
+          "rdata": "10.25.25.25",
           "subdomain": "a.long.path.of.sub.domains",
           "ttl": 300,
           "type": "A",
@@ -68,9 +60,7 @@
           "filepos": "[line:71:5]",
           "name": "www.a.long.path.of.sub.domains",
           "name_unicode": "www.a.long.path.of.sub.domains",
-          "rdata": {
-            "Addr": "10.26.26.26"
-          },
+          "rdata": "10.26.26.26",
           "subdomain": "a.long.path.of.sub.domains",
           "ttl": 300,
           "type": "A",
@@ -81,9 +71,7 @@
           "filepos": "[line:8:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "10.2.2.2"
-          },
+          "rdata": "10.2.2.2",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -103,9 +91,7 @@
           "filepos": "[line:18:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "20.5.5.5"
-          },
+          "rdata": "20.5.5.5",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -115,9 +101,7 @@
           "filepos": "[line:30:5]",
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Addr": "20.10.10.10"
-          },
+          "rdata": "20.10.10.10",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -127,9 +111,7 @@
           "filepos": "[line:19:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "20.6.6.6"
-          },
+          "rdata": "20.6.6.6",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -149,9 +131,7 @@
           "filepos": "[line:23:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "30.7.7.7"
-          },
+          "rdata": "30.7.7.7",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -161,9 +141,7 @@
           "filepos": "[line:27:5]",
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Addr": "30.9.9.9"
-          },
+          "rdata": "30.9.9.9",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -173,9 +151,7 @@
           "filepos": "[line:24:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "30.8.8.8"
-          },
+          "rdata": "30.8.8.8",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -195,9 +171,7 @@
           "filepos": "[line:36:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "40.12.12.12"
-          },
+          "rdata": "40.12.12.12",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -207,9 +181,7 @@
           "filepos": "[line:49:5]",
           "name": "morty",
           "name_unicode": "morty",
-          "rdata": {
-            "Addr": "40.17.17.17"
-          },
+          "rdata": "40.17.17.17",
           "subdomain": "morty",
           "ttl": 300,
           "type": "A",
@@ -220,9 +192,7 @@
           "filepos": "[line:50:5]",
           "name": "www.morty",
           "name_unicode": "www.morty",
-          "rdata": {
-            "Addr": "40.18.18.18"
-          },
+          "rdata": "40.18.18.18",
           "subdomain": "morty",
           "ttl": 300,
           "type": "A",
@@ -233,9 +203,7 @@
           "filepos": "[line:37:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "40.12.12.12"
-          },
+          "rdata": "40.12.12.12",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -255,9 +223,7 @@
           "filepos": "[line:41:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "50.13.13.13"
-          },
+          "rdata": "50.13.13.13",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -267,9 +233,7 @@
           "filepos": "[line:42:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "50.14.14.14"
-          },
+          "rdata": "50.14.14.14",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -279,9 +243,7 @@
           "filepos": "[line:45:5]",
           "name": "zip",
           "name_unicode": "zip",
-          "rdata": {
-            "Addr": "50.15.15.15"
-          },
+          "rdata": "50.15.15.15",
           "subdomain": "zip",
           "ttl": 300,
           "type": "A",
@@ -292,9 +254,7 @@
           "filepos": "[line:46:5]",
           "name": "www.zip",
           "name_unicode": "www.zip",
-          "rdata": {
-            "Addr": "50.16.16.16"
-          },
+          "rdata": "50.16.16.16",
           "subdomain": "zip",
           "ttl": 300,
           "type": "A",
@@ -315,9 +275,7 @@
           "filepos": "[line:56:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "60.19.19.19"
-          },
+          "rdata": "60.19.19.19",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -327,9 +285,7 @@
           "filepos": "[line:60:5]",
           "name": "bar",
           "name_unicode": "bar",
-          "rdata": {
-            "Addr": "60.21.21.21"
-          },
+          "rdata": "60.21.21.21",
           "subdomain": "bar",
           "ttl": 300,
           "type": "A",
@@ -340,9 +296,7 @@
           "filepos": "[line:64:5]",
           "name": "baz.bar",
           "name_unicode": "baz.bar",
-          "rdata": {
-            "Addr": "60.23.23.23"
-          },
+          "rdata": "60.23.23.23",
           "subdomain": "baz.bar",
           "ttl": 300,
           "type": "A",
@@ -353,9 +307,7 @@
           "filepos": "[line:65:5]",
           "name": "www.baz.bar",
           "name_unicode": "www.baz.bar",
-          "rdata": {
-            "Addr": "60.24.24.24"
-          },
+          "rdata": "60.24.24.24",
           "subdomain": "baz.bar",
           "ttl": 300,
           "type": "A",
@@ -366,9 +318,7 @@
           "filepos": "[line:61:5]",
           "name": "www.bar",
           "name_unicode": "www.bar",
-          "rdata": {
-            "Addr": "60.22.22.22"
-          },
+          "rdata": "60.22.22.22",
           "subdomain": "bar",
           "ttl": 300,
           "type": "A",
@@ -379,9 +329,7 @@
           "filepos": "[line:57:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "60.20.20.20"
-          },
+          "rdata": "60.20.20.20",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -401,9 +349,7 @@
           "filepos": "[line:77:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "10.0.0.1"
-          },
+          "rdata": "10.0.0.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -413,9 +359,7 @@
           "filepos": "[line:78:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "10.0.0.2"
-          },
+          "rdata": "10.0.0.2",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -425,9 +369,7 @@
           "filepos": "[line:82:5]",
           "name": "xn--dsseldorf-q9a",
           "name_unicode": "d\u00fcsseldorf",
-          "rdata": {
-            "Addr": "10.0.0.3"
-          },
+          "rdata": "10.0.0.3",
           "subdomain": "xn--dsseldorf-q9a",
           "ttl": 300,
           "type": "A",
@@ -438,9 +380,7 @@
           "filepos": "[line:83:5]",
           "name": "www.xn--dsseldorf-q9a",
           "name_unicode": "www.d\u00fcsseldorf",
-          "rdata": {
-            "Addr": "10.0.0.4"
-          },
+          "rdata": "10.0.0.4",
           "subdomain": "xn--dsseldorf-q9a",
           "ttl": 300,
           "type": "A",
@@ -451,9 +391,7 @@
           "filepos": "[line:87:5]",
           "name": "xn--tda",
           "name_unicode": "\u00fc",
-          "rdata": {
-            "Addr": "10.0.0.5"
-          },
+          "rdata": "10.0.0.5",
           "subdomain": "xn--tda",
           "ttl": 300,
           "type": "A",
@@ -464,9 +402,7 @@
           "filepos": "[line:88:5]",
           "name": "www.xn--tda",
           "name_unicode": "www.\u00fc",
-          "rdata": {
-            "Addr": "10.0.0.6"
-          },
+          "rdata": "10.0.0.6",
           "subdomain": "xn--tda",
           "ttl": 300,
           "type": "A",
@@ -487,9 +423,7 @@
           "filepos": "[line:94:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "10.0.0.7"
-          },
+          "rdata": "10.0.0.7",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -499,9 +433,7 @@
           "filepos": "[line:99:5]",
           "name": "subdomain",
           "name_unicode": "subdomain",
-          "rdata": {
-            "Addr": "10.0.0.9"
-          },
+          "rdata": "10.0.0.9",
           "subdomain": "subdomain",
           "ttl": 300,
           "type": "A",
@@ -512,9 +444,7 @@
           "filepos": "[line:100:5]",
           "name": "www.subdomain",
           "name_unicode": "www.subdomain",
-          "rdata": {
-            "Addr": "10.0.0.10"
-          },
+          "rdata": "10.0.0.10",
           "subdomain": "subdomain",
           "ttl": 300,
           "type": "A",
@@ -525,9 +455,7 @@
           "filepos": "[line:95:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "10.0.0.8"
-          },
+          "rdata": "10.0.0.8",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -537,9 +465,7 @@
           "filepos": "[line:104:5]",
           "name": "xn--dsseltal-65a",
           "name_unicode": "d\u00fcsseltal",
-          "rdata": {
-            "Addr": "10.0.0.11"
-          },
+          "rdata": "10.0.0.11",
           "subdomain": "xn--dsseltal-65a",
           "ttl": 300,
           "type": "A",
@@ -550,9 +476,7 @@
           "filepos": "[line:105:5]",
           "name": "www.xn--dsseltal-65a",
           "name_unicode": "www.d\u00fcsseltal",
-          "rdata": {
-            "Addr": "10.0.0.12"
-          },
+          "rdata": "10.0.0.12",
           "subdomain": "xn--dsseltal-65a",
           "ttl": 300,
           "type": "A",
@@ -563,9 +487,7 @@
           "filepos": "[line:109:5]",
           "name": "xn--tda",
           "name_unicode": "\u00fc",
-          "rdata": {
-            "Addr": "10.0.0.13"
-          },
+          "rdata": "10.0.0.13",
           "subdomain": "xn--tda",
           "ttl": 300,
           "type": "A",
@@ -576,9 +498,7 @@
           "filepos": "[line:110:5]",
           "name": "www.xn--tda",
           "name_unicode": "www.\u00fc",
-          "rdata": {
-            "Addr": "10.0.0.14"
-          },
+          "rdata": "10.0.0.14",
           "subdomain": "xn--tda",
           "ttl": 300,
           "type": "A",
@@ -599,9 +519,7 @@
           "filepos": "[line:116:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "10.0.0.15"
-          },
+          "rdata": "10.0.0.15",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -611,9 +529,7 @@
           "filepos": "[line:121:5]",
           "name": "subdomain",
           "name_unicode": "subdomain",
-          "rdata": {
-            "Addr": "10.0.0.17"
-          },
+          "rdata": "10.0.0.17",
           "subdomain": "subdomain",
           "ttl": 300,
           "type": "A",
@@ -624,9 +540,7 @@
           "filepos": "[line:122:5]",
           "name": "www.subdomain",
           "name_unicode": "www.subdomain",
-          "rdata": {
-            "Addr": "10.0.0.18"
-          },
+          "rdata": "10.0.0.18",
           "subdomain": "subdomain",
           "ttl": 300,
           "type": "A",
@@ -637,9 +551,7 @@
           "filepos": "[line:117:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "10.0.0.16"
-          },
+          "rdata": "10.0.0.16",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -649,9 +561,7 @@
           "filepos": "[line:126:5]",
           "name": "xn--dsseldorf-q9a",
           "name_unicode": "d\u00fcsseldorf",
-          "rdata": {
-            "Addr": "10.0.0.19"
-          },
+          "rdata": "10.0.0.19",
           "subdomain": "xn--dsseldorf-q9a",
           "ttl": 300,
           "type": "A",
@@ -662,9 +572,7 @@
           "filepos": "[line:127:5]",
           "name": "www.xn--dsseldorf-q9a",
           "name_unicode": "www.d\u00fcsseldorf",
-          "rdata": {
-            "Addr": "10.0.0.20"
-          },
+          "rdata": "10.0.0.20",
           "subdomain": "xn--dsseldorf-q9a",
           "ttl": 300,
           "type": "A",
@@ -675,9 +583,7 @@
           "filepos": "[line:131:5]",
           "name": "xn--tda",
           "name_unicode": "\u00fc",
-          "rdata": {
-            "Addr": "10.0.0.21"
-          },
+          "rdata": "10.0.0.21",
           "subdomain": "xn--tda",
           "ttl": 300,
           "type": "A",
@@ -688,9 +594,7 @@
           "filepos": "[line:132:5]",
           "name": "www.xn--tda",
           "name_unicode": "www.\u00fc",
-          "rdata": {
-            "Addr": "10.0.0.22"
-          },
+          "rdata": "10.0.0.22",
           "subdomain": "xn--tda",
           "ttl": 300,
           "type": "A",
@@ -711,9 +615,7 @@
           "filepos": "[line:138:5]",
           "name": "a.sub",
           "name_unicode": "a.sub",
-          "rdata": {
-            "Target": "b.sub.example.tld."
-          },
+          "rdata": "b.sub.example.tld.",
           "subdomain": "sub",
           "ttl": 300,
           "type": "CNAME",
@@ -724,9 +626,7 @@
           "filepos": "[line:139:5]",
           "name": "b.sub",
           "name_unicode": "b.sub",
-          "rdata": {
-            "Target": "sub.example.tld."
-          },
+          "rdata": "sub.example.tld.",
           "subdomain": "sub",
           "ttl": 300,
           "type": "CNAME",
@@ -737,9 +637,7 @@
           "filepos": "[line:140:5]",
           "name": "c.sub",
           "name_unicode": "c.sub",
-          "rdata": {
-            "Target": "sub.example.tld."
-          },
+          "rdata": "sub.example.tld.",
           "subdomain": "sub",
           "ttl": 300,
           "type": "CNAME",
@@ -750,9 +648,7 @@
           "filepos": "[line:142:5]",
           "name": "e.sub",
           "name_unicode": "e.sub",
-          "rdata": {
-            "Target": "otherdomain.tld."
-          },
+          "rdata": "otherdomain.tld.",
           "subdomain": "sub",
           "ttl": 300,
           "type": "CNAME",

--- a/pkg/js/parse_tests/030-dextenddoc.json
+++ b/pkg/js/parse_tests/030-dextenddoc.json
@@ -17,9 +17,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "127.0.0.1"
-          },
+          "rdata": "127.0.0.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -29,9 +27,7 @@
           "filepos": "[line:9:5]",
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Target": "b.domain.tld."
-          },
+          "rdata": "b.domain.tld.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -41,9 +37,7 @@
           "filepos": "[line:12:5]",
           "name": "aaa",
           "name_unicode": "aaa",
-          "rdata": {
-            "Addr": "127.0.0.3"
-          },
+          "rdata": "127.0.0.3",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -53,9 +47,7 @@
           "filepos": "[line:13:5]",
           "name": "c",
           "name_unicode": "c",
-          "rdata": {
-            "Target": "d.domain.tld."
-          },
+          "rdata": "d.domain.tld.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -65,9 +57,7 @@
           "filepos": "[line:25:5]",
           "name": "sub",
           "name_unicode": "sub",
-          "rdata": {
-            "Addr": "127.0.0.7"
-          },
+          "rdata": "127.0.0.7",
           "subdomain": "sub",
           "ttl": 300,
           "type": "A",
@@ -78,9 +68,7 @@
           "filepos": "[line:16:5]",
           "name": "bbb.sub",
           "name_unicode": "bbb.sub",
-          "rdata": {
-            "Addr": "127.0.0.4"
-          },
+          "rdata": "127.0.0.4",
           "subdomain": "sub",
           "ttl": 300,
           "type": "A",
@@ -91,9 +79,7 @@
           "filepos": "[line:17:5]",
           "name": "ccc.sub",
           "name_unicode": "ccc.sub",
-          "rdata": {
-            "Addr": "127.0.0.5"
-          },
+          "rdata": "127.0.0.5",
           "subdomain": "sub",
           "ttl": 300,
           "type": "A",
@@ -104,9 +90,7 @@
           "filepos": "[line:18:5]",
           "name": "e.sub",
           "name_unicode": "e.sub",
-          "rdata": {
-            "Target": "f.sub.domain.tld."
-          },
+          "rdata": "f.sub.domain.tld.",
           "subdomain": "sub",
           "ttl": 300,
           "type": "CNAME",
@@ -117,9 +101,7 @@
           "filepos": "[line:26:5]",
           "name": "i.sub",
           "name_unicode": "i.sub",
-          "rdata": {
-            "Target": "j.sub.domain.tld."
-          },
+          "rdata": "j.sub.domain.tld.",
           "subdomain": "sub",
           "ttl": 300,
           "type": "CNAME",
@@ -130,9 +112,7 @@
           "filepos": "[line:21:5]",
           "name": "ddd.sub.sub",
           "name_unicode": "ddd.sub.sub",
-          "rdata": {
-            "Addr": "127.0.0.6"
-          },
+          "rdata": "127.0.0.6",
           "subdomain": "sub.sub",
           "ttl": 300,
           "type": "A",
@@ -143,9 +123,7 @@
           "filepos": "[line:22:5]",
           "name": "g.sub.sub",
           "name_unicode": "g.sub.sub",
-          "rdata": {
-            "Target": "h.sub.sub.domain.tld."
-          },
+          "rdata": "h.sub.sub.domain.tld.",
           "subdomain": "sub.sub",
           "ttl": 300,
           "type": "CNAME",
@@ -156,9 +134,7 @@
           "filepos": "[line:8:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "127.0.0.2"
-          },
+          "rdata": "127.0.0.2",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/031-dextendnames.json
+++ b/pkg/js/parse_tests/031-dextendnames.json
@@ -17,9 +17,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "127.0.0.1"
-          },
+          "rdata": "127.0.0.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -29,9 +27,7 @@
           "filepos": "[line:21:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "127.0.0.3"
-          },
+          "rdata": "127.0.0.3",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -41,9 +37,7 @@
           "filepos": "[line:8:5]",
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Addr": "127.0.0.2"
-          },
+          "rdata": "127.0.0.2",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -53,9 +47,7 @@
           "filepos": "[line:9:5]",
           "name": "b",
           "name_unicode": "b",
-          "rdata": {
-            "Target": "c.domain.tld."
-          },
+          "rdata": "c.domain.tld.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -65,9 +57,7 @@
           "filepos": "[line:22:5]",
           "name": "d",
           "name_unicode": "d",
-          "rdata": {
-            "Addr": "127.0.0.4"
-          },
+          "rdata": "127.0.0.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -77,9 +67,7 @@
           "filepos": "[line:23:5]",
           "name": "e",
           "name_unicode": "e",
-          "rdata": {
-            "Target": "f.domain.tld."
-          },
+          "rdata": "f.domain.tld.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -89,9 +77,7 @@
           "filepos": "[line:42:5]",
           "name": "ssub",
           "name_unicode": "ssub",
-          "rdata": {
-            "Addr": "127.0.0.7"
-          },
+          "rdata": "127.0.0.7",
           "subdomain": "ssub",
           "ttl": 300,
           "type": "A",
@@ -102,9 +88,7 @@
           "filepos": "[line:43:5]",
           "name": "j.ssub",
           "name_unicode": "j.ssub",
-          "rdata": {
-            "Addr": "127.0.0.8"
-          },
+          "rdata": "127.0.0.8",
           "subdomain": "ssub",
           "ttl": 300,
           "type": "A",
@@ -115,9 +99,7 @@
           "filepos": "[line:44:5]",
           "name": "k.ssub",
           "name_unicode": "k.ssub",
-          "rdata": {
-            "Target": "l.ssub.domain.tld."
-          },
+          "rdata": "l.ssub.domain.tld.",
           "subdomain": "ssub",
           "ttl": 300,
           "type": "CNAME",
@@ -128,9 +110,7 @@
           "filepos": "[line:28:5]",
           "name": "ub",
           "name_unicode": "ub",
-          "rdata": {
-            "Addr": "127.0.0.5"
-          },
+          "rdata": "127.0.0.5",
           "subdomain": "ub",
           "ttl": 300,
           "type": "A",
@@ -141,9 +121,7 @@
           "filepos": "[line:29:5]",
           "name": "g.ub",
           "name_unicode": "g.ub",
-          "rdata": {
-            "Addr": "127.0.0.6"
-          },
+          "rdata": "127.0.0.6",
           "subdomain": "ub",
           "ttl": 300,
           "type": "A",
@@ -154,9 +132,7 @@
           "filepos": "[line:30:5]",
           "name": "h.ub",
           "name_unicode": "h.ub",
-          "rdata": {
-            "Target": "i.ub.domain.tld."
-          },
+          "rdata": "i.ub.domain.tld.",
           "subdomain": "ub",
           "ttl": 300,
           "type": "CNAME",
@@ -177,9 +153,7 @@
           "filepos": "[line:13:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "127.0.1.1"
-          },
+          "rdata": "127.0.1.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -189,9 +163,7 @@
           "filepos": "[line:35:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "127.0.1.3"
-          },
+          "rdata": "127.0.1.3",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -201,9 +173,7 @@
           "filepos": "[line:14:5]",
           "name": "aa",
           "name_unicode": "aa",
-          "rdata": {
-            "Addr": "127.0.1.2"
-          },
+          "rdata": "127.0.1.2",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -213,9 +183,7 @@
           "filepos": "[line:15:5]",
           "name": "bb",
           "name_unicode": "bb",
-          "rdata": {
-            "Target": "cc.sub.domain.tld."
-          },
+          "rdata": "cc.sub.domain.tld.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -225,9 +193,7 @@
           "filepos": "[line:36:5]",
           "name": "dd",
           "name_unicode": "dd",
-          "rdata": {
-            "Addr": "127.0.1.4"
-          },
+          "rdata": "127.0.1.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -237,9 +203,7 @@
           "filepos": "[line:37:5]",
           "name": "ee",
           "name_unicode": "ee",
-          "rdata": {
-            "Target": "ff.sub.domain.tld."
-          },
+          "rdata": "ff.sub.domain.tld.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5

--- a/pkg/js/parse_tests/032-reverseip.json
+++ b/pkg/js/parse_tests/032-reverseip.json
@@ -17,9 +17,7 @@
           "filepos": "[line:7:5]",
           "name": "1",
           "name_unicode": "1",
-          "rdata": {
-            "Ptr": "foo.example.com."
-          },
+          "rdata": "foo.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -29,9 +27,7 @@
           "filepos": "[line:8:5]",
           "name": "2",
           "name_unicode": "1.2.3.2",
-          "rdata": {
-            "Ptr": "bar.example.com."
-          },
+          "rdata": "bar.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -44,9 +40,7 @@
           },
           "name": "3",
           "name_unicode": "3.3.2.1.in-addr.arpa",
-          "rdata": {
-            "Ptr": "baz.example.com."
-          },
+          "rdata": "baz.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -56,9 +50,7 @@
           "filepos": "[line:14:5]",
           "name": "4",
           "name_unicode": "4",
-          "rdata": {
-            "Ptr": "silly.example.com."
-          },
+          "rdata": "silly.example.com.",
           "subdomain": "4",
           "ttl": 300,
           "type": "PTR",
@@ -69,9 +61,7 @@
           "filepos": "[line:17:5]",
           "name": "5",
           "name_unicode": "1.2.3.5",
-          "rdata": {
-            "Ptr": "willy.example.com."
-          },
+          "rdata": "willy.example.com.",
           "subdomain": "5",
           "ttl": 300,
           "type": "PTR",
@@ -82,9 +72,7 @@
           "filepos": "[line:20:5]",
           "name": "6",
           "name_unicode": "6.3.2.1.in-addr.arpa",
-          "rdata": {
-            "Ptr": "billy.example.com."
-          },
+          "rdata": "billy.example.com.",
           "subdomain": "6",
           "ttl": 300,
           "type": "PTR",
@@ -95,9 +83,7 @@
           "filepos": "[line:24:5]",
           "name": "7",
           "name_unicode": "7",
-          "rdata": {
-            "Ptr": "my.example.com."
-          },
+          "rdata": "my.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -107,9 +93,7 @@
           "filepos": "[line:27:5]",
           "name": "8",
           "name_unicode": "1.2.3.8",
-          "rdata": {
-            "Ptr": "fair.example.com."
-          },
+          "rdata": "fair.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -122,9 +106,7 @@
           },
           "name": "9",
           "name_unicode": "9.3.2.1.in-addr.arpa",
-          "rdata": {
-            "Ptr": "lady.example.com."
-          },
+          "rdata": "lady.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12

--- a/pkg/js/parse_tests/033-revextend.json
+++ b/pkg/js/parse_tests/033-revextend.json
@@ -17,9 +17,7 @@
           "filepos": "[line:8:5]",
           "name": "1.2",
           "name_unicode": "1.2.8.9.in-addr.arpa",
-          "rdata": {
-            "Ns": "ns1.example.com."
-          },
+          "rdata": "ns1.example.com.",
           "ttl": 300,
           "type": "NS",
           "typenum": 2
@@ -29,9 +27,7 @@
           "filepos": "[line:11:5]",
           "name": "6.7",
           "name_unicode": "6.7.8.9.in-addr.arpa",
-          "rdata": {
-            "Ns": "ns2.example.org."
-          },
+          "rdata": "ns2.example.org.",
           "subdomain": "7",
           "ttl": 300,
           "type": "NS",
@@ -52,9 +48,7 @@
           "filepos": "[line:17:5]",
           "name": "foo",
           "name_unicode": "foo",
-          "rdata": {
-            "Ns": "ns1.fooexample.com."
-          },
+          "rdata": "ns1.fooexample.com.",
           "ttl": 300,
           "type": "NS",
           "typenum": 2
@@ -64,9 +58,7 @@
           "filepos": "[line:20:5]",
           "name": "more.lego",
           "name_unicode": "more.lego",
-          "rdata": {
-            "Ns": "ns1.example.com."
-          },
+          "rdata": "ns1.example.com.",
           "subdomain": "lego",
           "ttl": 300,
           "type": "NS",
@@ -77,9 +69,7 @@
           "filepos": "[line:21:5]",
           "name": "short.lego",
           "name_unicode": "short.lego",
-          "rdata": {
-            "Ns": "ns1.lego.example.com."
-          },
+          "rdata": "ns1.lego.example.com.",
           "subdomain": "lego",
           "ttl": 300,
           "type": "NS",

--- a/pkg/js/parse_tests/035-naptr.json
+++ b/pkg/js/parse_tests/035-naptr.json
@@ -10,14 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flags": "U",
-            "Order": 100,
-            "Preference": 10,
-            "Regexp": "!^.*$!sip:customer-service@example.com!",
-            "Replacement": "example",
-            "Service": "E2U+sip"
-          },
+          "rdata": "100 10 \"U\" \"E2U+sip\" \"!^.*$!sip:customer-service@example.com!\" example",
           "ttl": 300,
           "type": "NAPTR",
           "typenum": 35
@@ -27,14 +20,7 @@
           "filepos": "[line:3:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flags": "U",
-            "Order": 102,
-            "Preference": 10,
-            "Regexp": "!^.*$!mailto:information@example.com!",
-            "Replacement": "example",
-            "Service": "E2U+email"
-          },
+          "rdata": "102 10 \"U\" \"E2U+email\" \"!^.*$!mailto:information@example.com!\" example",
           "ttl": 300,
           "type": "NAPTR",
           "typenum": 35
@@ -44,14 +30,7 @@
           "filepos": "[line:4:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flags": "U",
-            "Order": 103,
-            "Preference": 10,
-            "Regexp": "!^.*$!mailto:information@example.com!",
-            "Replacement": ".",
-            "Service": "E2U+email"
-          },
+          "rdata": "103 10 \"U\" \"E2U+email\" \"!^.*$!mailto:information@example.com!\" .",
           "ttl": 300,
           "type": "NAPTR",
           "typenum": 35
@@ -61,14 +40,7 @@
           "filepos": "[line:5:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Flags": "U",
-            "Order": 104,
-            "Preference": 10,
-            "Regexp": "!^.*$!mailto:information@example.com!",
-            "Replacement": ".",
-            "Service": "E2U+email"
-          },
+          "rdata": "104 10 \"U\" \"E2U+email\" \"!^.*$!mailto:information@example.com!\" .",
           "ttl": 300,
           "type": "NAPTR",
           "typenum": 35

--- a/pkg/js/parse_tests/036-dextendcf.json
+++ b/pkg/js/parse_tests/036-dextendcf.json
@@ -20,10 +20,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Then": "test-worker",
-            "When": "test3.foo.com"
-          },
+          "rdata": "test3.foo.com \"test-worker\"",
           "ttl": 300,
           "type": "CF_WORKER_ROUTE",
           "typenum": 65288
@@ -33,14 +30,7 @@
           "filepos": "[line:9:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 301,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "301,test1.foo.com,https://goo.com/$1",
-            "SRThen": "concat(\"https://goo.com\", http.request.uri.path)",
-            "SRWhen": "http.host eq \"test1.foo.com\" and http.request.uri.path eq \"/\""
-          },
+          "rdata": "\"301,test1.foo.com,https://goo.com/$1\" 301 \"http.host eq \\\"test1.foo.com\\\" and http.request.uri.path eq \\\"/\\\"\" \"concat(\\\"https://goo.com\\\", http.request.uri.path)\"",
           "ttl": 1,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289
@@ -50,14 +40,7 @@
           "filepos": "[line:10:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 302,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "302,test2.foo.com,https://goo.com/$1",
-            "SRThen": "concat(\"https://goo.com\", http.request.uri.path)",
-            "SRWhen": "http.host eq \"test2.foo.com\" and http.request.uri.path eq \"/\""
-          },
+          "rdata": "\"302,test2.foo.com,https://goo.com/$1\" 302 \"http.host eq \\\"test2.foo.com\\\" and http.request.uri.path eq \\\"/\\\"\" \"concat(\\\"https://goo.com\\\", http.request.uri.path)\"",
           "ttl": 1,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289
@@ -67,9 +50,7 @@
           "filepos": "[line:6:5]",
           "name": "test1.foo.com.sub",
           "name_unicode": "test1.foo.com.sub",
-          "rdata": {
-            "Addr": "10.2.3.1"
-          },
+          "rdata": "10.2.3.1",
           "subdomain": "sub",
           "ttl": 300,
           "type": "A",
@@ -80,9 +61,7 @@
           "filepos": "[line:7:5]",
           "name": "test2.foo.com.sub",
           "name_unicode": "test2.foo.com.sub",
-          "rdata": {
-            "Addr": "10.2.3.2"
-          },
+          "rdata": "10.2.3.2",
           "subdomain": "sub",
           "ttl": 300,
           "type": "A",
@@ -93,9 +72,7 @@
           "filepos": "[line:8:5]",
           "name": "test3.foo.com.sub",
           "name_unicode": "test3.foo.com.sub",
-          "rdata": {
-            "Addr": "10.2.3.3"
-          },
+          "rdata": "10.2.3.3",
           "subdomain": "sub",
           "ttl": 300,
           "type": "A",

--- a/pkg/js/parse_tests/037-splithor.json
+++ b/pkg/js/parse_tests/037-splithor.json
@@ -25,9 +25,7 @@
           "filepos": "[line:7:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "3.3.3.3"
-          },
+          "rdata": "3.3.3.3",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -37,9 +35,7 @@
           "filepos": "[line:19:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "33.33.33.33"
-          },
+          "rdata": "33.33.33.33",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -59,9 +55,7 @@
           "filepos": "[line:11:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "1.1.1.1"
-          },
+          "rdata": "1.1.1.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -71,9 +65,7 @@
           "filepos": "[line:23:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "11.11.11.11"
-          },
+          "rdata": "11.11.11.11",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -94,9 +86,7 @@
           "filepos": "[line:15:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "8.8.8.8"
-          },
+          "rdata": "8.8.8.8",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -117,9 +107,7 @@
           "filepos": "[line:31:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "203.0.113.12"
-          },
+          "rdata": "203.0.113.12",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -129,9 +117,7 @@
           "filepos": "[line:27:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "203.0.113.1"
-          },
+          "rdata": "203.0.113.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -151,9 +137,7 @@
           "filepos": "[line:36:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "192.0.2.1"
-          },
+          "rdata": "192.0.2.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -163,9 +147,7 @@
           "filepos": "[line:31:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "203.0.113.12"
-          },
+          "rdata": "203.0.113.12",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -175,9 +157,7 @@
           "filepos": "[line:27:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "203.0.113.1"
-          },
+          "rdata": "203.0.113.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -198,9 +178,7 @@
           "filepos": "[line:41:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "203.0.113.1"
-          },
+          "rdata": "203.0.113.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -210,9 +188,7 @@
           "filepos": "[line:31:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "203.0.113.12"
-          },
+          "rdata": "203.0.113.12",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -222,9 +198,7 @@
           "filepos": "[line:27:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "203.0.113.1"
-          },
+          "rdata": "203.0.113.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -245,9 +219,7 @@
           "filepos": "[line:49:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "203.0.113.22"
-          },
+          "rdata": "203.0.113.22",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -257,9 +229,7 @@
           "filepos": "[line:45:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "203.0.113.2"
-          },
+          "rdata": "203.0.113.2",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -279,9 +249,7 @@
           "filepos": "[line:57:5]",
           "name": "main",
           "name_unicode": "main",
-          "rdata": {
-            "Addr": "203.0.113.12"
-          },
+          "rdata": "203.0.113.12",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -291,9 +259,7 @@
           "filepos": "[line:53:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "203.0.113.1"
-          },
+          "rdata": "203.0.113.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/038-soa.json
+++ b/pkg/js/parse_tests/038-soa.json
@@ -10,15 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Expire": 604800,
-            "Mbox": "admin.foo.com",
-            "Minttl": 86400,
-            "Ns": "ns1.foo.com.",
-            "Refresh": 3600,
-            "Retry": 900,
-            "Serial": 0
-          },
+          "rdata": "ns1.foo.com. admin.foo.com 0 3600 900 604800 86400",
           "ttl": 300,
           "type": "SOA",
           "typenum": 6

--- a/pkg/js/parse_tests/039-include.json
+++ b/pkg/js/parse_tests/039-include.json
@@ -17,9 +17,7 @@
           "filepos": "[line:5:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -40,9 +38,7 @@
           "filepos": "[line:5:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -52,9 +48,7 @@
           "filepos": "[line:10:5]",
           "name": "local",
           "name_unicode": "local",
-          "rdata": {
-            "Addr": "127.0.0.1"
-          },
+          "rdata": "127.0.0.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/040-cfWorkerRoute.json
+++ b/pkg/js/parse_tests/040-cfWorkerRoute.json
@@ -13,10 +13,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Then": "test-worker",
-            "When": "test.foo.com"
-          },
+          "rdata": "test.foo.com \"test-worker\"",
           "ttl": 300,
           "type": "CF_WORKER_ROUTE",
           "typenum": 65288

--- a/pkg/js/parse_tests/040-r53-zone.json
+++ b/pkg/js/parse_tests/040-r53-zone.json
@@ -26,12 +26,7 @@
           },
           "name": "atest",
           "name_unicode": "atest",
-          "rdata": {
-            "AliasType": "A",
-            "EvalTargetHealth": "false",
-            "Target": "foo.com.",
-            "ZoneID": "Z2FTEDLFRTZ"
-          },
+          "rdata": "A foo.com. false Z2FTEDLFRTZ",
           "ttl": 300,
           "type": "R53_ALIAS",
           "typenum": 65298

--- a/pkg/js/parse_tests/044-ensureabsent.json
+++ b/pkg/js/parse_tests/044-ensureabsent.json
@@ -10,9 +10,7 @@
           "filepos": "[line:3:5]",
           "name": "helper",
           "name_unicode": "helper",
-          "rdata": {
-            "Addr": "2.2.2.2"
-          },
+          "rdata": "2.2.2.2",
           "ttl": 300,
           "type": "A",
           "typenum": 1
@@ -22,9 +20,7 @@
           "filepos": "[line:2:5]",
           "name": "normal",
           "name_unicode": "normal",
-          "rdata": {
-            "Addr": "1.1.1.1"
-          },
+          "rdata": "1.1.1.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/045-loc.json
+++ b/pkg/js/parse_tests/045-loc.json
@@ -10,15 +10,7 @@
           "filepos": "[line:3:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Altitude": 9997600,
-            "HorizPre": 0,
-            "Latitude": 2299997648,
-            "Longitude": 1891505648,
-            "Size": 51,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 21 54.000 N 71 06 18.000 W -24m 30m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -28,15 +20,7 @@
           "filepos": "[line:4:5]",
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Altitude": 9997599,
-            "HorizPre": 36,
-            "Latitude": 2299987598,
-            "Longitude": 1891577308,
-            "Size": 18,
-            "Version": 0,
-            "VertPre": 19
-          },
+          "rdata": "42 21 43.950 N 71 05 6.340 W -24.01m 1m 200m 10m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -46,15 +30,7 @@
           "filepos": "[line:5:5]",
           "name": "b",
           "name_unicode": "b",
-          "rdata": {
-            "Altitude": 10001033,
-            "HorizPre": 0,
-            "Latitude": 2335528648,
-            "Longitude": 2148013648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "52 14 5.000 N 00 08 50.000 E 10.33m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -64,15 +40,7 @@
           "filepos": "[line:23:5]",
           "name": "big-ben",
           "name_unicode": "big-ben",
-          "rdata": {
-            "Altitude": 10000600,
-            "HorizPre": 0,
-            "Latitude": 2332886678,
-            "Longitude": 2147034998,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "51 30 3.030 N 00 07 28.650 W 6m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -82,15 +50,7 @@
           "filepos": "[line:6:5]",
           "name": "c",
           "name_unicode": "c",
-          "rdata": {
-            "Altitude": 10001000,
-            "HorizPre": 0,
-            "Latitude": 2031844648,
-            "Longitude": 2565228648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "32 07 19.000 S 116 02 25.000 E 10m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -100,15 +60,7 @@
           "filepos": "[line:7:5]",
           "name": "d",
           "name_unicode": "d",
-          "rdata": {
-            "Altitude": 9995600,
-            "HorizPre": 0,
-            "Latitude": 2299972408,
-            "Longitude": 1891832028,
-            "Size": 37,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 21 28.760 N 71 00 51.620 W -44m 2000m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -118,15 +70,7 @@
           "filepos": "[line:8:5]",
           "name": "d-alt-highest",
           "name_unicode": "d-alt-highest",
-          "rdata": {
-            "Altitude": 4294967295,
-            "HorizPre": 0,
-            "Latitude": 2299972408,
-            "Longitude": 1891832028,
-            "Size": 37,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 21 28.760 N 71 00 51.620 W 42849672.95m 2000m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -136,15 +80,7 @@
           "filepos": "[line:9:5]",
           "name": "d-alt-lowest",
           "name_unicode": "d-alt-lowest",
-          "rdata": {
-            "Altitude": 0,
-            "HorizPre": 0,
-            "Latitude": 2299972408,
-            "Longitude": 1891832028,
-            "Size": 37,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 21 28.760 N 71 00 51.620 W -100000m 2000m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -154,15 +90,7 @@
           "filepos": "[line:12:5]",
           "name": "d-horizprecision-hi",
           "name_unicode": "d-horizprecision-hi",
-          "rdata": {
-            "Altitude": 10000000,
-            "HorizPre": 153,
-            "Latitude": 2299972408,
-            "Longitude": 1891832028,
-            "Size": 18,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 21 28.760 N 71 00 51.620 W 0m 1m 90000000m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -172,15 +100,7 @@
           "filepos": "[line:17:5]",
           "name": "d-size-hi",
           "name_unicode": "d-size-hi",
-          "rdata": {
-            "Altitude": 10000000,
-            "HorizPre": 0,
-            "Latitude": 2299972408,
-            "Longitude": 1891832028,
-            "Size": 153,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 21 28.760 N 71 00 51.620 W 0m 90000000m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -190,15 +110,7 @@
           "filepos": "[line:18:5]",
           "name": "d-vertprecision-hi",
           "name_unicode": "d-vertprecision-hi",
-          "rdata": {
-            "Altitude": 10000000,
-            "HorizPre": 0,
-            "Latitude": 2299972408,
-            "Longitude": 1891832028,
-            "Size": 18,
-            "Version": 0,
-            "VertPre": 153
-          },
+          "rdata": "42 21 28.760 N 71 00 51.620 W 0m 1m 0.00m 90000000m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -208,15 +120,7 @@
           "filepos": "[line:60:5]",
           "name": "fraser-island",
           "name_unicode": "fraser-island",
-          "rdata": {
-            "Altitude": 10000300,
-            "HorizPre": 0,
-            "Latitude": 2056619648,
-            "Longitude": 2698823648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "25 14 24.000 S 153 09 0.000 E 3m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -226,15 +130,7 @@
           "filepos": "[line:85:5]",
           "name": "guinness-brewery",
           "name_unicode": "guinness-brewery",
-          "rdata": {
-            "Altitude": 10030000,
-            "HorizPre": 0,
-            "Latitude": 2339523648,
-            "Longitude": 2124843648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "53 20 40.000 N 06 17 20.000 W 300m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -244,15 +140,7 @@
           "filepos": "[line:70:5]",
           "name": "hawaii",
           "name_unicode": "hawaii",
-          "rdata": {
-            "Altitude": 10092000,
-            "HorizPre": 0,
-            "Latitude": 2224883648,
-            "Longitude": 1578683648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "21 30 0.000 N 158 00 0.000 W 920m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -262,15 +150,7 @@
           "filepos": "[line:75:5]",
           "name": "old-faithful",
           "name_unicode": "old-faithful",
-          "rdata": {
-            "Altitude": 10224000,
-            "HorizPre": 0,
-            "Latitude": 2307541648,
-            "Longitude": 1748502648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "44 27 38.000 N 110 49 41.000 W 2240m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -280,15 +160,7 @@
           "filepos": "[line:36:5]",
           "name": "opera-house",
           "name_unicode": "opera-house",
-          "rdata": {
-            "Altitude": 10000400,
-            "HorizPre": 0,
-            "Latitude": 2025592648,
-            "Longitude": 2691854648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "33 51 31.000 S 151 12 51.000 E 4m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -298,15 +170,7 @@
           "filepos": "[line:42:5]",
           "name": "opera-house2",
           "name_unicode": "opera-house2",
-          "rdata": {
-            "Altitude": 10000400,
-            "HorizPre": 0,
-            "Latitude": 2025592648,
-            "Longitude": 2691854648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "33 51 31.000 S 151 12 51.000 E 4m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -316,15 +180,7 @@
           "filepos": "[line:48:5]",
           "name": "opera-house3",
           "name_unicode": "opera-house3",
-          "rdata": {
-            "Altitude": 10000400,
-            "HorizPre": 0,
-            "Latitude": 2025592648,
-            "Longitude": 2691854648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "33 51 31.000 S 151 12 51.000 E 4m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -334,15 +190,7 @@
           "filepos": "[line:54:5]",
           "name": "opera-house4",
           "name_unicode": "opera-house4",
-          "rdata": {
-            "Altitude": 10000400,
-            "HorizPre": 0,
-            "Latitude": 2025592648,
-            "Longitude": 2691854648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "33 51 31.000 S 151 12 51.000 E 4m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -352,15 +200,7 @@
           "filepos": "[line:80:5]",
           "name": "ribblehead-viaduct",
           "name_unicode": "ribblehead-viaduct",
-          "rdata": {
-            "Altitude": 10030000,
-            "HorizPre": 0,
-            "Latitude": 2342641648,
-            "Longitude": 2138950648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "54 12 38.000 N 02 22 13.000 W 300m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -370,15 +210,7 @@
           "filepos": "[line:65:5]",
           "name": "tasmania",
           "name_unicode": "tasmania",
-          "rdata": {
-            "Altitude": 10000300,
-            "HorizPre": 0,
-            "Latitude": 1996283648,
-            "Longitude": 2676683648,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 00 0.000 S 147 00 0.000 E 3m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -388,15 +220,7 @@
           "filepos": "[line:29:5]",
           "name": "white-house",
           "name_unicode": "white-house",
-          "rdata": {
-            "Altitude": 10001900,
-            "HorizPre": 0,
-            "Latitude": 2287515588,
-            "Longitude": 1870152068,
-            "Size": 0,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "38 53 51.940 N 77 02 11.580 W 19m 0.00m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29

--- a/pkg/js/parse_tests/046-DHCID.json
+++ b/pkg/js/parse_tests/046-DHCID.json
@@ -10,9 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Digest": "Test"
-          },
+          "rdata": "Test",
           "ttl": 300,
           "type": "DHCID",
           "typenum": 49

--- a/pkg/js/parse_tests/047-DNAME.json
+++ b/pkg/js/parse_tests/047-DNAME.json
@@ -10,9 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Target": "bar.com."
-          },
+          "rdata": "bar.com.",
           "ttl": 300,
           "type": "DNAME",
           "typenum": 39

--- a/pkg/js/parse_tests/047-SVCB.json
+++ b/pkg/js/parse_tests/047-SVCB.json
@@ -10,31 +10,7 @@
           "filepos": "[line:3:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Priority": 2,
-            "Target": ".",
-            "Value": [
-              {
-                "Alpn": [
-                  "h3",
-                  "h2"
-                ]
-              },
-              {
-                "Port": 443
-              },
-              {
-                "Hint": [
-                  "123.123.123.123"
-                ]
-              },
-              {
-                "Hint": [
-                  "dead::beaf"
-                ]
-              }
-            ]
-          },
+          "rdata": "2 . alpn=\"h3,h2\" port=\"443\" ipv4hint=\"123.123.123.123\" ipv6hint=\"dead::beaf\"",
           "ttl": 300,
           "type": "HTTPS",
           "typenum": 65
@@ -44,11 +20,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Priority": 1,
-            "Target": ".",
-            "Value": null
-          },
+          "rdata": "1 .",
           "ttl": 300,
           "type": "SVCB",
           "typenum": 64

--- a/pkg/js/parse_tests/048-DNSKEY.json
+++ b/pkg/js/parse_tests/048-DNSKEY.json
@@ -10,13 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Algorithm": 13,
-            "Flags": 257,
-            "Protocol": 3,
-            "PublicKey": "AABBCCDD",
-            "Tag": 0
-          },
+          "rdata": "257 3 13 AABBCCDD",
           "ttl": 300,
           "type": "DNSKEY",
           "typenum": 48

--- a/pkg/js/parse_tests/049-json5-require.json
+++ b/pkg/js/parse_tests/049-json5-require.json
@@ -10,9 +10,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Addr": "1.1.1.1"
-          },
+          "rdata": "1.1.1.1",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/050-cfSingleRedirect.json
+++ b/pkg/js/parse_tests/050-cfSingleRedirect.json
@@ -10,14 +10,7 @@
           "filepos": "[line:5:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 301,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "name1",
-            "SRThen": "then1",
-            "SRWhen": "when1"
-          },
+          "rdata": "name1 301 when1 then1",
           "ttl": 300,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289
@@ -27,14 +20,7 @@
           "filepos": "[line:6:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 302,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "name2",
-            "SRThen": "then2",
-            "SRWhen": "when2"
-          },
+          "rdata": "name2 302 when2 then2",
           "ttl": 300,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289
@@ -44,14 +30,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 301,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "name3",
-            "SRThen": "then3",
-            "SRWhen": "when3"
-          },
+          "rdata": "name3 301 when3 then3",
           "ttl": 300,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289
@@ -65,14 +44,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 302,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "namemeta",
-            "SRThen": "thenmeta",
-            "SRWhen": "whenmeta"
-          },
+          "rdata": "namemeta 302 whenmeta thenmeta",
           "ttl": 300,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289
@@ -82,14 +54,7 @@
           "filepos": "[line:8:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Code": 302,
-            "RT_SRRRulesetID": "",
-            "RT_SRRRulesetRuleID": "",
-            "SRName": "namettl",
-            "SRThen": "thenttl",
-            "SRWhen": "whenttl"
-          },
+          "rdata": "namettl 302 whenttl thenttl",
           "ttl": 999,
           "type": "CLOUDFLAREAPI_SINGLE_REDIRECT",
           "typenum": 65289
@@ -102,9 +67,7 @@
           },
           "name": "name1",
           "name_unicode": "name1",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/054-b3487_d_extend_rev.json
+++ b/pkg/js/parse_tests/054-b3487_d_extend_rev.json
@@ -17,9 +17,7 @@
           "filepos": "[line:5:5]",
           "name": "31.104",
           "name_unicode": "31.104",
-          "rdata": {
-            "Ptr": "example.site.com."
-          },
+          "rdata": "example.site.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -29,9 +27,7 @@
           "filepos": "[line:6:5]",
           "name": "206.104",
           "name_unicode": "206.104",
-          "rdata": {
-            "Ptr": "example2.site.com."
-          },
+          "rdata": "example2.site.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -41,9 +37,7 @@
           "filepos": "[line:17:5]",
           "name": "0.119",
           "name_unicode": "0.119",
-          "rdata": {
-            "Ptr": "ip-10-6-119-0.example.com."
-          },
+          "rdata": "ip-10-6-119-0.example.com.",
           "subdomain": "119",
           "ttl": 300,
           "type": "PTR",
@@ -54,9 +48,7 @@
           "filepos": "[line:18:5]",
           "name": "1.119",
           "name_unicode": "1.119",
-          "rdata": {
-            "Ptr": "ip-10-6-119-1.example.com."
-          },
+          "rdata": "ip-10-6-119-1.example.com.",
           "subdomain": "119",
           "ttl": 300,
           "type": "PTR",
@@ -67,9 +59,7 @@
           "filepos": "[line:19:5]",
           "name": "2.119",
           "name_unicode": "2.119",
-          "rdata": {
-            "Ptr": "ip-10-6-119-2.example.com."
-          },
+          "rdata": "ip-10-6-119-2.example.com.",
           "subdomain": "119",
           "ttl": 300,
           "type": "PTR",
@@ -80,9 +70,7 @@
           "filepos": "[line:20:5]",
           "name": "3.119",
           "name_unicode": "3.119",
-          "rdata": {
-            "Ptr": "ip-10-6-119-3.example.com."
-          },
+          "rdata": "ip-10-6-119-3.example.com.",
           "subdomain": "119",
           "ttl": 300,
           "type": "PTR",
@@ -93,9 +81,7 @@
           "filepos": "[line:10:5]",
           "name": "50.200",
           "name_unicode": "50.200",
-          "rdata": {
-            "Ptr": "ip-10-6-200-50.example.com."
-          },
+          "rdata": "ip-10-6-200-50.example.com.",
           "subdomain": "200",
           "ttl": 300,
           "type": "PTR",
@@ -106,9 +92,7 @@
           "filepos": "[line:11:5]",
           "name": "51.200",
           "name_unicode": "51.200",
-          "rdata": {
-            "Ptr": "ip-10-6-200-51.example.com."
-          },
+          "rdata": "ip-10-6-200-51.example.com.",
           "subdomain": "200",
           "ttl": 300,
           "type": "PTR",
@@ -119,9 +103,7 @@
           "filepos": "[line:12:5]",
           "name": "52.200",
           "name_unicode": "52.200",
-          "rdata": {
-            "Ptr": "ip-10-6-200-52.example.com."
-          },
+          "rdata": "ip-10-6-200-52.example.com.",
           "subdomain": "200",
           "ttl": 300,
           "type": "PTR",
@@ -132,9 +114,7 @@
           "filepos": "[line:13:5]",
           "name": "53.200",
           "name_unicode": "53.200",
-          "rdata": {
-            "Ptr": "ip-10-6-200-53.example.com."
-          },
+          "rdata": "ip-10-6-200-53.example.com.",
           "subdomain": "200",
           "ttl": 300,
           "type": "PTR",
@@ -145,9 +125,7 @@
           "filepos": "[line:24:5]",
           "name": "20.220",
           "name_unicode": "20.220",
-          "rdata": {
-            "Ptr": "ip-10-6-220-20.example.com."
-          },
+          "rdata": "ip-10-6-220-20.example.com.",
           "subdomain": "220",
           "ttl": 300,
           "type": "PTR",
@@ -158,9 +136,7 @@
           "filepos": "[line:28:5]",
           "name": "30.230",
           "name_unicode": "30.230",
-          "rdata": {
-            "Ptr": "ip-10-6-230-30.example.com."
-          },
+          "rdata": "ip-10-6-230-30.example.com.",
           "subdomain": "230",
           "ttl": 300,
           "type": "PTR",

--- a/pkg/js/parse_tests/055-b3550-ipv6ptr.json
+++ b/pkg/js/parse_tests/055-b3550-ipv6ptr.json
@@ -17,9 +17,7 @@
           "filepos": "[line:5:5]",
           "name": "1.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
           "name_unicode": "2011:abcd::11",
-          "rdata": {
-            "Ptr": "host11.example.com."
-          },
+          "rdata": "host11.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -29,9 +27,7 @@
           "filepos": "[line:6:5]",
           "name": "2.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
           "name_unicode": "2.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.1.1.0.2.ip6.arpa",
-          "rdata": {
-            "Ptr": "host22.example.com."
-          },
+          "rdata": "host22.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -51,9 +47,7 @@
           "filepos": "[line:10:5]",
           "name": "1.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
           "name_unicode": "2001:db8::11",
-          "rdata": {
-            "Ptr": "server11.example.com."
-          },
+          "rdata": "server11.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -63,9 +57,7 @@
           "filepos": "[line:11:5]",
           "name": "2.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
           "name_unicode": "2.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
-          "rdata": {
-            "Ptr": "server22.example.com."
-          },
+          "rdata": "server22.example.com.",
           "ttl": 300,
           "type": "PTR",
           "typenum": 12
@@ -75,9 +67,7 @@
           "filepos": "[line:15:5]",
           "name": "d.c.b.a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
           "name_unicode": "d.c.b.a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
-          "rdata": {
-            "Ptr": "abcd.example.com."
-          },
+          "rdata": "abcd.example.com.",
           "subdomain": "d.c.b.a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
           "ttl": 300,
           "type": "PTR",

--- a/pkg/js/parse_tests/056-openpgpkey.json
+++ b/pkg/js/parse_tests/056-openpgpkey.json
@@ -10,9 +10,7 @@
           "filepos": "[line:4:5]",
           "name": "bb7d0cf1ee44aca0bcc0f739b77b935f13aec2fd537f5c29dedd883d._openpgpkey",
           "name_unicode": "bb7d0cf1ee44aca0bcc0f739b77b935f13aec2fd537f5c29dedd883d._openpgpkey",
-          "rdata": {
-            "PublicKey": "mDMEAAAAARYJKwYBBAHaRw8BAQdAFHHsHVzE1rvYcCmX7Sn5X3p71eF5qo02mO/IuULrCPW0JEV4YW1wbGUgMSA8ZXhhbXBsZS0xQGRuc2NvbnRyb2wub3JnPoh+BBMWCgAmFiEEkwXxX/eDCW05Qn5tBI42Nn4+OuIFAgAAAAECGwECHgUCF4AACgkQBI42Nn4+OuL/qgD/S2rZm2Lafp11mr5q4jIBZ4DCS/Xl+Gm4ADvoPGpzkzwBALZqxlCToP4KQ0RI2ZlqtGQSy+fHDVxat0q7pFZsRo0K"
-          },
+          "rdata": "mDMEAAAAARYJKwYBBAHaRw8BAQdAFHHsHVzE1rvYcCmX7Sn5X3p71eF5qo02mO/IuULrCPW0JEV4YW1wbGUgMSA8ZXhhbXBsZS0xQGRuc2NvbnRyb2wub3JnPoh+BBMWCgAmFiEEkwXxX/eDCW05Qn5tBI42Nn4+OuIFAgAAAAECGwECHgUCF4AACgkQBI42Nn4+OuL/qgD/S2rZm2Lafp11mr5q4jIBZ4DCS/Xl+Gm4ADvoPGpzkzwBALZqxlCToP4KQ0RI2ZlqtGQSy+fHDVxat0q7pFZsRo0K",
           "ttl": 300,
           "type": "OPENPGPKEY",
           "typenum": 61
@@ -30,9 +28,7 @@
           "filepos": "[line:21:5]",
           "name": "bb7d0cf1ee44aca0bcc0f739b77b935f13aec2fd537f5c29dedd883d._openpgpkey",
           "name_unicode": "bb7d0cf1ee44aca0bcc0f739b77b935f13aec2fd537f5c29dedd883d._openpgpkey",
-          "rdata": {
-            "PublicKey": "mDMEAAAAARYJKwYBBAHaRw8BAQdAFHHsHVzE1rvYcCmX7Sn5X3p71eF5qo02mO/IuULrCPW0JEV4YW1wbGUgMSA8ZXhhbXBsZS0xQGRuc2NvbnRyb2wub3JnPoh+BBMWCgAmFiEEkwXxX/eDCW05Qn5tBI42Nn4+OuIFAgAAAAECGwECHgUCF4AACgkQBI42Nn4+OuL/qgD/S2rZm2Lafp11mr5q4jIBZ4DCS/Xl+Gm4ADvoPGpzkzwBALZqxlCToP4KQ0RI2ZlqtGQSy+fHDVxat0q7pFZsRo0K"
-          },
+          "rdata": "mDMEAAAAARYJKwYBBAHaRw8BAQdAFHHsHVzE1rvYcCmX7Sn5X3p71eF5qo02mO/IuULrCPW0JEV4YW1wbGUgMSA8ZXhhbXBsZS0xQGRuc2NvbnRyb2wub3JnPoh+BBMWCgAmFiEEkwXxX/eDCW05Qn5tBI42Nn4+OuIFAgAAAAECGwECHgUCF4AACgkQBI42Nn4+OuL/qgD/S2rZm2Lafp11mr5q4jIBZ4DCS/Xl+Gm4ADvoPGpzkzwBALZqxlCToP4KQ0RI2ZlqtGQSy+fHDVxat0q7pFZsRo0K",
           "ttl": 300,
           "type": "OPENPGPKEY",
           "typenum": 61

--- a/pkg/js/parse_tests/057-smimea.json
+++ b/pkg/js/parse_tests/057-smimea.json
@@ -10,12 +10,7 @@
           "filepos": "[line:2:5]",
           "name": "f10e7de079689f55c0cdd6782e4dd1448c84006962a4bd832e8eff73",
           "name_unicode": "f10e7de079689f55c0cdd6782e4dd1448c84006962a4bd832e8eff73",
-          "rdata": {
-            "Certificate": "MDFiYTQ3MTljODBiNmZlOTExYjA5MWE3YzA1MTI0YjY0ZWVlY2U5NjRlMDljMDU4ZWY4Zjk4MDVkYWNhNTQ2YiAgLQo=",
-            "MatchingType": 0,
-            "Selector": 0,
-            "Usage": 3
-          },
+          "rdata": "3 0 0 MDFiYTQ3MTljODBiNmZlOTExYjA5MWE3YzA1MTI0YjY0ZWVlY2U5NjRlMDljMDU4ZWY4Zjk4MDVkYWNhNTQ2YiAgLQo=",
           "ttl": 300,
           "type": "SMIMEA",
           "typenum": 53

--- a/pkg/js/parse_tests/058-ignore-external-dns.json
+++ b/pkg/js/parse_tests/058-ignore-external-dns.json
@@ -28,9 +28,7 @@
           "filepos": "[line:12:5]",
           "name": "api",
           "name_unicode": "api",
-          "rdata": {
-            "Target": "www.extdns-combined.com."
-          },
+          "rdata": "www.extdns-combined.com.",
           "ttl": 300,
           "type": "CNAME",
           "typenum": 5
@@ -40,9 +38,7 @@
           "filepos": "[line:11:5]",
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Addr": "1.2.3.4"
-          },
+          "rdata": "1.2.3.4",
           "ttl": 300,
           "type": "A",
           "typenum": 1

--- a/pkg/js/parse_tests/059-rawttls.json
+++ b/pkg/js/parse_tests/059-rawttls.json
@@ -10,10 +10,7 @@
           "filepos": "[line:6:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Mbox": "user.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user.example.com. mytxt.example.com.",
           "ttl": 300,
           "type": "RP",
           "typenum": 17
@@ -23,10 +20,7 @@
           "filepos": "[line:7:5]",
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Mbox": "user2.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user2.example.com. mytxt.example.com.",
           "ttl": 300,
           "type": "RP",
           "typenum": 17
@@ -36,10 +30,7 @@
           "filepos": "[line:10:5]",
           "name": "aaa300",
           "name_unicode": "aaa300",
-          "rdata": {
-            "Mbox": "user.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user.example.com. mytxt.example.com.",
           "ttl": 300,
           "type": "RP",
           "typenum": 17
@@ -49,10 +40,7 @@
           "filepos": "[line:14:5]",
           "name": "bbb1",
           "name_unicode": "bbb1",
-          "rdata": {
-            "Mbox": "user.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user.example.com. mytxt.example.com.",
           "ttl": 1111,
           "type": "RP",
           "typenum": 17
@@ -62,10 +50,7 @@
           "filepos": "[line:17:5]",
           "name": "ccc2",
           "name_unicode": "ccc2",
-          "rdata": {
-            "Mbox": "user.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user.example.com. mytxt.example.com.",
           "ttl": 2222,
           "type": "RP",
           "typenum": 17
@@ -75,10 +60,7 @@
           "filepos": "[line:20:5]",
           "name": "ddd1",
           "name_unicode": "ddd1",
-          "rdata": {
-            "Mbox": "user.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user.example.com. mytxt.example.com.",
           "ttl": 1111,
           "type": "RP",
           "typenum": 17
@@ -88,10 +70,7 @@
           "filepos": "[line:24:5]",
           "name": "eee3",
           "name_unicode": "eee3",
-          "rdata": {
-            "Mbox": "user.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user.example.com. mytxt.example.com.",
           "ttl": 3333,
           "type": "RP",
           "typenum": 17
@@ -101,11 +80,7 @@
           "filepos": "[line:3:5]",
           "name": "mytxt",
           "name_unicode": "mytxt",
-          "rdata": {
-            "Txt": [
-              "Do not call me on my phone"
-            ]
-          },
+          "rdata": "\"Do not call me on my phone\"",
           "ttl": 300,
           "type": "TXT",
           "typenum": 16

--- a/pkg/js/parse_tests/060-rawmetas.json
+++ b/pkg/js/parse_tests/060-rawmetas.json
@@ -13,10 +13,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "Mbox": "user2.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user2.example.com. mytxt.example.com.",
           "ttl": 300,
           "type": "RP",
           "typenum": 17
@@ -29,10 +26,7 @@
           },
           "name": "foo",
           "name_unicode": "foo",
-          "rdata": {
-            "Mbox": "user2.example.com.",
-            "Txt": "mytxt.example.com."
-          },
+          "rdata": "user2.example.com. mytxt.example.com.",
           "ttl": 300,
           "type": "RP",
           "typenum": 17

--- a/pkg/js/parse_tests/061-mikrotik.json
+++ b/pkg/js/parse_tests/061-mikrotik.json
@@ -15,9 +15,7 @@
           },
           "name": "@",
           "name_unicode": "@",
-          "rdata": {
-            "ForwardTo": "8.8.8.8"
-          },
+          "rdata": "8.8.8.8",
           "ttl": 300,
           "type": "MIKROTIK_FWD",
           "typenum": 65293
@@ -29,7 +27,6 @@
           },
           "name": "blocked",
           "name_unicode": "blocked",
-          "rdata": {},
           "ttl": 300,
           "type": "MIKROTIK_NXDOMAIN",
           "typenum": 65294
@@ -42,9 +39,7 @@
           },
           "name": "corp.example.com",
           "name_unicode": "corp.example.com",
-          "rdata": {
-            "Target": "10.0.0.53"
-          },
+          "rdata": "10.0.0.53",
           "ttl": 300,
           "type": "MIKROTIK_FORWARDER",
           "typenum": 65321

--- a/pkg/js/parse_tests/062-dextendbuilder.json
+++ b/pkg/js/parse_tests/062-dextendbuilder.json
@@ -17,15 +17,7 @@
           "filepos": "[line:16:5]",
           "name": "loctest1",
           "name_unicode": "loctest1",
-          "rdata": {
-            "Altitude": 9997600,
-            "HorizPre": 0,
-            "Latitude": 2299997648,
-            "Longitude": 1891505648,
-            "Size": 51,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 21 54.000 N 71 06 18.000 W -24m 30m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29
@@ -35,15 +27,7 @@
           "filepos": "[line:22:5]",
           "name": "loctest2.ssub",
           "name_unicode": "loctest2.ssub",
-          "rdata": {
-            "Altitude": 9997600,
-            "HorizPre": 0,
-            "Latitude": 2299997648,
-            "Longitude": 1891505648,
-            "Size": 51,
-            "Version": 0,
-            "VertPre": 0
-          },
+          "rdata": "42 21 54.000 N 71 06 18.000 W -24m 30m 0.00m 0.00m",
           "ttl": 300,
           "type": "LOC",
           "typenum": 29

--- a/pkg/js/parse_tests/063-adguard.json
+++ b/pkg/js/parse_tests/063-adguard.json
@@ -13,9 +13,7 @@
           },
           "name": "a",
           "name_unicode": "a",
-          "rdata": {
-            "Target": ""
-          },
+          "rdata": "\"\"",
           "ttl": 300,
           "type": "ADGUARDHOME_A_PASSTHROUGH",
           "typenum": 65280
@@ -28,9 +26,7 @@
           },
           "name": "aaaa",
           "name_unicode": "aaaa",
-          "rdata": {
-            "Target": ""
-          },
+          "rdata": "\"\"",
           "ttl": 300,
           "type": "ADGUARDHOME_AAAA_PASSTHROUGH",
           "typenum": 65281

--- a/pkg/js/parse_tests/064-lua.json
+++ b/pkg/js/parse_tests/064-lua.json
@@ -13,10 +13,7 @@
           },
           "name": "_diag",
           "name_unicode": "_diag",
-          "rdata": {
-            "LuaPayload": "; return 'ok'",
-            "LuaType": "TXT"
-          },
+          "rdata": "TXT \"; return 'ok'\"",
           "ttl": 30,
           "type": "LUA",
           "typenum": 65292
@@ -29,10 +26,7 @@
           },
           "name": "app",
           "name_unicode": "app",
-          "rdata": {
-            "LuaPayload": "return_127_0_0_1",
-            "LuaType": "A"
-          },
+          "rdata": "A \"return_127_0_0_1\"",
           "ttl": 60,
           "type": "LUA",
           "typenum": 65292

--- a/pkg/js/parse_tests/065-bunny.json
+++ b/pkg/js/parse_tests/065-bunny.json
@@ -13,9 +13,7 @@
           },
           "name": "cdn",
           "name_unicode": "cdn",
-          "rdata": {
-            "PullZoneID": 12345
-          },
+          "rdata": "12345",
           "ttl": 300,
           "type": "BUNNY_DNS_PZ",
           "typenum": 65287
@@ -28,9 +26,7 @@
           },
           "name": "go",
           "name_unicode": "go",
-          "rdata": {
-            "Target": "https://example.com"
-          },
+          "rdata": "\"https://example.com\"",
           "ttl": 300,
           "type": "BUNNY_DNS_RDR",
           "typenum": 65320

--- a/pkg/js/parse_tests/066-cloudns.json
+++ b/pkg/js/parse_tests/066-cloudns.json
@@ -13,9 +13,7 @@
           },
           "name": "www",
           "name_unicode": "www",
-          "rdata": {
-            "Target": "https://example.com"
-          },
+          "rdata": "\"https://example.com\"",
           "ttl": 300,
           "type": "CLOUDNS_WR",
           "typenum": 65290

--- a/pkg/js/parse_tests/067-porkbun.json
+++ b/pkg/js/parse_tests/067-porkbun.json
@@ -16,9 +16,7 @@
           },
           "name": "shop",
           "name_unicode": "shop",
-          "rdata": {
-            "Location": "https://example.com"
-          },
+          "rdata": "\"https://example.com\"",
           "ttl": 300,
           "type": "PORKBUN_URLFWD",
           "typenum": 65297


### PR DESCRIPTION
# Issue

"dnscontrol print-ir --out filename" and "dnscontrol preview --ir filename" should round-trip.  They don't in v5.0.3

# Resolution

Output the .RDATA field as a string (zonefile format) and parse it back on read.  The .String() function and NewRecordConfigParse() must always round-trip (IIRC), making this a better format.

This is a big change, since "rdata" is now a string instead of a json object.  However if we used a json object, we'd have to deal with the fact that dnsv2 doesn't properly round trip all of its json.