### PR TITLE
HOSTINGDE: Fix SOA mailbox with a host being dropped

### DIFF
--- a/documentation/provider/hostingde.md
+++ b/documentation/provider/hostingde.md
@@ -75,9 +75,13 @@ The `HOSTINGDE` provider **ignores the default nameserver set** defined in your 
 Instead, it uses hosting.de's nameservers (`ns1.hosting.de.`, `ns2.hosting.de.`, and `ns3.hosting.de.`) by default, regardless of your account settings.
 Using the `default_ns` metadata, the default nameserver set can be overwritten.
 
-## SOA records
+## Caveats
 
-hosting.de keeps the contact address of a zone in the zone configuration rather than in an SOA record, so the mailbox of [`SOA()`](../language-reference/domain-modifiers/SOA.md) ends up there.
+### SOA
+
+hosting.de derives the primary nameserver of a zone from its nameserver set and offers no way to override it, so the `ns` parameter of [`SOA()`](../language-reference/domain-modifiers/SOA.md) is ignored.
+
+The contact address of a zone lives in the zone configuration rather than in an SOA record, so the mailbox of `SOA()` ends up there.
 A mailbox that names its own host is used as the address, so `hostmaster.example.com.` becomes `hostmaster@example.com`.
 One without a host is qualified with the zone name.
 The address may not end in a period; the API rejects that.

--- a/documentation/provider/hostingde.md
+++ b/documentation/provider/hostingde.md
@@ -75,6 +75,13 @@ The `HOSTINGDE` provider **ignores the default nameserver set** defined in your 
 Instead, it uses hosting.de's nameservers (`ns1.hosting.de.`, `ns2.hosting.de.`, and `ns3.hosting.de.`) by default, regardless of your account settings.
 Using the `default_ns` metadata, the default nameserver set can be overwritten.
 
+## SOA records
+
+hosting.de keeps the contact address of a zone in the zone configuration rather than in an SOA record, so the mailbox of [`SOA()`](../language-reference/domain-modifiers/SOA.md) ends up there.
+A mailbox that names its own host is used as the address, so `hostmaster.example.com.` becomes `hostmaster@example.com`.
+One without a host is qualified with the zone name.
+The address may not end in a period; the API rejects that.
+
 ## Feature Summary
 
 <!-- provider-features-start -->

--- a/integrationTest/integration_test.go
+++ b/integrationTest/integration_test.go
@@ -901,12 +901,29 @@ func makeTests() []*TestGroup {
 		// SOA
 		testgroup("SOA",
 			requires(providers.CanUseSOA),
-			tcEmptyZone(), // Required or only the first run passes.
+			not("HOSTINGDE"), // Has its own group below.
+			tcEmptyZone(),    // Required or only the first run passes.
 			// Providers such as Route53 cannot delete the mandatory SOA during
 			// the empty-zone setup. It may therefore already have this value
 			// when a previous run stopped after this test.
 			tc("Create SOA record", soa("@", "kim.ns.cloudflare.com.", "dns.cloudflare.com.", 2037190000, 10000, 2400, 604800, 3600)).AllowNoChanges(),
 			tc("Modify SOA ns    ", soa("@", "mmm.ns.cloudflare.com.", "dns.cloudflare.com.", 2037190000, 10000, 2400, 604800, 3600)),
+			tc("Modify SOA mbox  ", soa("@", "mmm.ns.cloudflare.com.", "eee.cloudflare.com.", 2037190000, 10000, 2400, 604800, 3600)),
+			tc("Modify SOA refres", soa("@", "mmm.ns.cloudflare.com.", "eee.cloudflare.com.", 2037190000, 10001, 2400, 604800, 3600)),
+			tc("Modify SOA retry ", soa("@", "mmm.ns.cloudflare.com.", "eee.cloudflare.com.", 2037190000, 10001, 2401, 604800, 3600)),
+			tc("Modify SOA expire", soa("@", "mmm.ns.cloudflare.com.", "eee.cloudflare.com.", 2037190000, 10001, 2401, 604801, 3600)),
+			tc("Modify SOA minttl", soa("@", "mmm.ns.cloudflare.com.", "eee.cloudflare.com.", 2037190000, 10001, 2401, 604801, 3601)),
+		),
+
+		// hosting.de derives the primary nameserver of a zone from its
+		// nameserver set, so a change to the ns produces no correction here.
+		// The group above expects one, which is correct for the providers that
+		// store the SOA as a record.
+		testgroup("SOA",
+			only("HOSTINGDE"),
+			tcEmptyZone(), // Required or only the first run passes.
+			tc("Create SOA record", soa("@", "kim.ns.cloudflare.com.", "dns.cloudflare.com.", 2037190000, 10000, 2400, 604800, 3600)).AllowNoChanges(),
+			tc("Modify SOA ns    ", soa("@", "mmm.ns.cloudflare.com.", "dns.cloudflare.com.", 2037190000, 10000, 2400, 604800, 3600)).AllowNoChanges(),
 			tc("Modify SOA mbox  ", soa("@", "mmm.ns.cloudflare.com.", "eee.cloudflare.com.", 2037190000, 10000, 2400, 604800, 3600)),
 			tc("Modify SOA refres", soa("@", "mmm.ns.cloudflare.com.", "eee.cloudflare.com.", 2037190000, 10001, 2400, 604800, 3600)),
 			tc("Modify SOA retry ", soa("@", "mmm.ns.cloudflare.com.", "eee.cloudflare.com.", 2037190000, 10001, 2401, 604800, 3600)),

--- a/pkg/soautil/soautil.go
+++ b/pkg/soautil/soautil.go
@@ -10,3 +10,25 @@ func RFC5322MailToBind(rfc5322Mail string) string {
 	user = strings.ReplaceAll(user, ".", "\\.")
 	return user + "." + domain
 }
+
+// BindMailToRFC5322 converts a BIND format mailbox to a user@host email address.
+// It returns "" if there is no unescaped dot to split on.
+func BindMailToRFC5322(bindMail string) string {
+	bindMail = strings.TrimRight(bindMail, ".")
+	for i := 0; i < len(bindMail); i++ {
+		if bindMail[i] == '\\' {
+			i++
+			continue
+		}
+		if bindMail[i] != '.' {
+			continue
+		}
+		user, domain := bindMail[:i], bindMail[i+1:]
+		if user == "" {
+			return ""
+		}
+		// RFC-1035 [Section-8]
+		return strings.ReplaceAll(user, "\\.", ".") + "@" + domain
+	}
+	return ""
+}

--- a/pkg/soautil/soautil_test.go
+++ b/pkg/soautil/soautil_test.go
@@ -23,3 +23,27 @@ func Test_RFC5322MailToBind(t *testing.T) {
 		})
 	}
 }
+
+func Test_BindMailToRFC5322(t *testing.T) {
+	tests := []struct {
+		name        string
+		bindMail    string
+		rfc5322Mail string
+	}{
+		{"0", "hostmaster.example.com", "hostmaster@example.com"},
+		{"1", "hostmaster.example.com.", "hostmaster@example.com"},
+		{"2", "admin\\.dns.example.com", "admin.dns@example.com"},
+		{"3", "hostmaster.sub.example.com", "hostmaster@sub.example.com"},
+		{"4", "hostmaster", ""},
+		{"5", "", ""},
+		{"6", ".", ""},
+		{"7", ".example.com", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BindMailToRFC5322(tt.bindMail); !reflect.DeepEqual(got, tt.rfc5322Mail) {
+				t.Errorf("BindMailToRFC5322(%v) = %v, want %v", tt.bindMail, got, tt.rfc5322Mail)
+			}
+		})
+	}
+}

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -166,8 +166,8 @@ func soaMailToEmail(mbox, zone string) string {
 // numeric fields are read, and they fall back to the provider's defaults
 // because they are zero. The mailbox must stay empty: a non-empty one makes
 // GetZoneRecordsCorrections rewrite the zone's contact address.
-func placeholderSOA(dc *models.DomainConfig) *models.RecordConfig {
-	return dc.MustNewRecordConfig("@", 0, dnsv2.TypeSOA, "ns", "", 0, 0, 0, 0)
+func placeholderSOA(dc *models.DomainConfig) (*models.RecordConfig, error) {
+	return dc.NewRecordConfig("@", 0, dnsv2.TypeSOA, "ns", "", 0, 0, 0, 0)
 }
 
 // GetZoneRecordsCorrections returns a list of corrections that will turn existing records into dc.Records.
@@ -243,7 +243,10 @@ func (hp *hostingdeProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, 
 		}
 	}
 	if desiredSoa == nil {
-		desiredSoa = placeholderSOA(dc)
+		desiredSoa, err = placeholderSOA(dc)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 
 	defaultSoa := &hp.defaultSoa
@@ -326,7 +329,7 @@ func (hp *hostingdeProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, 
 	}
 
 	corrections = append(corrections, &models.Correction{
-		Msg: "\n" + strings.Join(msg, "\n"),
+		Msg: strings.Join(msg, "\n"),
 		F: func() error {
 			for i := range 10 {
 				err := hp.updateZone(&zone.ZoneConfig, DNSSecOptions, create, del, mod)

--- a/providers/hostingde/hostingdeProvider.go
+++ b/providers/hostingde/hostingdeProvider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DNSControl/dnscontrol/v5/models"
 	"github.com/DNSControl/dnscontrol/v5/pkg/diff2"
 	"github.com/DNSControl/dnscontrol/v5/pkg/providers"
+	"github.com/DNSControl/dnscontrol/v5/pkg/soautil"
 )
 
 var defaultNameservers = []string{"ns1.hosting.de", "ns2.hosting.de", "ns3.hosting.de"}
@@ -146,6 +147,21 @@ func soaToString(s soaValues) string {
 	return fmt.Sprintf("refresh=%d retry=%d expire=%d negativettl=%d ttl=%d", s.Refresh, s.Retry, s.Expire, s.NegativeTTL, s.TTL)
 }
 
+// soaMailToEmail turns a SOA mailbox into the address hosting.de keeps in the
+// zone config. A mailbox without a host of its own is qualified with the zone.
+// The address must not end in a period, the API rejects that.
+func soaMailToEmail(mbox, zone string) string {
+	mbox = strings.TrimRight(mbox, ".")
+	if mbox == "" {
+		return ""
+	}
+	if mail := soautil.BindMailToRFC5322(mbox); mail != "" {
+		return mail
+	}
+	// RFC-1035 [Section-8]
+	return strings.ReplaceAll(mbox, "\\.", ".") + "@" + zone
+}
+
 // placeholderSOA stands in for a zone that declares no SOA record. Only the
 // numeric fields are read, and they fall back to the provider's defaults
 // because they are zero. The mailbox must stay empty: a non-empty one makes
@@ -248,16 +264,10 @@ func (hp *hostingdeProvider) GetZoneRecordsCorrections(dc *models.DomainConfig, 
 		zoneChanged = true
 	}
 
-	if df.Mbox != "" {
-		desiredMail := ""
-		if df.Mbox[len(df.Mbox)-1] != '.' {
-			desiredMail = df.Mbox + "@" + dc.Name
-		}
-		if desiredMail != "" && zone.ZoneConfig.EmailAddress != desiredMail {
-			msg = append(msg, fmt.Sprintf("Changing SOA Mail from %s to %s", zone.ZoneConfig.EmailAddress, desiredMail))
-			zone.ZoneConfig.EmailAddress = desiredMail
-			zoneChanged = true
-		}
+	if desiredMail := soaMailToEmail(df.Mbox, dc.Name); desiredMail != "" && zone.ZoneConfig.EmailAddress != desiredMail {
+		msg = append(msg, fmt.Sprintf("Changing SOA Mail from %s to %s", zone.ZoneConfig.EmailAddress, desiredMail))
+		zone.ZoneConfig.EmailAddress = desiredMail
+		zoneChanged = true
 	}
 
 	existingAutoDNSSecEnabled := zone.ZoneConfig.DNSSECMode == "automatic"

--- a/providers/hostingde/hostingdeProvider_test.go
+++ b/providers/hostingde/hostingdeProvider_test.go
@@ -11,7 +11,12 @@ import (
 func TestPlaceholderSOAHasNoMailbox(t *testing.T) {
 	dc := models.MustNewDomainConfig("example.com")
 
-	if got := placeholderSOA(dc).AsSOA().Mbox; got != "" {
+	rc, err := placeholderSOA(dc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rc.AsSOA().Mbox; got != "" {
 		t.Errorf("placeholder mailbox = %q, want empty; a non-empty one is turned into %s@example.com", got, got)
 	}
 }

--- a/providers/hostingde/hostingdeProvider_test.go
+++ b/providers/hostingde/hostingdeProvider_test.go
@@ -15,3 +15,24 @@ func TestPlaceholderSOAHasNoMailbox(t *testing.T) {
 		t.Errorf("placeholder mailbox = %q, want empty; a non-empty one is turned into %s@example.com", got, got)
 	}
 }
+
+func TestSoaMailToEmail(t *testing.T) {
+	tests := []struct {
+		name string
+		mbox string
+		want string
+	}{
+		{"0", "", ""},
+		{"1", "hostmaster", "hostmaster@example.com"},
+		{"2", "hostmaster.example.com.", "hostmaster@example.com"},
+		// The host may be outside the zone.
+		{"3", "eee.cloudflare.com.", "eee@cloudflare.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := soaMailToEmail(tt.mbox, "example.com"); got != tt.want {
+				t.Errorf("soaMailToEmail(%v) = %v, want %v", tt.mbox, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
hosting.de keeps the contact address of a zone in `zoneConfig.emailAddress` rather than in an SOA record, so the provider turns the mailbox of `SOA()` into an address. It only handled a mailbox without a dot, appending `@` and the zone name, and skipped everything else. The spelling that [`SOA.md`](../language-reference/domain-modifiers/SOA.md) uses as its own example, `hostmaster.example.com.`, therefore did nothing at all.

Worse, `SOA()` also accepts a plain email address, and `mustbe.SoaMailbox()` turns `admin@example.com` into the mailbox `admin.example.com`, which has no trailing dot either. The provider appended the zone on top of that and wrote `admin.example.com@example.com`.

This adds `soautil.BindMailToRFC5322()` as the counterpart to the existing `RFC5322MailToBind()` and uses it. A mailbox that names its host becomes the address, one without is qualified with the zone as before.

Verified against a hosting.de account, preview and push, nothing else in the zone touched:

```
hostmaster.example.com.  ->  hostmaster@example.com   next preview clean
admin@example.com        ->  admin@example.com        next preview clean
hostmaster               ->  hostmaster@example.com   unchanged from before
```

The API accepts an address outside the zone, and rejects one ending in a period with `Code:13012`, so neither form causes trouble.

Behaviour change worth noting: the dotted spelling used to be a guaranteed no-op for this provider, and now it takes effect. Anyone using it may see one `Changing SOA Mail` line on the first preview after upgrading. Nothing is written without showing up there first.

`BindMailToRFC5322()` sits next to its counterpart in `pkg/soautil`, but it is only used here. Happy to move it into the provider if you would rather not grow that package.