### PR TITLE
fix(p/CLOUDFLAREAPI): Preserve Single Redirect order. New redirects added to end of list.

### DIFF
--- a/commands/types/dnscontrol.d.ts
+++ b/commands/types/dnscontrol.d.ts
@@ -607,16 +607,24 @@ declare function CF_REDIRECT(source: string, destination: string, ...modifiers: 
  *
  * The fields are:
  *
- * * name: The name (basically a comment)
+ * * name: The name used to match this rule between deployments. Use a unique, stable name for each rule in a zone.
  * * code: Any of 301, 302, 303, 307, 308. May be a number or string.
  * * when: What Cloudflare sometimes calls the "rule expression".
  * * then: The replacement expression.
  *
- * DNSControl does not currently choose the order of the rules.  New rules are added to the end of the list. Use Cloudflare's dashboard to re-order the rule, DNSControl should not change them.  (In the future we hope to add a feature where the order the rules appear in dnsconfig.js is maintained in the dashboard.)
+ * DNSControl does not currently choose the order of the rules. New rules are added to the end of the list. Use Cloudflare's dashboard to reorder them. Editing the status code, condition, or destination of a rule with the same unique name preserves its Cloudflare rule ID and current position. Its enabled state is also preserved. A condition or status edit preserves the existing query-string behavior; changing the destination derives that behavior from the new destination, as for a new rule.
+ *
+ * Changing a rule's name is a replacement: the old rule is deleted and the new rule is appended. Names are case-sensitive. Rules with duplicate names cannot be reliably matched during edits; use unique names when position matters.
+ *
+ * Preserving positions does not restore an already misordered ruleset, enforce declaration order, or detect order-only drift. When conditions overlap, put specific rules before broader fallbacks in Cloudflare's dashboard. In the future we hope to support declarative ordering as a separate feature.
+ *
+ * Single Redirects are HTTP rules and have no DNS TTL. DNSControl normalizes their internal TTL to 1 when planning Cloudflare changes, including when a default TTL or an explicit `TTL()` modifier is present. This does not control browser redirect caching.
  *
  * ## `CF_REDIRECT` and `CF_TEMP_REDIRECT`
  *
  * `CF_REDIRECT` and `CF_TEMP_REDIRECT` used to manage Cloudflare Page Rules. However that feature is going away.  To help with the migration, DNSControl now translates those commands into CF_SINGLE_REDIRECT equivalents.  The conversion process is a transpiler that only understands certain formats. Please submit a Github issue if you find something it can't handle.
+ *
+ * These generated rules share the same ordered list as explicit `CF_SINGLE_REDIRECT` rules. Their generated names include the status code, source pattern, and destination. Changing any of those produces a replacement that is appended. To edit a redirect while retaining its position, use an explicit `CF_SINGLE_REDIRECT` with a stable name.
  *
  * @see https://docs.dnscontrol.org/language-reference/domain-modifiers/service-provider-specific/cloudflare-dns/cf_single_redirect
  */

--- a/documentation/language-reference/domain-modifiers/CF_SINGLE_REDIRECT.md
+++ b/documentation/language-reference/domain-modifiers/CF_SINGLE_REDIRECT.md
@@ -35,13 +35,21 @@ D("example.com", REG_MY_PROVIDER, DnsProvider(DSP_MY_PROVIDER),
 
 The fields are:
 
-* name: The name (basically a comment)
+* name: The name used to match this rule between deployments. Use a unique, stable name for each rule in a zone.
 * code: Any of 301, 302, 303, 307, 308. May be a number or string.
 * when: What Cloudflare sometimes calls the "rule expression".
 * then: The replacement expression.
 
-DNSControl does not currently choose the order of the rules.  New rules are added to the end of the list. Use Cloudflare's dashboard to re-order the rule, DNSControl should not change them.  (In the future we hope to add a feature where the order the rules appear in dnsconfig.js is maintained in the dashboard.)
+DNSControl does not currently choose the order of the rules. New rules are added to the end of the list. Use Cloudflare's dashboard to reorder them. Editing the status code, condition, or destination of a rule with the same unique name preserves its Cloudflare rule ID and current position. Its enabled state is also preserved. A condition or status edit preserves the existing query-string behavior; changing the destination derives that behavior from the new destination, as for a new rule.
+
+Changing a rule's name is a replacement: the old rule is deleted and the new rule is appended. Names are case-sensitive. Rules with duplicate names cannot be reliably matched during edits; use unique names when position matters.
+
+Preserving positions does not restore an already misordered ruleset, enforce declaration order, or detect order-only drift. When conditions overlap, put specific rules before broader fallbacks in Cloudflare's dashboard. In the future we hope to support declarative ordering as a separate feature.
+
+Single Redirects are HTTP rules and have no DNS TTL. DNSControl normalizes their internal TTL to 1 when planning Cloudflare changes, including when a default TTL or an explicit `TTL()` modifier is present. This does not control browser redirect caching.
 
 ## `CF_REDIRECT` and `CF_TEMP_REDIRECT`
 
 `CF_REDIRECT` and `CF_TEMP_REDIRECT` used to manage Cloudflare Page Rules. However that feature is going away.  To help with the migration, DNSControl now translates those commands into CF_SINGLE_REDIRECT equivalents.  The conversion process is a transpiler that only understands certain formats. Please submit a Github issue if you find something it can't handle.
+
+These generated rules share the same ordered list as explicit `CF_SINGLE_REDIRECT` rules. Their generated names include the status code, source pattern, and destination. Changing any of those produces a replacement that is appended. To edit a redirect while retaining its position, use an explicit `CF_SINGLE_REDIRECT` with a stable name.

--- a/models/record.go
+++ b/models/record.go
@@ -255,6 +255,11 @@ func (rc *RecordConfig) Key() RecordKey {
 	t := rc.Type
 	if rc.GetRDATA() != nil {
 		switch rc.Type {
+		case "CLOUDFLAREAPI_SINGLE_REDIRECT":
+			// Redirects share the apex label but have individual identities.
+			// Pair edits by name so an add/delete cannot turn a content update
+			// into a modification of a different rule (and change precedence).
+			t = fmt.Sprintf("%s_%s", t, rc.AsCLOUDFLAREAPISINGLEREDIRECT().SRName)
 		case "R53_ALIAS":
 			// Route53 aliases append their alias type, so that records for the same
 			// label with different alias types are considered separate.

--- a/providers/cloudflare/cloudflareProvider.go
+++ b/providers/cloudflare/cloudflareProvider.go
@@ -659,6 +659,9 @@ func (c *cloudflareProvider) preprocessConfig(dc *models.DomainConfig) error {
 
 		switch rec.TypeNum {
 		case privatetypes.TypeCLOUDFLAREAPISINGLEREDIRECT:
+			// HTTP redirects have no DNS TTL. Match provider read-back and the
+			// CF_REDIRECT/CF_TEMP_REDIRECT builders, including explicit TTLs.
+			rec.TTL = 1
 			// SINGLEREDIRECT record types. Verify they are enabled.
 			if !c.manageSingleRedirects {
 				return errors.New("you must add 'manage_single_redirects: true' metadata to cloudflare provider to use CLOUDFLAREAPI_SINGLE_REDIRECT records")

--- a/providers/cloudflare/rest.go
+++ b/providers/cloudflare/rest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	dnsv2 "codeberg.org/miekg/dns"
@@ -409,43 +410,34 @@ func (c *cloudflareProvider) getSingleRedirects(dc *models.DomainConfig, id stri
 	return recs, nil
 }
 
-func (c *cloudflareProvider) createSingleRedirect(domainID string, cfr privatetypesrdata.CLOUDFLAREAPISINGLEREDIRECT) error {
-	newSingleRedirectRulesActionParameters := cloudflare.RulesetRuleActionParameters{}
-	newSingleRedirectRule := cloudflare.RulesetRule{}
-	newSingleRedirectRules := []cloudflare.RulesetRule{}
-	newSingleRedirectRules = append(newSingleRedirectRules, newSingleRedirectRule)
-	newSingleRedirect := cloudflare.UpdateEntrypointRulesetParams{}
-
+func singleRedirectRule(cfr privatetypesrdata.CLOUDFLAREAPISINGLEREDIRECT) cloudflare.RulesetRule {
 	// Preserve query string if there isn't one in the replacement.
 	preserveQueryString := !strings.Contains(cfr.SRThen, "?")
+	return cloudflare.RulesetRule{
+		Action:      "redirect",
+		Description: cfr.SRName,
+		Expression:  cfr.SRWhen,
+		ActionParameters: &cloudflare.RulesetRuleActionParameters{
+			FromValue: &cloudflare.RulesetRuleActionParametersFromValue{
+				StatusCode:          cfr.Code,
+				TargetURL:           cloudflare.RulesetRuleActionParametersTargetURL{Expression: cfr.SRThen},
+				PreserveQueryString: &preserveQueryString,
+			},
+		},
+	}
+}
 
-	newSingleRedirectRulesActionParameters.FromValue = &cloudflare.RulesetRuleActionParametersFromValue{}
-	// Redirect status code
-	newSingleRedirectRulesActionParameters.FromValue.StatusCode = uint16(cfr.Code)
-	// Incoming request expression
-	newSingleRedirectRules[0].Expression = cfr.SRWhen
-	// Redirect expression
-	newSingleRedirectRulesActionParameters.FromValue.TargetURL.Expression = cfr.SRThen
-	// Redirect name
-	newSingleRedirectRules[0].Description = cfr.SRName
-
-	// Rule action, should always be redirect in this case
-	newSingleRedirectRules[0].Action = "redirect"
-	// Phase should always be http_request_dynamic_redirect
-	newSingleRedirect.Phase = "http_request_dynamic_redirect"
-
-	// Assigns the values in the nested structs
-	newSingleRedirectRulesActionParameters.FromValue.PreserveQueryString = &preserveQueryString
-	newSingleRedirectRules[0].ActionParameters = &newSingleRedirectRulesActionParameters
-
+func (c *cloudflareProvider) createSingleRedirect(domainID string, cfr privatetypesrdata.CLOUDFLAREAPISINGLEREDIRECT) error {
 	// Get a list of current redirects so that the new redirect get appended to it
 	rules, err := c.cfClient.GetEntrypointRuleset(context.Background(), cloudflare.ZoneIdentifier(domainID), "http_request_dynamic_redirect")
 	var e *cloudflare.NotFoundError
 	if err != nil && !errors.As(err, &e) {
 		return fmt.Errorf("failed fetching redirect rule list cloudflare: %w", err)
 	}
-	newSingleRedirect.Rules = newSingleRedirectRules
-	newSingleRedirect.Rules = append(rules.Rules, newSingleRedirect.Rules...)
+	newSingleRedirect := cloudflare.UpdateEntrypointRulesetParams{
+		Phase: "http_request_dynamic_redirect",
+		Rules: append(rules.Rules, singleRedirectRule(cfr)),
+	}
 
 	_, err = c.cfClient.UpdateEntrypointRuleset(context.Background(), cloudflare.ZoneIdentifier(domainID), newSingleRedirect)
 
@@ -459,7 +451,7 @@ func (c *cloudflareProvider) deleteSingleRedirects(domainID string, cfr privatet
 	},
 	)
 	// NB(tlim): Yuck. This returns an error even when it is successful. Dig into the JSON for the real status.
-	if strings.Contains(err.Error(), `"success": true,`) {
+	if err != nil && strings.Contains(err.Error(), `"success": true,`) {
 		return nil
 	}
 
@@ -467,10 +459,30 @@ func (c *cloudflareProvider) deleteSingleRedirects(domainID string, cfr privatet
 }
 
 func (c *cloudflareProvider) updateSingleRedirect(domainID string, oldrec, newrec *models.RecordConfig) error {
-	if err := c.deleteSingleRedirects(domainID, oldrec.AsCLOUDFLAREAPISINGLEREDIRECT()); err != nil {
+	old := oldrec.AsCLOUDFLAREAPISINGLEREDIRECT()
+	desired := newrec.AsCLOUDFLAREAPISINGLEREDIRECT()
+	rule := singleRedirectRule(desired)
+	original := oldrec.Original.(cloudflare.RulesetRule)
+	rule.Enabled = original.Enabled
+	rule.Ref = original.Ref
+	// The DSL derives query-string handling from the destination. Leave the
+	// deployed setting alone when only the condition or status changes.
+	if old.SRThen == desired.SRThen {
+		rule.ActionParameters.FromValue.PreserveQueryString = original.ActionParameters.FromValue.PreserveQueryString
+	}
+
+	// The pinned SDK has no typed rule PATCH method. Raw still uses its
+	// authentication, retries, and error handling. Omitting position keeps the
+	// existing rule in place; do not send a stale copy of the entire ruleset.
+	endpoint := fmt.Sprintf("/zones/%s/rulesets/%s/rules/%s", domainID, old.RT_SRRRulesetID, old.RT_SRRRulesetRuleID)
+	result, err := c.cfClient.Raw(context.Background(), http.MethodPatch, endpoint, rule, nil)
+	if err != nil {
 		return err
 	}
-	return c.createSingleRedirect(domainID, newrec.AsCLOUDFLAREAPISINGLEREDIRECT())
+	if !result.Success {
+		return fmt.Errorf("failed updating Cloudflare Single Redirect %q: %v", desired.SRName, result.Errors)
+	}
+	return nil
 }
 
 func (c *cloudflareProvider) getWorkerRoutes(id string, dc *models.DomainConfig) (models.Records, error) {

--- a/providers/cloudflare/single_redirect_test.go
+++ b/providers/cloudflare/single_redirect_test.go
@@ -1,0 +1,372 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/DNSControl/dnscontrol/v5/models"
+	"github.com/DNSControl/dnscontrol/v5/pkg/js"
+	"github.com/DNSControl/dnscontrol/v5/pkg/normalize"
+	"github.com/DNSControl/dnscontrol/v5/pkg/zonecache"
+	_ "github.com/DNSControl/dnscontrol/v5/providers/cloudflare/rtypes/cfsingleredirect"
+	"github.com/cloudflare/cloudflare-go"
+)
+
+const redirectEntrypoint = "/zones/zone-id/rulesets/phases/http_request_dynamic_redirect/entrypoint"
+const redirectRulePrefix = "/zones/zone-id/rulesets/ruleset-id/rules/"
+
+// redirectAPI models only the Rulesets API operations used by these tests.
+// The real Cloudflare SDK serializes every request; no credentials or network
+// access are needed. A replacement without an ID is a new rule, appended by PUT.
+type redirectAPI struct {
+	rules           []cloudflare.RulesetRule
+	writes          []string
+	bodies          []map[string]json.RawMessage
+	failMethod      string
+	failStatus      int
+	deleteNoContent bool
+}
+
+func (a *redirectAPI) RoundTrip(r *http.Request) (*http.Response, error) {
+	respond := func(status int, body any) (*http.Response, error) {
+		var data []byte
+		if body != nil {
+			var err error
+			data, err = json.MarshalIndent(body, "", "  ")
+			if err != nil {
+				return nil, err
+			}
+		}
+		return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(string(data))), Request: r}, nil
+	}
+	result := func() (*http.Response, error) {
+		return respond(http.StatusOK, struct {
+			Success bool               `json:"success"`
+			Result  cloudflare.Ruleset `json:"result"`
+		}{true, cloudflare.Ruleset{ID: "ruleset-id", Rules: a.rules}})
+	}
+	if r.Method != http.MethodGet {
+		a.writes = append(a.writes, r.Method+" "+r.URL.Path)
+		body := map[string]json.RawMessage{}
+		if r.Body != nil {
+			defer r.Body.Close()
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				return nil, err
+			}
+		}
+		a.bodies = append(a.bodies, body)
+	}
+	if r.Method == a.failMethod {
+		return respond(a.failStatus, map[string]any{"success": false, "errors": []any{map[string]any{"code": 1000, "message": "synthetic failure"}}})
+	}
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == redirectEntrypoint:
+		return result()
+	case r.Method == http.MethodPut && r.URL.Path == redirectEntrypoint:
+		var rules []cloudflare.RulesetRule
+		if err := json.Unmarshal(a.bodies[len(a.bodies)-1]["rules"], &rules); err != nil {
+			return nil, err
+		}
+		for i := range rules {
+			if rules[i].ID == "" {
+				rules[i].ID = fmt.Sprintf("created-%d-%d", len(a.writes), i)
+			}
+		}
+		a.rules = rules
+		return result()
+	case strings.HasPrefix(r.URL.Path, redirectRulePrefix):
+		id := strings.TrimPrefix(r.URL.Path, redirectRulePrefix)
+		i := slices.IndexFunc(a.rules, func(rule cloudflare.RulesetRule) bool { return rule.ID == id })
+		if i < 0 {
+			return nil, fmt.Errorf("unknown rule ID %q", id)
+		}
+		switch r.Method {
+		case http.MethodDelete:
+			a.rules = slices.Delete(a.rules, i, i+1)
+			if a.deleteNoContent {
+				return respond(http.StatusNoContent, nil)
+			}
+			return result()
+		case http.MethodPatch:
+			data, err := json.Marshal(a.bodies[len(a.bodies)-1])
+			if err != nil {
+				return nil, err
+			}
+			var rule cloudflare.RulesetRule
+			if err := json.Unmarshal(data, &rule); err != nil {
+				return nil, err
+			}
+			rule.ID = id
+			a.rules[i] = rule
+			return result()
+		}
+	}
+	return nil, fmt.Errorf("unexpected request: %s %s", r.Method, r.URL)
+}
+
+func redirectRule(id, name, host, destination string) cloudflare.RulesetRule {
+	enabled, preserve := true, true
+	return cloudflare.RulesetRule{
+		ID: id, Ref: "ref-" + id, Description: name, Action: "redirect", Enabled: &enabled,
+		Expression: fmt.Sprintf(`http.host eq %q`, host),
+		ActionParameters: &cloudflare.RulesetRuleActionParameters{FromValue: &cloudflare.RulesetRuleActionParametersFromValue{
+			StatusCode: 301, PreserveQueryString: &preserve,
+			TargetURL: cloudflare.RulesetRuleActionParametersTargetURL{Expression: fmt.Sprintf(`concat(%q, http.request.uri.path)`, destination)},
+		}},
+	}
+}
+
+func redirectFixture(t *testing.T) (*cloudflareProvider, *redirectAPI, *models.DomainConfig) {
+	t.Helper()
+	a := &redirectAPI{rules: []cloudflare.RulesetRule{
+		redirectRule("meta-id", "Meta", "meta.example.com", "https://meta.example.net"),
+		redirectRule("chat-id", "Chat", "chat.example.com", "https://chat.example.net"),
+		redirectRule("fallback-id", "Fallback", "example.com", "https://main.example.net"),
+	}}
+	a.rules[2].Expression = `http.host eq "example.com" or ends_with(http.host, ".example.com")`
+	client, err := cloudflare.NewWithAPIToken("synthetic-token", cloudflare.BaseURL("https://cloudflare.invalid"), cloudflare.HTTPClient(&http.Client{Transport: a}), cloudflare.UsingRateLimit(100000), cloudflare.UsingRetryPolicy(0, 0, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &cloudflareProvider{cfClient: client, manageSingleRedirects: true}
+	c.zoneCache = zonecache.New(func() (map[string]cloudflare.Zone, error) {
+		return map[string]cloudflare.Zone{"example.com": {ID: "zone-id", Name: "example.com"}}, nil
+	})
+	dc := models.MustNewDomainConfig("example.com")
+	for _, rule := range a.rules {
+		dc.Records = append(dc.Records, dc.MustNewRecordConfig("@", 1, "CLOUDFLAREAPI_SINGLE_REDIRECT", rule.Description, rule.ActionParameters.FromValue.StatusCode, rule.Expression, rule.ActionParameters.FromValue.TargetURL.Expression))
+	}
+	return c, a, dc
+}
+
+func redirectPlan(t *testing.T, c *cloudflareProvider, dc *models.DomainConfig) []*models.Correction {
+	t.Helper()
+	existing, err := c.getSingleRedirects(dc, "zone-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Each preview/push starts from a fresh desired config; preprocessing mutates it.
+	desired, err := dc.Copy()
+	if err != nil {
+		t.Fatal(err)
+	}
+	corrs, _, err := c.GetZoneRecordsCorrections(desired, existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return corrs
+}
+
+func applyRedirectPlan(t *testing.T, corrs []*models.Correction) {
+	t.Helper()
+	for _, corr := range corrs {
+		t.Log(corr.Msg)
+		if err := corr.F(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func assertRedirectNoop(t *testing.T, c *cloudflareProvider, dc *models.DomainConfig) {
+	t.Helper()
+	if corrs := redirectPlan(t, c, dc); len(corrs) != 0 {
+		t.Fatalf("second reconciliation planned %d corrections: %v", len(corrs), corrs)
+	}
+}
+
+func TestSingleRedirectUpdatePreservesOrder(t *testing.T) {
+	c, a, dc := redirectFixture(t)
+	before, _ := json.Marshal(a.rules[1:])
+	rd := dc.Records[0].AsCLOUDFLAREAPISINGLEREDIRECT()
+	rd.SRThen = `concat("https://new-meta.example.net", http.request.uri.path)`
+	dc.Records[0].SetRDATA(rd)
+	corrs := redirectPlan(t, c, dc)
+	if len(corrs) != 1 {
+		t.Fatalf("want one correction, got %d", len(corrs))
+	}
+	if len(a.writes) != 0 {
+		t.Fatal("preview wrote to the API")
+	}
+	applyRedirectPlan(t, corrs)
+	var names []string
+	for _, rule := range a.rules {
+		names = append(names, rule.Description)
+	}
+	if !reflect.DeepEqual(names, []string{"Meta", "Chat", "Fallback"}) {
+		t.Errorf("rule order = %v; requests to meta.example.com now hit Fallback first", names)
+	}
+	if a.rules[0].ID != "meta-id" {
+		t.Errorf("Meta identity changed: %s", a.rules[0].ID)
+	}
+	if !reflect.DeepEqual(a.writes, []string{"PATCH " + redirectRulePrefix + "meta-id"}) {
+		t.Errorf("mutations = %v; want one in-place PATCH", a.writes)
+	}
+	if a.rules[0].ActionParameters.FromValue.TargetURL.Expression != rd.SRThen {
+		t.Error("destination not updated in original slot")
+	}
+	after, _ := json.Marshal(a.rules[1:])
+	if string(before) != string(after) {
+		t.Error("unrelated rules changed")
+	}
+	assertRedirectNoop(t, c, dc)
+}
+
+func TestSingleRedirectTTLNoop(t *testing.T) {
+	for _, declaration := range []string{
+		`CF_SINGLE_REDIRECT("Meta", 301, 'http.host eq "meta.example.com"', 'concat("https://meta.example.net", http.request.uri.path)')`,
+		`CF_SINGLE_REDIRECT("Meta", 301, 'http.host eq "meta.example.com"', 'concat("https://meta.example.net", http.request.uri.path)', TTL(999))`,
+		`CF_REDIRECT("meta.example.com/*", "https://meta.example.net/$1")`,
+		`CF_TEMP_REDIRECT("meta.example.com/*", "https://meta.example.net/$1")`,
+	} {
+		t.Run(declaration, func(t *testing.T) {
+			c, a, _ := redirectFixture(t)
+			config, err := js.ExecuteJavascriptString([]byte(`D("example.com", "none", `+declaration+`);`), false, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if errs := normalize.ValidateAndNormalizeConfig(config); len(errs) != 0 {
+				t.Fatal(errs)
+			}
+			dc := config.Domains[0]
+			rd := dc.Records[0].AsCLOUDFLAREAPISINGLEREDIRECT()
+			a.rules = a.rules[:1]
+			a.rules[0].Description = rd.SRName
+			a.rules[0].Expression = rd.SRWhen
+			a.rules[0].ActionParameters.FromValue.StatusCode = rd.Code
+			a.rules[0].ActionParameters.FromValue.TargetURL.Expression = rd.SRThen
+			corrs := redirectPlan(t, c, dc)
+			for _, corr := range corrs {
+				t.Log(corr.Msg)
+			}
+			if len(corrs) != 0 {
+				t.Errorf("unchanged HTTP redirect planned %d corrections (desired TTL %d, native TTL 1)", len(corrs), dc.Records[0].TTL)
+			}
+			assertRedirectNoop(t, c, dc)
+			if len(a.writes) != 0 {
+				t.Fatal("no-op reconciliation wrote to API")
+			}
+		})
+	}
+}
+
+func TestSingleRedirectMixedChanges(t *testing.T) {
+	c, a, dc := redirectFixture(t)
+	// Remove Chat, edit Meta, and add a name that sorts ahead of Meta. The
+	// generic diff must not pair the new rule with Meta's existing identity.
+	dc.Records = slices.Delete(dc.Records, 1, 2)
+	rd := dc.Records[0].AsCLOUDFLAREAPISINGLEREDIRECT()
+	rd.Code = 302
+	dc.Records[0].SetRDATA(rd)
+	dc.Records = append(dc.Records, dc.MustNewRecordConfig("@", 1, "CLOUDFLAREAPI_SINGLE_REDIRECT", "A-new", 301, `http.host eq "new.example.com"`, `concat("https://new.example.net", http.request.uri.path)`))
+	applyRedirectPlan(t, redirectPlan(t, c, dc))
+	if len(a.rules) != 3 {
+		t.Fatalf("got %d rules", len(a.rules))
+	}
+	if a.rules[0].ID != "meta-id" || a.rules[0].Description != "Meta" || a.rules[0].ActionParameters.FromValue.StatusCode != 302 {
+		t.Errorf("surviving Meta rule lost its identity/position: %+v", a.rules[0])
+	}
+	if a.rules[1].ID != "fallback-id" || a.rules[2].Description != "A-new" {
+		t.Errorf("unexpected rule order: %+v", a.rules)
+	}
+	assertRedirectNoop(t, c, dc)
+}
+
+func TestSingleRedirectDefinitionEdits(t *testing.T) {
+	for _, field := range []string{"status", "expression", "destination-query"} {
+		t.Run(field, func(t *testing.T) {
+			c, a, dc := redirectFixture(t)
+			disabled, preserve := false, false
+			a.rules[0].Enabled = &disabled
+			a.rules[0].ActionParameters.FromValue.PreserveQueryString = &preserve
+			rd := dc.Records[0].AsCLOUDFLAREAPISINGLEREDIRECT()
+			switch field {
+			case "status":
+				rd.Code = 308
+			case "expression":
+				rd.SRWhen = `http.host eq "new-meta.example.com"`
+			case "destination-query":
+				rd.SRThen = `concat("https://new-meta.example.net", http.request.uri.path, "?fixed=1")`
+			}
+			dc.Records[0].SetRDATA(rd)
+			applyRedirectPlan(t, redirectPlan(t, c, dc))
+			rule := a.rules[0]
+			if rule.ID != "meta-id" || rule.Ref != "ref-meta-id" || rule.Enabled == nil || *rule.Enabled {
+				t.Fatalf("lost identity or disabled state: %+v", rule)
+			}
+			if rule.Action != "redirect" || rule.Description != rd.SRName || rule.Expression != rd.SRWhen {
+				t.Errorf("wrong definition: %+v", rule)
+			}
+			fv := rule.ActionParameters.FromValue
+			if fv.StatusCode != rd.Code || fv.TargetURL.Expression != rd.SRThen || fv.PreserveQueryString == nil || *fv.PreserveQueryString {
+				t.Errorf("wrong redirect parameters: %+v", fv)
+			}
+			body := a.bodies[0]
+			for _, key := range []string{"id", "version", "last_updated", "position", "rules"} {
+				if _, present := body[key]; present {
+					t.Errorf("PATCH should omit %q", key)
+				}
+			}
+			assertRedirectNoop(t, c, dc)
+		})
+	}
+}
+
+func TestSingleRedirectUpdateFailure(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusOK} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			c, a, dc := redirectFixture(t)
+			a.failMethod, a.failStatus = http.MethodPatch, status
+			before, _ := json.Marshal(a.rules)
+			rd := dc.Records[0].AsCLOUDFLAREAPISINGLEREDIRECT()
+			rd.Code = 302
+			dc.Records[0].SetRDATA(rd)
+			corrs := redirectPlan(t, c, dc)
+			if len(corrs) != 1 {
+				t.Fatalf("want one correction, got %d", len(corrs))
+			}
+			if err := corrs[0].F(); err == nil || !strings.Contains(err.Error(), "synthetic failure") {
+				t.Errorf("expected API error, got %v", err)
+			}
+			after, _ := json.Marshal(a.rules)
+			if string(before) != string(after) {
+				t.Error("failed update changed live rules")
+			}
+			if len(redirectPlan(t, c, dc)) != 1 {
+				t.Error("failed update disappeared from next preview")
+			}
+		})
+	}
+}
+
+func TestSingleRedirectRenameIsReplacement(t *testing.T) {
+	c, a, dc := redirectFixture(t)
+	rd := dc.Records[0].AsCLOUDFLAREAPISINGLEREDIRECT()
+	rd.SRName = "Renamed Meta"
+	dc.Records[0].SetRDATA(rd)
+	applyRedirectPlan(t, redirectPlan(t, c, dc))
+	if a.rules[0].ID != "chat-id" || a.rules[1].ID != "fallback-id" || a.rules[2].Description != rd.SRName || a.rules[2].ID == "meta-id" {
+		t.Errorf("rename should be a new rule appended after survivors: %+v", a.rules)
+	}
+	assertRedirectNoop(t, c, dc)
+}
+
+func TestSingleRedirectDeleteResponses(t *testing.T) {
+	for _, noContent := range []bool{false, true} {
+		t.Run(fmt.Sprint(noContent), func(t *testing.T) {
+			c, a, dc := redirectFixture(t)
+			a.deleteNoContent = noContent
+			dc.Records = slices.Delete(dc.Records, 1, 2)
+			applyRedirectPlan(t, redirectPlan(t, c, dc))
+			if len(a.rules) != 2 || a.rules[0].ID != "meta-id" || a.rules[1].ID != "fallback-id" {
+				t.Errorf("delete changed surviving rules: %+v", a.rules)
+			}
+			assertRedirectNoop(t, c, dc)
+		})
+	}
+}

--- a/providers/cloudflare/single_redirect_test.go
+++ b/providers/cloudflare/single_redirect_test.go
@@ -370,3 +370,49 @@ func TestSingleRedirectDeleteResponses(t *testing.T) {
 		})
 	}
 }
+
+func TestSingleRedirectKeepUnknown(t *testing.T) {
+	c, a, dc := redirectFixture(t)
+	// NO_PURGE promises to preserve undeclared rules, including their relative
+	// order and disabled state, while allowing an explicitly managed edit.
+	dc.KeepUnknown = true
+	dc.Records = slices.Delete(dc.Records, 1, 2)
+	disabled := false
+	a.rules[1].Enabled = &disabled
+	before, _ := json.Marshal(a.rules[1:])
+	rd := dc.Records[0].AsCLOUDFLAREAPISINGLEREDIRECT()
+	rd.Code = 302
+	dc.Records[0].SetRDATA(rd)
+	applyRedirectPlan(t, redirectPlan(t, c, dc))
+	after, _ := json.Marshal(a.rules[1:])
+	if string(before) != string(after) || a.rules[0].ID != "meta-id" {
+		t.Error("NO_PURGE rules or their relative order changed")
+	}
+	assertRedirectNoop(t, c, dc)
+}
+
+func TestSingleRedirectGeneratedEditIsReplacement(t *testing.T) {
+	for _, builder := range []string{"CF_REDIRECT", "CF_TEMP_REDIRECT"} {
+		t.Run(builder, func(t *testing.T) {
+			c, a, _ := redirectFixture(t)
+			parse := func(destination string) *models.DomainConfig {
+				config, err := js.ExecuteJavascriptString([]byte(fmt.Sprintf(`D("example.com", "none", %s("meta.example.com/*", %q));`, builder, destination)), false, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return config.Domains[0]
+			}
+			old := parse("https://meta.example.net/$1").Records[0].AsCLOUDFLAREAPISINGLEREDIRECT()
+			a.rules = a.rules[:1]
+			a.rules[0].Description, a.rules[0].Expression = old.SRName, old.SRWhen
+			a.rules[0].ActionParameters.FromValue.StatusCode = old.Code
+			a.rules[0].ActionParameters.FromValue.TargetURL.Expression = old.SRThen
+			dc := parse("https://new-meta.example.net/$1")
+			applyRedirectPlan(t, redirectPlan(t, c, dc))
+			if len(a.rules) != 1 || a.rules[0].ID == "meta-id" {
+				t.Errorf("expected generated-name replacement: %+v", a.rules)
+			}
+			assertRedirectNoop(t, c, dc)
+		})
+	}
+}


### PR DESCRIPTION

# Issue

"push" changes the order of CLOUDFLARE_SINGLE_REDIRECT items.

# Resolution

Change the update mechanism to maintain the existing order. New items are added to the end of the list.

If you need a specific order, use DNSControl to create the items but update the order via the website. The new order will be retained.

# More info...

Updating a Cloudflare Single Redirect currently deletes it and appends a replacement. A Meta → Chat → Fallback ruleset becomes Chat → Fallback → Meta after editing Meta, so the overlapping fallback takes precedence. Explicit v5 declarations also acquire TTL 300 while native read-back uses 1, triggering this path for unchanged HTTP behavior.

Addresses the immediate correctness defects in #4868:

- Normalize Single Redirect TTLs in Cloudflare preprocessing, including explicit TTL modifiers. The legacy builders already use TTL 1.
- Match redirect edits by name in `RecordConfig.Key()`, following the existing provider-specific key convention. This prevents unrelated additions/deletions from being paired with a surviving named redirect.
- PATCH the existing rule through the pinned SDK's authenticated `Raw` method, omitting `position` and response-only fields. Send the desired definition while retaining `enabled` and `ref`; retain query-string behavior when the destination is unchanged. Check unsuccessful API responses.
- Handle successful empty DELETE responses without dereferencing a nil error. Document the behavior and regenerate the embedded TypeScript documentation.

**Compatibility / review points:** unique, stable, case-sensitive names identify explicit rules. Content edits preserve their IDs and existing positions. A rename replaces and appends; legacy `CF_REDIRECT`/`CF_TEMP_REDIRECT` names include their status/source/destination, so edits that change those names remain replacements. Duplicate names are still ambiguous; this PR documents the need for unique names rather than rejecting existing no-op configurations. Please review this identity contract in particular.

Manual order remains the default, and existing ownership/NO_PURGE behavior is retained. This does not enforce declaration order, detect order-only drift, or repair an already misordered ruleset. Declarative ordering discussed in #3150 remains a separate, unimplemented feature; no priority DSL is added. Rule creation retains the existing read-and-append path; this PR does not claim transactional reconciliation across concurrent clients.

**Validation**

The credential-free tests use the real JavaScript parser/normalizer, provider conversion and correction planning/application, and Cloudflare SDK serialization over an in-memory HTTP transport. They check the ordered resulting state and request sequence, not only intermediate arrays. Coverage includes TTL no-ops for explicit/legacy declarations, destination/status/condition edits, IDs/positions, payload fields, disabled/query-string state, mixed add/delete/update, NO_PURGE preservation, rename/generated-name replacement, HTTP and `success:false` errors, both DELETE response forms, preview without writes, and a second no-op reconciliation.

- [Failing baseline commit](https://github.com/KyleMit/dnscontrol/commit/c7821466605547d37e873aadba3d5c5906914093): `go test ./providers/cloudflare -run 'TestSingleRedirect(UpdatePreservesOrder|TTLNoop)$' -v` reproduces delete/append order movement and `ttl=(1->300)`. The same tests fail on v5.0.2, v5.0.4, and upstream main `3ae38d73`, checked 2026-09-11. #4868 records the exact revisions and the tested TTL refactor boundary.
- Fixed branch: `go test ./...` passes (81 packages with tests), including provider regressions and models/diff/normalization/parser coverage.
- `go build .` and `bin/generate-all.sh` pass with Go 1.27.1. golangci-lint 2.13.2 reports **0 issues**; the generation script skips the absent optional standalone staticcheck executable.
- `git diff --check` passes. Host `autocrlf` expansions were restored to repository LF bytes for fixture/generator checks; no line-ending-only changes are included.

No live Cloudflare writes or credentialed integration tests were performed. The fake transport is not a general Cloudflare expression evaluator.
